### PR TITLE
webapp: apps can assume an IAM role

### DIFF
--- a/charts/webapp/CHANGELOG.md
+++ b/charts/webapp/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+
+## [1.2.0] - 2017-08-31
+### Added
+- webapps can assume an IAM role passed via `AWS.IAMRole` value, see README
+- `CHANGELOG.md`
+
+
+### Removed
+- Unused AWS values: `AccessKeyId`, `SecretAccessKey` and `DefaultRegion`

--- a/charts/webapp/Chart.yaml
+++ b/charts/webapp/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: webapp Helm chart for Kubernetes
 name: webapp
-version: 1.1.1
+version: 1.2.0

--- a/charts/webapp/README.md
+++ b/charts/webapp/README.md
@@ -29,5 +29,6 @@ Listing only the required params here. See `/chart-env-config/` for more details
 | `AuthProxy.AuthenticationRequired` | Determine if the app requires authentication | `"true"` |
 | `AuthProxy.IPRanges` | Comma (,) separated list of CIDR IP ranges. When not provided the user IP is not checked. | `""` |
 | `app.name` (required) | Application name. This will be part of the app URL | |
+| `AWS.IAMRole` | IAM role assumed by the webapp. | `""` |
 | `webapp.docker.repository` (required) | Docker image for the app | |
 | `webapp.docker.tag` | Tag to use for the docker repository | `latest` |

--- a/charts/webapp/templates/deployment.yaml
+++ b/charts/webapp/templates/deployment.yaml
@@ -14,6 +14,7 @@ spec:
         app: {{ template "fullname" . }}
       annotations:
         checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+        iam.amazonaws.com/role: {{ .Values.AWS.IAMRole }}
     spec:
       containers:
         - name: auth-proxy

--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -16,9 +16,7 @@ AuthProxy:
     Tag: "latest"
     PullPolicy: "IfNotPresent"
 AWS:
-  AccessKeyId: ""
-  SecretAccessKey: ""
-  DefaultRegion: "eu-west-1"
+  IAMRole: ""
 OAuth:
   ClientSecret: ""
   ClientId: ""


### PR DESCRIPTION
Ability to attach an IAM role to the app so that we can control the level
of permissions it has (e.g. access to S3 buckets, etc...)

The IAM role name is passed via the `AWS.IAMRole` chart value and it's
optional.

Under the hood the `iam.amazonaws.com/role` annotation is used by the
[kube2iam](https://github.com/jtblin/kube2iam) daemonset running in our kubernetes cluster.

### Related PRs
 - [AWS_IAM_ROLE param](https://github.com/moj-analytical-services/rshiny-template/pull/6) @ rshiny-template
 - [request AWS_IAM_ROLE param](https://github.com/moj-analytical-services/webapp-template/pull/1) @ webapp-template
 - [pass AWS_IAM_ROLE param to helm](https://github.com/ministryofjustice/analytics-platform-jenkins-lib/pull/18) @ jenkins-lib

### Ticket (part of)
https://trello.com/c/SrnUOD12/351-ability-for-webapps-to-assume-an-iam-role