### PR TITLE
cpfrontend 1.3.0: Setting `TOOLS_DOMAIN` environment variable

### DIFF
--- a/charts/cpfrontend/CHANGELOG.md
+++ b/charts/cpfrontend/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+
+## [1.3.0] - 2017-12-12
+### Added
+Added `TOOLS_DOMAIN` environment variable

--- a/charts/cpfrontend/Chart.yaml
+++ b/charts/cpfrontend/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Analytics Platform Control Panel webapp
 name: cpfrontend
-version: 1.2.0
+version: 1.3.0

--- a/charts/cpfrontend/README.md
+++ b/charts/cpfrontend/README.md
@@ -1,0 +1,39 @@
+# Control Panel frontend Helm Chart
+
+Installing this chart will deploy the Analytical Platform Control Panel frontend.
+The Control Panel allows the creation and management of users, apps and
+data sources on the platform.
+
+
+## Installing the Chart
+
+To install the chart:
+
+```bash
+helm install mojanalytics/cpfrontend \
+  --name cpfrontend-$BRANCH_NAME \
+  --set ServicesDomain=$SERVICES_DOMAIN \
+  --set Frontend.Image.Tag=$DOCKER_IMAGE_TAG \
+  --set Frontend.Environment.ENV=$ENV \
+  --set Frontend.Environment.AUTH0_DOMAIN=$AUTH0_DOMAIN \
+  --set Frontend.Environment.AUTH0_CLIENT_ID=$AUTH0_CLIENT_ID \
+  --set Frontend.Environment.AUTH0_CLIENT_SECRET=$AUTH0_CLIENT_SECRET \
+  --set Frontend.Environment.SENTRY_DSN=$SENTRY_DSN \
+  --set Frontend.Environment.TOOLS_DOMAIN=$TOOLS_DOMAIN \
+```
+
+The instance will be available at https://cpfrontend-$BRANCH_NAME.$SERVICES_DOMAIN
+
+
+## Configuration
+
+| Parameter  | Description     | Default |
+| ---------- | --------------- | ------- |
+| `Frontend.Environment.API_URL` | URL where the API is running | `""` |
+| `Frontend.Environment.AUTH0_CLIENT_ID` | Auth0 client ID | `""` |
+| `Frontend.Environment.AUTH0_CLIENT_SECRET` | Auth0 client ID | `""` |
+| `Frontend.Environment.AUTH0_DOMAIN` | Auth0 client domain | `""` |
+| `Frontend.Environment.ENV` | Environment name, e.g. `"dev"` | `""` |
+| `Frontend.Environment.SENTRY_DSN` | Credentials needed to report errors to Sentry | `""` |
+| `Frontend.Environment.TOOLS_DOMAIN` | Domain under which tools are deployed, e.g. `tools.example.com` | `""` |
+| `ServicesDomain` | domain under which the UI will be available, e.g. `services.example.com` | `""` |

--- a/charts/cpfrontend/templates/deployment.yaml
+++ b/charts/cpfrontend/templates/deployment.yaml
@@ -50,6 +50,11 @@ spec:
                 secretKeyRef:
                   name: "{{ printf "%s-%s" .Release.Name "redis" | trunc 63 | trimSuffix "-" }}"
                   key: redis-password
+            - name: TOOLS_DOMAIN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "fullname" . }}
+                  key: tools-domain
           readinessProbe:
             httpGet:
               path: /login?healthz

--- a/charts/cpfrontend/templates/secrets.yaml
+++ b/charts/cpfrontend/templates/secrets.yaml
@@ -10,3 +10,4 @@ data:
   auth0-client-id: {{ .Values.Frontend.Environment.AUTH0_CLIENT_ID | b64enc | quote }}
   auth0-client-secret: {{ .Values.Frontend.Environment.AUTH0_CLIENT_SECRET | b64enc | quote }}
   sentry-dsn: {{ .Values.Frontend.Environment.SENTRY_DSN | b64enc | quote }}
+  tools-domain: {{ .Values.Frontend.Environment.TOOLS_DOMAIN | b64enc | quote }}

--- a/charts/cpfrontend/values.yaml
+++ b/charts/cpfrontend/values.yaml
@@ -12,6 +12,7 @@ Frontend:
     AUTH0_DOMAIN: ""
     ENV: ""
     SENTRY_DSN: ""
+    TOOLS_DOMAIN: ""
 
 redis:
   persistence:


### PR DESCRIPTION
Also added `README.md` and `CHANGELOG.md`.

### Ticket
Part of ticket: https://trello.com/c/BbHaXQXt/562-2-cp-app-add-node-endpoint-to-deploy-a-tool

### Related PR
https://github.com/ministryofjustice/analytics-platform-control-panel-frontend/pull/84