### PR TITLE
Refactor to helm best practices and fix RStudio auth proxy env vars

### DIFF
--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
-description: A Helm chart for RStudio
+description: RStudio with Auth0 authentication proxy
 name: rstudio
-version: 1.1.0
+version: 1.2.0

--- a/charts/rstudio/templates/deployment.yml
+++ b/charts/rstudio/templates/deployment.yml
@@ -12,19 +12,19 @@ spec:
       labels:
         app: "{{ .Chart.Name }}"
       annotations:
-        iam.amazonaws.com/role: {{ .Values.AWS.IAMRole }}
+        iam.amazonaws.com/role: {{ .Values.aws.iamRole }}
     spec:
       containers:
 
         - name: rstudio-auth-proxy
-          image: "{{ .Values.AuthProxy.Image.Repository }}:{{ .Values.AuthProxy.Image.Tag }}"
-          imagePullPolicy: {{ .Values.AuthProxy.Image.PullPolicy }}
+          image: "{{ .Values.authProxy.image.repository }}:{{ .Values.authProxy.image.tag }}"
+          imagePullPolicy: {{ .Values.authProxy.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: 3000
+              containerPort: {{ .Values.authProxy.express.port }}
           env:
             - name: USER
-              value: {{ .Values.Username }}
+              value: {{ .Values.username }}
             - name: AUTH0_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
@@ -55,12 +55,14 @@ spec:
                 secretKeyRef:
                   name: {{ template "fullname" . }}
                   key: secure_cookie_key
-            - name: SHINY_HOST
+            - name: PROXY_TARGET_HOST
               value: localhost
-            - name: SHINY_PORT
-              value: "8787"
-            - name: PORT
-              value: "3000"
+            - name: PROXY_TARGET_PORT
+              value: {{ .Values.rstudio.port }}
+            - name: EXPRESS_HOST
+              value: {{ .Values.authProxy.express.host }}
+            - name: EXPRESS_PORT
+              value: {{ .Values.authProxy.express.port }}
           readinessProbe:
             httpGet:
               path: /login?healthz
@@ -68,17 +70,17 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 5
           resources:
-{{ toYaml .Values.AuthProxy.resources | indent 12 }}
+{{ toYaml .Values.authProxy.resources | indent 12 }}
 
         - name: r-studio-server
-          image: "{{ .Values.RStudio.Image.Repository }}:{{ .Values.RStudio.Image.Tag }}"
-          imagePullPolicy: {{ .Values.RStudio.Image.PullPolicy }}
+          image: "{{ .Values.rstudio.image.Repository }}:{{ .Values.rstudio.image.tag }}"
+          imagePullPolicy: {{ .Values.rstudio.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: 8787
+              containerPort: {{ .Values.rstudio.port }}
           env:
             - name: USER
-              value: {{ .Values.Username }}
+              value: {{ .Values.username }}
             - name: AWS_DEFAULT_REGION
               valueFrom:
                 secretKeyRef:
@@ -90,7 +92,7 @@ spec:
                   name: {{ template "fullname" . }}
                   key: secure_cookie_key
             - name: TOOLS_DOMAIN
-              value: {{ .Values.ToolsDomain }}
+              value: {{ .Values.toolsDomain }}
           readinessProbe:
             httpGet:
               path: /
@@ -99,9 +101,9 @@ spec:
             periodSeconds: 5
           volumeMounts:
             - name: home
-              mountPath: "/home/{{ .Values.Username }}"
+              mountPath: "/home/{{ .Values.username }}"
           resources:
-{{ toYaml .Values.RStudio.resources | indent 12 }}
+{{ toYaml .Values.rstudio.resources | indent 12 }}
 
       volumes:
         - name: home

--- a/charts/rstudio/templates/ingress.yml
+++ b/charts/rstudio/templates/ingress.yml
@@ -9,7 +9,7 @@ metadata:
     kubernetes.io/ingress.class: "nginx"
 spec:
   rules:
-  - host: {{ .Values.Username | lower }}-rstudio.{{ .Values.ToolsDomain }}
+  - host: {{ .Values.username | lower }}-rstudio.{{ .Values.toolsDomain }}
     http:
       paths:
       - backend:

--- a/charts/rstudio/templates/secrets.yml
+++ b/charts/rstudio/templates/secrets.yml
@@ -7,10 +7,10 @@ metadata:
     app: "{{ .Chart.Name }}"
 type: Opaque
 data:
-  client_secret: {{ .Values.OAuth.ClientSecret | b64enc | quote }}
-  client_id: {{ .Values.OAuth.ClientId | b64enc | quote }}
-  domain: {{ .Values.OAuth.Domain | b64enc | quote }}
-  callback_url: {{ printf "https://%s-rstudio.%s/callback" .Values.Username .Values.ToolsDomain | lower | b64enc | quote }}
-  cookie_secret: {{ .Values.CookieSecret | b64enc | quote }}
-  secure_cookie_key: {{ .Values.SecureCookieKey | b64enc | quote }}
-  aws_default_region: {{ .Values.AWS.DefaultRegion | b64enc | quote }}
+  client_secret: {{ .Values.authProxy.auth0.clientSecret | b64enc | quote }}
+  client_id: {{ .Values.authproxy.auth0.clientId | b64enc | quote }}
+  domain: {{ .Values.authProxy.auth0.domain | b64enc | quote }}
+  callback_url: {{ printf "https://%s-rstudio.%s/callback" .Values.username .Values.toolsDomain | lower | b64enc | quote }}
+  cookie_secret: {{ .Values.authProxy.cookieSecret | b64enc | quote }}
+  secure_cookie_key: {{ .Values.rstudio.secureCookieKey | b64enc | quote }}
+  aws_default_region: {{ .Values.aws.defaultRegion | b64enc | quote }}

--- a/charts/rstudio/values.yaml
+++ b/charts/rstudio/values.yaml
@@ -1,19 +1,21 @@
-Username: ""
-ToolsDomain: "tools.EXAMPLE.COM"
-CookieSecret: ""
-SecureCookieKey: ""
-OAuth:
-  ClientSecret: ""
-  ClientId: ""
-  Domain: "AUTH0_USER.eu.auth0.com"
-AWS:
-  IAMRole: ""
-  DefaultRegion: "eu-west-1"
-AuthProxy:
-  Image:
-    Repository: quay.io/mojanalytics/rstudio-auth-proxy
-    Tag: "latest"
-    PullPolicy: "IfNotPresent"
+username: ""
+toolsDomain: "tools.EXAMPLE.COM"
+aws:
+  iamRole: ""
+  defaultRegion: "eu-west-1"
+authProxy:
+  auth0:
+    clientSecret: ""
+    clientId: ""
+    domain: "AUTH0_USER.eu.auth0.com"
+  cookieSecret: ""
+  express:
+    host: "0.0.0.0"
+    port: "3000"
+  image:
+    repository: quay.io/mojanalytics/rstudio-auth-proxy
+    tag: "latest"
+    pullPolicy: "IfNotPresent"
   resources:
     limits:
       cpu: 100m
@@ -21,11 +23,13 @@ AuthProxy:
     requests:
       cpu: 25m
       memory: 64Mi
-RStudio:
-  Image:
-    Repository: quay.io/mojanalytics/rstudio
-    Tag: "latest"
-    PullPolicy: "Always"
+rstudio:
+  secureCookieKey: ""
+  port: "8787"
+  image:
+    repository: quay.io/mojanalytics/rstudio
+    tag: "latest"
+    pullPolicy: "Always"
   resources:
     limits:
       cpu: 1.5


### PR DESCRIPTION
* Rename and restructure `values.yml` keys - helm best practice is to use camelCase for value names
* Add missing env vars for RStudio auth proxy