### PR TITLE
Make cpfrontend always pull the latest image

### DIFF
--- a/charts/cpfrontend/Chart.yaml
+++ b/charts/cpfrontend/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Analytics Platform Control Panel webapp
 name: cpfrontend
-version: 1.0.2
+version: 1.0.3

--- a/charts/cpfrontend/values.yaml
+++ b/charts/cpfrontend/values.yaml
@@ -4,7 +4,7 @@ Frontend:
   Image:
     Repository: quay.io/mojanalytics/control-panel-frontend
     Tag: 0.1.0
-    PullPolicy: IfNotPresent
+    PullPolicy: Always
   Environment:
     API_URL: "http://cpanel-api-cpanel"
     AUTH0_CLIENT_ID: ""


### PR DESCRIPTION
This can be reverted when we switch to using git hashes for cpfrontend image tags instead of the branch name