### PR TITLE
Role-binding to make user's admins in their own namespaces

### DIFF
--- a/charts/init-user/templates/role-binding.yml
+++ b/charts/init-user/templates/role-binding.yml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: user-{{ .Values.Username }}
+  namespace: user-{{ .Values.Username }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: admin # Does not allow user to modify resource quotas or the namespace itself
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: User
+    name: {{ .Values.Username }}


### PR DESCRIPTION
This assigns the admin user-facing role to a user, scoped to the user's namespace. 