### PR TITLE
webapp chart: Added missing ?healthz querystring param on healthchecks

### DIFF
--- a/charts/webapp/Chart.yaml
+++ b/charts/webapp/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: webapp Helm chart for Kubernetes
 name: webapp
-version: 1.3.0
+version: 1.3.1

--- a/charts/webapp/templates/deployment.yaml
+++ b/charts/webapp/templates/deployment.yaml
@@ -63,7 +63,7 @@ spec:
               value: "3000"
           readinessProbe:
             httpGet:
-              path: /login
+              path: /login?healthz
               port: http
             initialDelaySeconds: 5
             periodSeconds: 5
@@ -75,7 +75,7 @@ spec:
             - containerPort: {{ .Values.WebApp.Port }}
           livenessProbe:
             httpGet:
-              path: /
+              path: /?healthz
               port: {{ .Values.WebApp.Port }}
             initialDelaySeconds: 180
             periodSeconds: 10


### PR DESCRIPTION
Prevents elasticsearch/kibana from filling up with not particularly useful logs.

Makes use of fluentd rule here https://github.com/ministryofjustice/analytics-platform-helm-charts/blob/master/charts/fluentd/values.yaml#L141