### PR TITLE
cpanel: Control Panel API can assume an IAM role

### DIFF
--- a/charts/cpanel/CHANGELOG.md
+++ b/charts/cpanel/CHANGELOG.md
@@ -8,4 +8,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [0.2.0] - 2017-09-11
 ### Added
 - Control Panel API can assume an IAM role passed via `AWS.IAMRole` value
+- Added `ENV` environment variable value
+- Added `BUCKET_REGION`, `IAM_ARN_BASE` and `LOGS_BUCKET_NAME`  environment variables values
 - `CHANGELOG.md`

--- a/charts/cpanel/CHANGELOG.md
+++ b/charts/cpanel/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+
+## [0.2.0] - 2017-09-11
+### Added
+- Control Panel API can assume an IAM role passed via `AWS.IAMRole` value
+- `CHANGELOG.md`

--- a/charts/cpanel/Chart.yaml
+++ b/charts/cpanel/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Analytics Platform Control Panel API webapp
 name: cpanel
-version: 0.1.0
+version: 0.2.0

--- a/charts/cpanel/templates/deployment.yml
+++ b/charts/cpanel/templates/deployment.yml
@@ -11,6 +11,8 @@ spec:
     metadata:
       labels:
         app: {{ template "fullname" . }}
+      annotations:
+        iam.amazonaws.com/role: {{ .Values.AWS.IAMRole }}
     spec:
       containers:
         - name: api

--- a/charts/cpanel/templates/deployment.yml
+++ b/charts/cpanel/templates/deployment.yml
@@ -27,6 +27,8 @@ spec:
               #valueFrom:
                 #fieldRef:
                   #fieldPath: status.podIP
+            - name: BUCKET_REGION
+              value: "{{ .Values.API.Environment.BUCKET_REGION }}"
             - name: DB_HOST
               value: "{{ .Values.API.Environment.DB_HOST }}"
             - name: DB_NAME
@@ -39,6 +41,12 @@ spec:
               value: "{{ .Values.API.Environment.DEBUG }}"
             - name: DJANGO_SETTINGS_MODULE
               value: "control_panel_api.settings"
+            - name: ENV
+              value: "{{ .Values.API.Environment.ENV }}"
+            - name: IAM_ARN_BASE
+              value: "{{ .Values.API.Environment.IAM_ARN_BASE }}"
+            - name: LOGS_BUCKET_NAME
+              value: "{{ .Values.API.Environment.LOGS_BUCKET_NAME }}"
           readinessProbe:
             httpGet:
               path: /auth/login

--- a/charts/cpanel/values.yaml
+++ b/charts/cpanel/values.yaml
@@ -5,10 +5,14 @@ API:
     Tag: 0.1.0
     PullPolicy: IfNotPresent
   Environment:
+    BUCKET_REGION: "eu-west-1"
     DB_HOST: ""
     DB_NAME: ""
-    DB_USER: ""
     DB_PASSWORD: ""
+    DB_USER: ""
     DEBUG: "False"
+    ENV: ""
+    IAM_ARN_BASE: ""
+    LOGS_BUCKET_NAME: ""
 AWS:
   IAMRole: ""

--- a/charts/cpanel/values.yaml
+++ b/charts/cpanel/values.yaml
@@ -10,3 +10,5 @@ API:
     DB_USER: ""
     DB_PASSWORD: ""
     DEBUG: "False"
+AWS:
+  IAMRole: ""


### PR DESCRIPTION
### What/Why?
This is so that the Control Panel API instances can have permissions to
perform certain operations (e.g. create S3 bucket, etc...)

### Ticket
https://trello.com/c/oNMQLEfF/360-add-iam-role-support-to-control-panel-api-helm-chart


### Related to
 - Role added: https://github.com/ministryofjustice/analytics-platform-ops/pull/106
 - cpanel helm chart config: https://github.com/ministryofjustice/analytics-platform-config/pull/8