### PR TITLE
Add support for vanilla Kibana installs

### DIFF
--- a/charts/kibana-auth-proxy/Chart.yaml
+++ b/charts/kibana-auth-proxy/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: kibana-auth-proxy
-version: 0.1.0
+version: 1.0.0

--- a/charts/kibana-auth-proxy/templates/deployment.yaml
+++ b/charts/kibana-auth-proxy/templates/deployment.yaml
@@ -52,5 +52,15 @@ spec:
               secretKeyRef:
                 name: {{ template "fullname" . }}
                 key: kibana_url
+          - name: KIBANA_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "fullname" . }}
+                key: kibana_username
+          - name: KIBANA_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "fullname" . }}
+                key: kibana_password
         resources:
 {{ toYaml .Values.resources | indent 12 }}

--- a/charts/kibana-auth-proxy/templates/deployment.yaml
+++ b/charts/kibana-auth-proxy/templates/deployment.yaml
@@ -52,6 +52,16 @@ spec:
               secretKeyRef:
                 name: {{ template "fullname" . }}
                 key: kibana_url
+          - name: KIBANA_ADMIN_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "fullname" . }}
+                key: kibana_admin_username
+          - name: KIBANA_ADMIN_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "fullname" . }}
+                key: kibana_admin_password
           - name: KIBANA_USERNAME
             valueFrom:
               secretKeyRef:

--- a/charts/kibana-auth-proxy/templates/secrets.yml
+++ b/charts/kibana-auth-proxy/templates/secrets.yml
@@ -12,6 +12,8 @@ data:
   domain: {{ .Values.auth.domain | b64enc | quote }}
   cookie_secret: {{ .Values.auth.cookieSecret | b64enc | quote }}
   kibana_url: {{ .Values.kibana.url | b64enc | quote }}
-  kibana_username: {{ .Values.kibana.username | b64enc | quote }}
-  kibana_password: {{ .Values.kibana.password | b64enc | quote }}
+  kibana_admin_username: {{ .Values.kibana.admin.username | b64enc | quote }}
+  kibana_admin_password: {{ .Values.kibana.admin.password | b64enc | quote }}
+  kibana_username: {{ .Values.kibana.user.username | b64enc | quote }}
+  kibana_password: {{ .Values.kibana.user.password | b64enc | quote }}
   callback_url: {{ printf "https://%s/callback" .Values.ingress.host | b64enc | quote }}

--- a/charts/kibana-auth-proxy/templates/secrets.yml
+++ b/charts/kibana-auth-proxy/templates/secrets.yml
@@ -11,5 +11,7 @@ data:
   client_id: {{ .Values.auth.clientID | b64enc | quote }}
   domain: {{ .Values.auth.domain | b64enc | quote }}
   cookie_secret: {{ .Values.auth.cookieSecret | b64enc | quote }}
-  kibana_url: {{ printf "http://%s:%s/_plugin/kibana/" .Values.elasticsearch.host .Values.elasticsearch.port | b64enc | quote }}
+  kibana_url: {{ .Values.kibana.url | b64enc | quote }}
+  kibana_username: {{ .Values.kibana.username | b64enc | quote }}
+  kibana_password: {{ .Values.kibana.password | b64enc | quote }}
   callback_url: {{ printf "https://%s/callback" .Values.ingress.host | b64enc | quote }}

--- a/charts/kibana-auth-proxy/values.yaml
+++ b/charts/kibana-auth-proxy/values.yaml
@@ -16,7 +16,11 @@ auth:
   cookieSecret: ""
 kibana:
   url: "http://localhost/"
-  username: ""
-  password: ""
+  admin:
+    username: ""
+    password: ""
+  user:
+    username: ""
+    password: ""
 ingress:
   host: "example.com"

--- a/charts/kibana-auth-proxy/values.yaml
+++ b/charts/kibana-auth-proxy/values.yaml
@@ -14,8 +14,9 @@ auth:
   domain: ""
   callbackURL: ""
   cookieSecret: ""
-elasticsearch:
-  host: "es.example.com"
-  port: 9200
+kibana:
+  url: "http://localhost/"
+  username: ""
+  password: ""
 ingress:
   host: "example.com"


### PR DESCRIPTION
  - no longer assumes that AWS ElasticSearch service is in use
  - allows for differing Kibana credentials to be used based on identity provider used at login


See also chart config PR: 