### PR TITLE
cpanel 3.0.0: Added K8S_WORKER_ROLE_ARN environment variable value

### DIFF
--- a/charts/cpanel/CHANGELOG.md
+++ b/charts/cpanel/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [0.3.0] - 2017-09-15
+### Added
+- Added `K8S_WORKER_ROLE_ARN` environment variables value
+
+
 ## [0.2.0] - 2017-09-11
 ### Added
 - Control Panel API can assume an IAM role passed via `AWS.IAMRole` value

--- a/charts/cpanel/Chart.yaml
+++ b/charts/cpanel/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Analytics Platform Control Panel API webapp
 name: cpanel
-version: 0.2.1
+version: 0.3.0

--- a/charts/cpanel/templates/deployment.yml
+++ b/charts/cpanel/templates/deployment.yml
@@ -45,6 +45,8 @@ spec:
               value: "{{ .Values.API.Environment.ENV }}"
             - name: IAM_ARN_BASE
               value: "{{ .Values.API.Environment.IAM_ARN_BASE }}"
+            - name: K8S_WORKER_ROLE_ARN
+              value: "{{ .Values.API.Environment.K8S_WORKER_ROLE_ARN }}"
             - name: LOGS_BUCKET_NAME
               value: "{{ .Values.API.Environment.LOGS_BUCKET_NAME }}"
           readinessProbe:

--- a/charts/cpanel/values.yaml
+++ b/charts/cpanel/values.yaml
@@ -14,6 +14,7 @@ API:
     DEBUG: "False"
     ENV: ""
     IAM_ARN_BASE: ""
+    K8S_WORKER_ROLE_ARN: ""
     LOGS_BUCKET_NAME: ""
 AWS:
   IAMRole: ""


### PR DESCRIPTION
### What and why
This is required by: https://github.com/ministryofjustice/analytics-platform-control-panel/pull/19

See that PR for more info but basically it's how we tell the Control Panel
API the k8s worker role which will need to end up in the `sts:AssumeRole`
policy, used by kube2iam

### Part of ticket

https://trello.com/c/3dZNb9rw/379-cp-api-when-an-app-is-created-the-app-iam-role-is-created