### PR TITLE
Rename cpfrontend container

### DIFF
--- a/charts/cpfrontend/Chart.yaml
+++ b/charts/cpfrontend/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Analytics Platform Control Panel webapp
 name: cpfrontend
-version: 1.1.4
+version: 1.1.5

--- a/charts/cpfrontend/templates/deployment.yaml
+++ b/charts/cpfrontend/templates/deployment.yaml
@@ -13,7 +13,7 @@ spec:
         app: {{ template "fullname" . }}
     spec:
       containers:
-        - name: api
+        - name: cpfrontend
           image: "{{ .Values.Frontend.Image.Repository }}:{{ .Values.Frontend.Image.Tag }}"
           imagePullPolicy: {{ .Values.Frontend.Image.PullPolicy }}
           ports:


### PR DESCRIPTION
It was confusingly named `api`