### PR TITLE
RStudio: ensure deployments are zero-downtime

### DIFF
--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: RStudio with Auth0 authentication proxy
 name: rstudio
-version: 1.2.5
+version: 1.2.6

--- a/charts/rstudio/templates/deployment.yml
+++ b/charts/rstudio/templates/deployment.yml
@@ -7,6 +7,11 @@ metadata:
     app: "{{ .Chart.Name }}"
 spec:
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   template:
     metadata:
       labels:


### PR DESCRIPTION
Added [maxUnavailable and maxSurge attributes](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#max-unavailable) to the RStudio Deployment spec, so that old pods are killed _after_ new pods are up and running.

To test:

1. Run `kubectl get pods -n user-$YOUR_USERNAME -w` to watch the status of your pods
2. In a separate terminal session, from the chart repo, run `helm upgrade $YOUR_USERNAME-rstudio ./charts/rstudio -f ../analytics-platform-config/chart-env-config/dev/rstudio.yml --set username=$YOUR_USERNAME --set aws.iamRole=dev_user_$YOUR_USERNAME --set rstudio.image.tag=latest --namespace user-$YOUR_USERNAME --install --wait` to update the Deployment
3. Watch the `kubectl get pods` output as the deployment rolls out, and verify that the old pod is not terminated until the new pod is available