### PR TITLE
Nfs backup: configure job garbage collection and changed default schedule to daily

### DIFF
--- a/charts/nfs-backup/Chart.yaml
+++ b/charts/nfs-backup/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: nfs-backup
-version: 0.1.2
+version: 0.2.0

--- a/charts/nfs-backup/templates/cronjob.yml
+++ b/charts/nfs-backup/templates/cronjob.yml
@@ -8,6 +8,8 @@ metadata:
 spec:
   schedule: "{{ .Values.Schedule }}"
   concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: {{ .Values.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.failedJobsHistoryLimit }}
   jobTemplate:
     spec:
       template:

--- a/charts/nfs-backup/values.yaml
+++ b/charts/nfs-backup/values.yaml
@@ -7,3 +7,5 @@ Image:
   Tag: "1.6.1"
   PullPolicy: IfNotPresent
 Schedule: "@hourly"
+successfulJobsHistoryLimit: 5
+failedJobsHistoryLimit: 5

--- a/charts/nfs-backup/values.yaml
+++ b/charts/nfs-backup/values.yaml
@@ -6,6 +6,6 @@ Image:
   Repository: samepagelabs/s3cmd
   Tag: "1.6.1"
   PullPolicy: IfNotPresent
-Schedule: "@hourly"
+Schedule: "@daily"
 successfulJobsHistoryLimit: 5
 failedJobsHistoryLimit: 5


### PR DESCRIPTION
This change limits the number of completed and failed cronjob pods that are retained, to prevent them cluttering up the cluster. Default backup frequency has also been dropped to daily, due to the resource-intensive nature of the s3cmd backup command.