### PR TITLE
cpanel: Renamed K8S_WORKER_ROLE_ARN => K8S_WORKER_ROLE_NAME

### DIFF
--- a/charts/cpanel/CHANGELOG.md
+++ b/charts/cpanel/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [0.3.1] - 2017-09-15
+### Changed
+- Renamed `K8S_WORKER_ROLE_ARN` environment variables value to
+  `K8S_WORKER_ROLE_NAME`
+
+
 ## [0.3.0] - 2017-09-15
 ### Added
 - Added `K8S_WORKER_ROLE_ARN` environment variables value

--- a/charts/cpanel/Chart.yaml
+++ b/charts/cpanel/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Analytics Platform Control Panel API webapp
 name: cpanel
-version: 0.3.0
+version: 0.3.1

--- a/charts/cpanel/templates/deployment.yml
+++ b/charts/cpanel/templates/deployment.yml
@@ -45,8 +45,8 @@ spec:
               value: "{{ .Values.API.Environment.ENV }}"
             - name: IAM_ARN_BASE
               value: "{{ .Values.API.Environment.IAM_ARN_BASE }}"
-            - name: K8S_WORKER_ROLE_ARN
-              value: "{{ .Values.API.Environment.K8S_WORKER_ROLE_ARN }}"
+            - name: K8S_WORKER_ROLE_NAME
+              value: "{{ .Values.API.Environment.K8S_WORKER_ROLE_NAME }}"
             - name: LOGS_BUCKET_NAME
               value: "{{ .Values.API.Environment.LOGS_BUCKET_NAME }}"
           readinessProbe:

--- a/charts/cpanel/values.yaml
+++ b/charts/cpanel/values.yaml
@@ -14,7 +14,7 @@ API:
     DEBUG: "False"
     ENV: ""
     IAM_ARN_BASE: ""
-    K8S_WORKER_ROLE_ARN: ""
+    K8S_WORKER_ROLE_NAME: ""
     LOGS_BUCKET_NAME: ""
 AWS:
   IAMRole: ""


### PR DESCRIPTION
As suggested by Kerin in [other PR](https://github.com/ministryofjustice/analytics-platform-config/pull/10#pullrequestreview-63053919).

(I'm threating this as a non-breaking minor fix as the control_panel_api
code using this is not even merged yet, so just bumping the patch version number as bump the minor number seems overkill)