### PR TITLE
cpanel: Added `SENTRY_DSN` environment variable value

### DIFF
--- a/charts/cpanel/CHANGELOG.md
+++ b/charts/cpanel/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [0.5.0] - 2017-10-09
+### Added
+- Added `SENTRY_DSN` environment variables value
+
+
 ## [0.3.1] - 2017-09-15
 ### Changed
 - Renamed `K8S_WORKER_ROLE_ARN` environment variables value to

--- a/charts/cpanel/Chart.yaml
+++ b/charts/cpanel/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Analytics Platform Control Panel API webapp
 name: cpanel
-version: 0.4.1
+version: 0.5.0

--- a/charts/cpanel/README.md
+++ b/charts/cpanel/README.md
@@ -30,6 +30,7 @@ The instance will be available at https://cpanelapi-$BRANCH_NAME.<ServicesDomain
 | `API.Environment.IAM_ARN_BASE` | | |
 | `API.Environment.K8S_WORKER_ROLE_NAME` | | |
 | `API.Environment.LOGS_BUCKET_NAME` | | |
+| `API.Environment.SENTRY_DSN` | Sentry credentials | |
 | `AWS.DefaultRegion` | AWS region | `eu-west-1` |
 | `AWS.IAMRole` | IAM role assumed by the instance running the API | |
 | `postgresql.postgresDatabase` | The database name where API data will be stored | |

--- a/charts/cpanel/templates/deployment.yaml
+++ b/charts/cpanel/templates/deployment.yaml
@@ -60,6 +60,8 @@ spec:
               value: "{{ .Values.API.Environment.K8S_WORKER_ROLE_NAME }}"
             - name: LOGS_BUCKET_NAME
               value: "{{ .Values.API.Environment.LOGS_BUCKET_NAME }}"
+            - name: SENTRY_DSN
+              value: "{{ .Values.API.Environment.SENTRY_DSN }}"
           readinessProbe:
             httpGet:
               path: /auth/login

--- a/charts/cpanel/templates/deployment.yaml
+++ b/charts/cpanel/templates/deployment.yaml
@@ -61,7 +61,10 @@ spec:
             - name: LOGS_BUCKET_NAME
               value: "{{ .Values.API.Environment.LOGS_BUCKET_NAME }}"
             - name: SENTRY_DSN
-              value: "{{ .Values.API.Environment.SENTRY_DSN }}"
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ template "fullname" . }}"
+                  key: SENTRY_DSN
           readinessProbe:
             httpGet:
               path: /auth/login

--- a/charts/cpanel/templates/secrets.yaml
+++ b/charts/cpanel/templates/secrets.yaml
@@ -8,3 +8,4 @@ metadata:
 type: Opaque
 data:
   postgres-password: {{ .Values.postgresql.postgresPassword | b64enc | quote }}
+  SENTRY_DSN: {{ .Values.API.Environment.SENTRY_DSN | b64enc | quote }}

--- a/charts/cpanel/values.yaml
+++ b/charts/cpanel/values.yaml
@@ -12,6 +12,7 @@ API:
     IAM_ARN_BASE: ""
     K8S_WORKER_ROLE_NAME: ""
     LOGS_BUCKET_NAME: ""
+    SENTRY_DSN: ""
   RDSPassword: ""
 AWS:
   DefaultRegion: "eu-west-1"


### PR DESCRIPTION
### What

This is to pass the Sentry credentials to the control-panel-api: https://github.com/ministryofjustice/analytics-platform-control-panel/pull/34

### Part of ticket

https://trello.com/c/G8qny9WN/400-cp-api-set-up-sentry-for-exceptions