### PR TITLE
OIDC Username Claim

### DIFF
--- a/charts/init-user/templates/role-binding.yml
+++ b/charts/init-user/templates/role-binding.yml
@@ -10,4 +10,4 @@ roleRef:
 subjects:
   - apiGroup: rbac.authorization.k8s.io
     kind: User
-    name: {{ .Values.Username }}
+    name: https://alpha-analytics-moj.eu.auth0.com/#{{ .Values.Username }}


### PR DESCRIPTION
The Kubernetes API prefixes the 'IssuerURL' to all UsernameClaims other than email.
To use the nickname claim, we must prefix the subject's name with the 'IssuerURL' until which point kops supports the --oidc-username-prefix flag.
See: https://kubernetes.io/docs/admin/authentication/#configuring-the-api-server

Also, see Aldo's PR where he added support for --oidc-username-prefix
to kops: kubernetes/kops#4085