### PR TITLE
Deprecate unnecessary charts

### DIFF
--- a/charts/elasticsearch-curator/Chart.yaml
+++ b/charts/elasticsearch-curator/Chart.yaml
@@ -1,4 +1,5 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: elasticsearch-curator
-version: 0.1.0
+version: 0.1.1
+deprecated: true

--- a/charts/nfs-migration/Chart.yaml
+++ b/charts/nfs-migration/Chart.yaml
@@ -1,4 +1,5 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: nfs-migration
-version: 0.1.0
+version: 0.1.1
+deprecated: true

--- a/charts/shiny-app/Chart.yaml
+++ b/charts/shiny-app/Chart.yaml
@@ -1,4 +1,5 @@
 apiVersion: v1
 description: Shiny app Helm chart for Kubernetes
 name: shiny-app
-version: 0.1.0
+version: 0.1.1
+deprecated: true


### PR DESCRIPTION
Deprecating before removing:
* `elasticsearch-curator` - this is now a lambda function
* `nfs-migration` - this was a one off task
* `shiny-app` - superseded by `webapp`