### PR TITLE
cpanel 0.10.0: Added `ENABLE_K8S_RBAC` flag.

### DIFF
--- a/charts/cpanel/CHANGELOG.md
+++ b/charts/cpanel/CHANGELOG.md
@@ -5,6 +5,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [0.10.0] - 2018-01-11
+### Added
+Added `ENABLE_K8S_RBAC` flag. Set to `True` when k8s RBAC is enabled,
+the k8s proxy endpoint will then use the user's JWT token to make requests
+to kubernetes instead of use the credentials read from the cluster.
+
+See [PR](https://github.com/ministryofjustice/analytics-platform-control-panel/pull/85)
+
+
 ## [0.9.0] - 2017-12-12
 ### Added
 Added environment variables needed to deploy RStudio

--- a/charts/cpanel/Chart.yaml
+++ b/charts/cpanel/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Analytics Platform Control Panel API webapp
 name: cpanel
-version: 0.9.0
+version: 0.10.0

--- a/charts/cpanel/README.md
+++ b/charts/cpanel/README.md
@@ -26,6 +26,7 @@ The instance will be available at https://cpanelapi-$BRANCH_NAME.<ServicesDomain
 | Parameter  | Description     | Default |
 | ---------- | --------------- | ------- |
 | `API.Environment.DEBUG` | Used to set Django DEBUG mode | `False` |
+| `API.Environment.ENABLE_K8S_RBAC` | Set to `True` if k8s RBAC is enabled | `False` |
 | `API.Environment.ENV` | The environment name (`dev` or `alpha`) | |
 | `API.Environment.IAM_ARN_BASE` | | |
 | `API.Environment.K8S_WORKER_ROLE_NAME` | | |

--- a/charts/cpanel/templates/deployment.yaml
+++ b/charts/cpanel/templates/deployment.yaml
@@ -52,6 +52,8 @@ spec:
               value: "{{ .Values.API.Environment.DEBUG }}"
             - name: DJANGO_SETTINGS_MODULE
               value: "control_panel_api.settings"
+            - name: ENABLE_K8S_RBAC
+              value: "{{ .Values.API.Environment.ENABLE_K8S_RBAC }}"
             - name: ENV
               value: "{{ .Values.API.Environment.ENV }}"
             - name: IAM_ARN_BASE

--- a/charts/cpanel/values.yaml
+++ b/charts/cpanel/values.yaml
@@ -8,6 +8,7 @@ API:
     PullPolicy: IfNotPresent
   Environment:
     DEBUG: "False"
+    ENABLE_K8S_RBAC: "False"
     ENV: ""
     IAM_ARN_BASE: ""
     K8S_WORKER_ROLE_NAME: ""


### PR DESCRIPTION
Set to `True` when k8s RBAC is enabled, the k8s proxy endpoint will then use
the user's JWT token to make requests to kubernetes instead of use the
credentials read from the cluster.

See [PR](https://github.com/ministryofjustice/analytics-platform-control-panel/pull/85)