### PR TITLE
v0.9.0: Added environment variables needed to deploy RStudio

### DIFF
--- a/charts/cpanel/CHANGELOG.md
+++ b/charts/cpanel/CHANGELOG.md
@@ -5,6 +5,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [0.9.0] - 2017-12-12
+### Added
+Added environment variables needed to deploy RStudio
+- Added `TOOLS_DOMAIN` variable
+- Added `RSTUDIO_AUTH_CLIENT_DOMAIN` variable
+- Added `RSTUDIO_AUTH_CLIENT_ID` variable
+- Added `RSTUDIO_AUTH_CLIENT_SECRET` variable
+
+
 ## [0.7.0] - 2017-10-27
 ### Added
 - Added `NFS_HOSTNAME` variable

--- a/charts/cpanel/Chart.yaml
+++ b/charts/cpanel/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Analytics Platform Control Panel API webapp
 name: cpanel
-version: 0.8.0
+version: 0.9.0

--- a/charts/cpanel/templates/deployment.yaml
+++ b/charts/cpanel/templates/deployment.yaml
@@ -87,6 +87,26 @@ spec:
                 secretKeyRef:
                   name: "{{ template "fullname" . }}"
                   key: NFS_HOSTNAME
+            - name: TOOLS_DOMAIN
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ template "fullname" . }}"
+                  key: TOOLS_DOMAIN
+            - name: RSTUDIO_AUTH_CLIENT_DOMAIN
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ template "fullname" . }}"
+                  key: RSTUDIO_AUTH_CLIENT_DOMAIN
+            - name: RSTUDIO_AUTH_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ template "fullname" . }}"
+                  key: RSTUDIO_AUTH_CLIENT_ID
+            - name: RSTUDIO_AUTH_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ template "fullname" . }}"
+                  key: RSTUDIO_AUTH_CLIENT_SECRET
           readinessProbe:
             httpGet:
               path: /auth/login

--- a/charts/cpanel/templates/secrets.yaml
+++ b/charts/cpanel/templates/secrets.yaml
@@ -13,3 +13,7 @@ data:
   OIDC_DOMAIN: {{ .Values.API.Environment.OIDC_DOMAIN | b64enc | quote }}
   SENTRY_DSN: {{ .Values.API.Environment.SENTRY_DSN | b64enc | quote }}
   NFS_HOSTNAME: {{ .Values.API.Environment.NFS_HOSTNAME | b64enc | quote }}
+  TOOLS_DOMAIN: {{ .Values.API.Environment.TOOLS_DOMAIN | b64enc | quote }}
+  RSTUDIO_AUTH_CLIENT_DOMAIN: {{ .Values.API.Environment.RSTUDIO_AUTH_CLIENT_DOMAIN | b64enc | quote }}
+  RSTUDIO_AUTH_CLIENT_ID: {{ .Values.API.Environment.RSTUDIO_AUTH_CLIENT_ID | b64enc | quote }}
+  RSTUDIO_AUTH_CLIENT_SECRET: {{ .Values.API.Environment.RSTUDIO_AUTH_CLIENT_SECRET | b64enc | quote }}

--- a/charts/cpanel/values.yaml
+++ b/charts/cpanel/values.yaml
@@ -18,6 +18,10 @@ API:
     SAML_PROVIDER: ""
     SENTRY_DSN: ""
     NFS_HOSTNAME: ""
+    RSTUDIO_AUTH_CLIENT_DOMAIN: ""
+    RSTUDIO_AUTH_CLIENT_ID: ""
+    RSTUDIO_AUTH_CLIENT_SECRET: ""
+    TOOLS_DOMAIN: ""
   RDSPassword: ""
 AWS:
   DefaultRegion: "eu-west-1"


### PR DESCRIPTION
### What
- Added `TOOLS_DOMAIN` variable
- Added `RSTUDIO_AUTH_CLIENT_DOMAIN` variable
- Added `RSTUDIO_AUTH_CLIENT_ID` variable
- Added `RSTUDIO_AUTH_CLIENT_SECRET` variable

### Related PR
- https://github.com/ministryofjustice/analytics-platform-control-panel/pull/82
- https://github.com/ministryofjustice/analytics-platform-config/pull/21

### Ticket
https://trello.com/c/77FMKVLE/536-3-cp-api-add-endpoint-to-deploy-rstudio