### PR TITLE
Updated nginx-ingress controller from latest upstream

### DIFF
--- a/charts/nginx-ingress/Chart.yaml
+++ b/charts/nginx-ingress/Chart.yaml
@@ -1,3 +1,4 @@
+appVersion: 0.9.0-beta.15
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.
 engine: gotpl
 icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png
@@ -6,10 +7,12 @@ keywords:
 - nginx
 maintainers:
 - email: jack.zampolin@gmail.com
-  name: Jack Zampolin
+  name: jackzampolin
 - email: mgoodness@gmail.com
-  name: Michael Goodness
+  name: mgoodness
+- email: chance.zibolski@coreos.com
+  name: chancez
 name: nginx-ingress
 sources:
-- https://github.com/kubernetes/contrib/tree/master/ingress/controllers/nginx
-version: 0.3.0
+- https://github.com/kubernetes/ingress-nginx
+version: 0.8.26

--- a/charts/nginx-ingress/README.md
+++ b/charts/nginx-ingress/README.md
@@ -1,6 +1,6 @@
 # nginx-ingress
 
-[nginx-ingress](https://github.com/kubernetes/contrib/tree/master/ingress/controllers/nginx) is an Ingress controller that uses ConfigMap to store the nginx configuration.
+[nginx-ingress](https://github.com/kubernetes/ingress-nginx) is an Ingress controller that uses ConfigMap to store the nginx configuration.
 
 To use, add the `kubernetes.io/ingress.class: nginx` annotation to your Ingress resources.
 
@@ -41,28 +41,45 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Configuration
 
-The following tables lists the configurable parameters of the aws-cluster-autoscaler chart and their default values.
+The following tables lists the configurable parameters of the nginx-ingress chart and their default values.
 
 Parameter | Description | Default
 --- | --- | ---
 `controller.name` | name of the controller component | `controller`
-`controller.image.repository` | controller container image repository | `gcr.io/google_containers/nginx-ingress-controller`
-`controller.image.tag` | controller container image tag | `0.8.3`
+`controller.image.repository` | controller container image repository | `k8s.gcr.io/nginx-ingress-controller`
+`controller.image.tag` | controller container image tag | `0.9.0-beta.15`
 `controller.image.pullPolicy` | controller container image pull policy | `IfNotPresent`
 `controller.config` | nginx ConfigMap entries | none
+`controller.hostNetwork` | If the nginx deployment / daemonset should run on the host's network namespace | false
 `controller.defaultBackendService` | default 404 backend service; required only if `defaultBackend.enabled = false` | `""`
+`controller.electionID` | election ID to use for the status update | `ingress-controller-leader`
+`controller.extraEnvs` | any additional environment variables to set in the pods | `{}`
+`controller.ingressClass` | name of the ingress class to route through this controller | `nginx`
+`controller.scope.enabled` | limit the scope of the ingress controller | `false` (watch all namespaces)
+`controller.scope.namespace` | namespace to watch for ingress | `""` (use the release namespace)
 `controller.extraArgs` | Additional controller container arguments | `{}`
 `controller.kind` | install as Deployment or DaemonSet | `Deployment`
+`controller.tolerations` | node taints to tolerate (requires Kubernetes >=1.6) | `[]`
+`controller.minReadySeconds` | how many seconds a pod needs to be ready before killing the next, during update | `0`
 `controller.nodeSelector` | node labels for pod assignment | `{}`
 `controller.podAnnotations` | annotations to be added to pods | `{}`
 `controller.replicaCount` | desired number of controller pods | `1`
 `controller.resources` | controller pod resource requests & limits | `{}`
+`controller.lifecycle` | controller pod lifecycle hooks | `{}`
 `controller.service.annotations` | annotations for controller service | `{}`
+`controller.publishService.enabled` | if true, the controller will set the endpoint records on the ingress objects to reflect those on the service | `false`
+`controller.publishService.pathOverride` | override of the default publish-service name | `""`
 `controller.service.clusterIP` | internal controller cluster service IP | `""`
 `controller.service.externalIPs` | controller service external IP addresses | `[]`
+`controller.service.externalTrafficPolicy` | If `controller.service.type` is `NodePort` or `LoadBalancer`, set this to `Local` to enable [source IP preservation](https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typenodeport) | `"Cluster"`
+`controller.service.healthCheckNodePort` | If `controller.service.type` is `NodePort` or `LoadBalancer` and `controller.service.externalTrafficPolicy` is set to `Local`, set this to [the managed health-check port the kube-proxy will expose](https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typenodeport). If blank, a random port in the `NodePort` range will be assigned | `""`
 `controller.service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`
 `controller.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`
+`controller.service.targetPorts.http` | Sets the targetPort that maps to the Ingress' port 80 | `80`
+`controller.service.targetPorts.https` | Sets the targetPort that maps to the Ingress' port 443 | `443`
 `controller.service.type` | type of controller service to create | `LoadBalancer`
+`controller.service.nodePorts.http` | If `controller.service.type` is `NodePort` and this is non-empty, it sets the nodePort that maps to the Ingress' port 80 | `""`
+`controller.service.nodePorts.https` | If `controller.service.type` is `NodePort` and this is non-empty, it sets the nodePort that maps to the Ingress' port 443 | `""`
 `controller.stats.enabled` | if true, enable "vts-status" page & Prometheus metrics | `false`
 `controller.stats.service.annotations` | annotations for controller stats service | `{}`
 `controller.stats.service.clusterIP` | internal controller stats cluster service IP | `""`
@@ -70,11 +87,16 @@ Parameter | Description | Default
 `controller.stats.service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`
 `controller.stats.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`
 `controller.stats.service.type` | type of controller stats service to create | `ClusterIP`
+`controller.customTemplate.configMapName` | configMap containing a custom nginx template | `""`
+`controller.customTemplate.configMapKey` | configMap key containing the nginx template | `""`
+`controller.headers` | configMap key:value pairs containing the [custom headers](https://github.com/kubernetes/ingress-nginx/tree/master/docs/examples/customization/custom-headers) for Nginx | `{}`
+`controller.updateStrategy` | allows setting of RollingUpdate strategy | `{}`
 `defaultBackend.name` | name of the default backend component | `default-backend`
-`defaultBackend.image.repository` | default backend container image repository | `gcr.io/google_containers/defaultbackend`
-`defaultBackend.image.tag` | default backend container image tag | `1.2`
+`defaultBackend.image.repository` | default backend container image repository | `k8s.gcr.io/defaultbackend`
+`defaultBackend.image.tag` | default backend container image tag | `1.3`
 `defaultBackend.image.pullPolicy` | default backend container image pull policy | `IfNotPresent`
 `defaultBackend.extraArgs` | Additional default backend container arguments | `{}`
+`defaultBackend.tolerations` | node taints to tolerate (requires Kubernetes >=1.6) | `[]`
 `defaultBackend.nodeSelector` | node labels for pod assignment | `{}`
 `defaultBackend.podAnnotations` | annotations to be added to pods | `{}`
 `defaultBackend.replicaCount` | desired number of default backend pods | `1`
@@ -85,9 +107,12 @@ Parameter | Description | Default
 `defaultBackend.service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`
 `defaultBackend.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`
 `defaultBackend.service.type` | type of default backend service to create | `ClusterIP`
+`rbac.create` | If true, create & use RBAC resources | `false`
+`rbac.serviceAccountName` | ServiceAccount to be used (ignored if rbac.create=true) | `default`
+`revisionHistoryLimit` | The number of old history to retain to allow rollback. | `10`
 `statsExporter.name` | name of the Prometheus metrics exporter component | `stats-exporter`
-`statsExporter.image.repository` | Prometheus metrics exporter container image repository | `quay.io/cy-play/vts-nginx-exporter`
-`statsExporter.image.tag` | Prometheus metrics exporter image tag | `v0.0.3`
+`statsExporter.image.repository` | Prometheus metrics exporter container image repository | `sophos/nginx-vts-exporter`
+`statsExporter.image.tag` | Prometheus metrics exporter image tag | `v0.6`
 `statsExporter.image.pullPolicy` | Prometheus metrics exporter image pull policy | `IfNotPresent`
 `statsExporter.endpoint` | path at which Prometheus metrics are exposed | `/metrics`
 `statsExporter.extraArgs` | Additional Prometheus metrics exporter container arguments | `{}`
@@ -100,6 +125,7 @@ Parameter | Description | Default
 `statsExporter.service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`
 `statsExporter.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`
 `statsExporter.service.servicePort` | Prometheus metrics exporter service port | `9913`
+`statsExporter.service.targetPort` | Prometheus metrics exporter target port | `9913`
 `statsExporter.service.type` | type of Prometheus metrics exporter service to create | `ClusterIP`
 `tcp` | TCP service key:value pairs | `{}`
 `udp` | UDP service key:value pairs | `{}`

--- a/charts/nginx-ingress/templates/NOTES.txt
+++ b/charts/nginx-ingress/templates/NOTES.txt
@@ -2,15 +2,27 @@ The nginx-ingress controller has been installed.
 
 {{- if contains "NodePort" .Values.controller.service.type }}
 Get the application URL by running these commands:
-  export NODE_PORT=$(kubectl --namespace {{ .Release.Namespace }} get services -o jsonpath="{.spec.ports[0].nodePort}" {{ template "controller.fullname" . }})
+
+{{- if (not (empty .Values.controller.service.nodePorts.http)) }}
+  export HTTP_NODE_PORT={{ .Values.controller.service.nodePorts.http }}
+{{- else }}
+  export HTTP_NODE_PORT=$(kubectl --namespace {{ .Release.Namespace }} get services -o jsonpath="{.spec.ports[0].nodePort}" {{ template "nginx-ingress.controller.fullname" . }})
+{{- end }}
+{{- if (not (empty .Values.controller.service.nodePorts.https)) }}
+  export HTTPS_NODE_PORT={{ .Values.controller.service.nodePorts.https }}
+{{- else }}
+  export HTTPS_NODE_PORT=$(kubectl --namespace {{ .Release.Namespace }} get services -o jsonpath="{.spec.ports[1].nodePort}" {{ template "nginx-ingress.controller.fullname" . }})
+{{- end }}
   export NODE_IP=$(kubectl --namespace {{ .Release.Namespace }} get nodes -o jsonpath="{.items[0].status.addresses[1].address}")
-  echo "Visit http://$NODE_IP:$NODE_PORT to access your application."
+
+  echo "Visit http://$NODE_IP:$HTTP_NODE_PORT to access your application via HTTP."
+  echo "Visit https://$NODE_IP:$HTTPS_NODE_PORT to access your application via HTTPS."
 {{- else if contains "LoadBalancer" .Values.controller.service.type }}
 It may take a few minutes for the LoadBalancer IP to be available.
-You can watch the status by running 'kubectl --namespace {{ .Release.Namespace }} get services -o wide -w {{ template "controller.fullname" . }}'
+You can watch the status by running 'kubectl --namespace {{ .Release.Namespace }} get services -o wide -w {{ template "nginx-ingress.controller.fullname" . }}'
 {{- else if contains "ClusterIP"  .Values.controller.service.type }}
 Get the application URL by running these commands:
-  export POD_NAME=$(kubectl --namespace {{ .Release.Namespace }} get pods -o jsonpath="{.items[0].metadata.name}" -l "app={{ template "name" . }},component={{ .Values.controller.name }},release={{ .Release.Name }}")
+  export POD_NAME=$(kubectl --namespace {{ .Release.Namespace }} get pods -o jsonpath="{.items[0].metadata.name}" -l "app={{ template "nginx-ingress.name" . }},component={{ .Values.controller.name }},release={{ .Release.Name }}")
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:80
   echo "Visit http://127.0.0.1:8080 to access your application."
 {{- end }}
@@ -21,7 +33,7 @@ An example Ingress that makes use of the controller:
   kind: Ingress
   metadata:
     annotations:
-      kubernetes.io/ingress.class: nginx
+      kubernetes.io/ingress.class: {{ .Values.controller.ingressClass }}
     name: example
     namespace: foo
   spec:

--- a/charts/nginx-ingress/templates/_helpers.tpl
+++ b/charts/nginx-ingress/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "name" -}}
+{{- define "nginx-ingress.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -10,25 +10,52 @@ Expand the name of the chart.
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "fullname" -}}
+{{- define "nginx-ingress.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}
 
 {{/*
 Create a default fully qualified controller name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "controller.fullname" -}}
+{{- define "nginx-ingress.controller.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- printf "%s-%s" .Release.Name .Values.controller.name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- printf "%s-%s-%s" .Release.Name $name .Values.controller.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Construct the path for the publish-service.
+
+By convention this will simply use the <namespace>/<controller-name> to match the name of the
+service generated.
+
+Users can provide an override for an explicit service they want bound via `.Values.controller.publishService.pathOverride`
+
+*/}}
+{{- define "nginx-ingress.controller.publishServicePath" -}}
+{{- $defServiceName := printf "%s/%s" .Release.Namespace (include "nginx-ingress.controller.fullname" .) -}}
+{{- $servicePath := default $defServiceName .Values.controller.publishService.pathOverride }}
+{{- print $servicePath | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Create a default fully qualified default backend name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "defaultBackend.fullname" -}}
+{{- define "nginx-ingress.defaultBackend.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- printf "%s-%s" .Release.Name .Values.defaultBackend.name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- printf "%s-%s-%s" .Release.Name $name .Values.defaultBackend.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}

--- a/charts/nginx-ingress/templates/clusterrole.yaml
+++ b/charts/nginx-ingress/templates/clusterrole.yaml
@@ -1,0 +1,69 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+    app: {{ template "nginx-ingress.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "nginx-ingress.fullname" . }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - endpoints
+      - nodes
+      - pods
+      - secrets
+    verbs:
+      - list
+      - watch
+{{- if and .Values.controller.scope.enabled .Values.controller.scope.namespace }}
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    resourceNames:
+      - "{{ .Values.controller.scope.namespace }}"
+    verbs:
+      - get
+{{- end }}
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses/status
+    verbs:
+      - update
+{{- end -}}

--- a/charts/nginx-ingress/templates/clusterrolebinding.yaml
+++ b/charts/nginx-ingress/templates/clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: {{ template "nginx-ingress.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "nginx-ingress.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "nginx-ingress.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "nginx-ingress.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/charts/nginx-ingress/templates/controller-configmap.yaml
+++ b/charts/nginx-ingress/templates/controller-configmap.yaml
@@ -2,14 +2,17 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "nginx-ingress.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "controller.fullname" . }}
+  name: {{ template "nginx-ingress.controller.fullname" . }}
 data:
   enable-vts-status: "{{ .Values.controller.stats.enabled }}"
+{{- if .Values.controller.headers }}
+  proxy-set-headers: {{ .Release.Namespace }}/{{ template "nginx-ingress.fullname" . }}-custom-headers
+{{- end }}
 {{- if .Values.controller.config }}
 {{ toYaml .Values.controller.config | indent 2 }}
 {{- end }}

--- a/charts/nginx-ingress/templates/controller-customconfig-configmap.yaml
+++ b/charts/nginx-ingress/templates/controller-customconfig-configmap.yaml
@@ -1,14 +1,12 @@
-{{- if .Values.controller.serverConfigFile }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "nginx-ingress.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "fullname" . }}-nginxconf
+  name: nginx-ingress-customconfig
 data:
-{{ toYaml .Values.controller.serverConfigFile | indent 2 }}
-{{- end }}
+{{ toYaml .Values.controller.customTemplate | indent 2 }}

--- a/charts/nginx-ingress/templates/controller-daemonset.yaml
+++ b/charts/nginx-ingress/templates/controller-daemonset.yaml
@@ -3,36 +3,72 @@ apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "nginx-ingress.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "controller.fullname" . }}
+  name: {{ template "nginx-ingress.controller.fullname" . }}
 spec:
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  updateStrategy:
+{{ toYaml .Values.controller.updateStrategy | indent 4 }}
+  minReadySeconds: {{ .Values.controller.minReadySeconds }}
   template:
     metadata:
-    {{- if .Values.controller.podAnnotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/controller-configmap.yaml") . | sha256sum }}
+    {{- if .Values.controller.podAnnotations }}
 {{ toYaml .Values.controller.podAnnotations | indent 8}}
     {{- end }}
       labels:
-        app: {{ template "name" . }}
+        app: {{ template "nginx-ingress.name" . }}
         component: "{{ .Values.controller.name }}"
         release: {{ .Release.Name }}
+        {{- if .Values.controller.podLabels }}
+{{ toYaml .Values.controller.podLabels | indent 8}}
+        {{- end }}
     spec:
       containers:
-        - name: {{ template "name" . }}-{{ .Values.controller.name }}
+        - name: {{ template "nginx-ingress.name" . }}-{{ .Values.controller.name }}
           image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
           imagePullPolicy: "{{ .Values.controller.image.pullPolicy }}"
+          {{- if .Values.controller.lifecycle }}
+          lifecycle:
+{{ toYaml .Values.controller.lifecycle | indent 12 }}
+          {{- end }}
           args:
             - /nginx-ingress-controller
-            - --default-backend-service={{ if .Values.defaultBackend.enabled }}{{ .Release.Namespace }}/{{ template "defaultBackend.fullname" . }}{{ else }}{{ .Values.controller.defaultBackendService }}{{ end }}
-            - --nginx-configmap={{ .Release.Namespace }}/{{ template "controller.fullname" . }}
-            - --tcp-services-configmap={{ .Release.Namespace }}/{{ template "fullname" . }}-tcp
-            - --udp-services-configmap={{ .Release.Namespace }}/{{ template "fullname" . }}-udp
+            - --default-backend-service={{ if .Values.defaultBackend.enabled }}{{ .Release.Namespace }}/{{ template "nginx-ingress.defaultBackend.fullname" . }}{{ else }}{{ .Values.controller.defaultBackendService }}{{ end }}
+          {{- if and (contains "0.9" .Values.controller.image.tag) .Values.controller.publishService.enabled }}
+            - --publish-service={{ template "nginx-ingress.controller.publishServicePath" . }}
+          {{- end }}
+          {{- if (contains "0.9" .Values.controller.image.tag) }}
+            - --election-id={{ .Values.controller.electionID }}
+          {{- end }}
+          {{- if (contains "0.9" .Values.controller.image.tag) }}
+            - --ingress-class={{ .Values.controller.ingressClass }}
+          {{- end }}
+          {{- if (contains "0.9" .Values.controller.image.tag) }}
+            - --configmap={{ .Release.Namespace }}/{{ template "nginx-ingress.controller.fullname" . }}
+          {{- else }}
+            - --nginx-configmap={{ .Release.Namespace }}/{{ template "nginx-ingress.controller.fullname" . }}
+          {{- end }}
+          {{- if .Values.tcp }}
+            - --tcp-services-configmap={{ .Release.Namespace }}/{{ template "nginx-ingress.fullname" . }}-tcp
+          {{- end }}
+          {{- if .Values.udp }}
+            - --udp-services-configmap={{ .Release.Namespace }}/{{ template "nginx-ingress.fullname" . }}-udp
+          {{- end }}
+          {{- if .Values.controller.scope.enabled }}
+            - --watch-namespace={{ default .Release.Namespace .Values.controller.scope.namespace }}
+          {{- end }}
           {{- range $key, $value := .Values.controller.extraArgs }}
+            {{- if $value }}
             - --{{ $key }}={{ $value }}
+            {{- else }}
+            - --{{ $key }}
+            {{- end }}
           {{- end }}
           env:
             - name: POD_NAME
@@ -43,6 +79,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          {{- range $key, $value := .Values.controller.extraEnvs }}
+            - name: {{ $key | upper | replace "." "_" }}
+              value: {{ $value }}
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz
@@ -54,9 +94,15 @@ spec:
             - name: http
               containerPort: 80
               protocol: TCP
+              {{- if .Values.controller.daemonset.useHostPorts }}
+              hostPort: 80
+              {{- end }}
             - name: https
               containerPort: 443
               protocol: TCP
+              {{- if .Values.controller.daemonset.useHostPorts }}
+              hostPort: 443
+              {{- end }}
           {{- if .Values.controller.stats.enabled }}
             - name: stats
               containerPort: 18080
@@ -77,14 +123,16 @@ spec:
               path: /healthz
               port: 10254
               scheme: HTTP
+{{- if .Values.controller.customTemplate.configMapName }}
           volumeMounts:
-          - name: nginxtmpl
-            mountPath: /etc/nginx/template
+            - mountPath: /etc/nginx/template
+              name: nginx-template-volume
+              readOnly: true
+{{- end }}
           resources:
 {{ toYaml .Values.controller.resources | indent 12 }}
-
       {{- if .Values.controller.stats.enabled }}
-        - name: {{ template "name" . }}-{{ .Values.statsExporter.name }}
+        - name: {{ template "nginx-ingress.name" . }}-{{ .Values.statsExporter.name }}
           image: "{{ .Values.statsExporter.image.repository }}:{{ .Values.statsExporter.image.tag }}"
           imagePullPolicy: "{{ .Values.statsExporter.image.pullPolicy }}"
           env:
@@ -103,17 +151,26 @@ spec:
           resources:
 {{ toYaml .Values.statsExporter.resources | indent 12 }}
       {{- end }}
+      hostNetwork: {{ .Values.controller.hostNetwork }}
     {{- if .Values.controller.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.controller.nodeSelector | indent 8 }}
     {{- end }}
+    {{- if .Values.controller.tolerations }}
+      tolerations:
+{{ toYaml .Values.controller.tolerations | indent 8 }}
+    {{- end }}
+      serviceAccountName: {{ if .Values.rbac.create }}{{ template "nginx-ingress.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
       terminationGracePeriodSeconds: 60
-
+{{- if .Values.controller.customTemplate.configMapName }}
       volumes:
-        - name: nginxtmpl
+        - name: nginx-template-volume
           configMap:
-            name: {{ .Release.Namespace }}/{{ template "fullname" . }}-nginxconf
+            name: {{ .Values.controller.customTemplate.configMapName }}
             items:
-            - key: nginx.tmpl
+            - key: {{ .Values.controller.customTemplate.configMapKey }}
               path: nginx.tmpl
+{{- end }}
+  updateStrategy:
+{{ toYaml .Values.controller.updateStrategy | indent 4 }}
 {{- end }}

--- a/charts/nginx-ingress/templates/controller-deployment.yaml
+++ b/charts/nginx-ingress/templates/controller-deployment.yaml
@@ -3,41 +3,73 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "nginx-ingress.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "controller.fullname" . }}
+  name: {{ template "nginx-ingress.controller.fullname" . }}
 spec:
   replicas: {{ .Values.controller.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+{{ toYaml .Values.controller.updateStrategy | indent 4 }}
+  minReadySeconds: {{ .Values.controller.minReadySeconds }}
   template:
     metadata:
-    {{- if .Values.controller.podAnnotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/controller-configmap.yaml") . | sha256sum }}
+      {{- if .Values.controller.podAnnotations }}
 {{ toYaml .Values.controller.podAnnotations | indent 8}}
-    {{- end }}
+      {{- end }}
       labels:
-        app: {{ template "name" . }}
+        app: {{ template "nginx-ingress.name" . }}
         component: "{{ .Values.controller.name }}"
         release: {{ .Release.Name }}
+        {{- if .Values.controller.podLabels }}
+{{ toYaml .Values.controller.podLabels | indent 8 }}
+        {{- end }}
     spec:
       containers:
-        - name: {{ template "name" . }}-{{ .Values.controller.name }}
+        - name: {{ template "nginx-ingress.name" . }}-{{ .Values.controller.name }}
           image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
           imagePullPolicy: "{{ .Values.controller.image.pullPolicy }}"
+          {{- if .Values.controller.lifecycle }}
+          lifecycle:
+{{ toYaml .Values.controller.lifecycle | indent 12 }}
+          {{- end }}
           args:
             - /nginx-ingress-controller
-            - --default-backend-service={{ if .Values.defaultBackend.enabled }}{{ .Release.Namespace }}/{{ template "defaultBackend.fullname" . }}{{ else }}{{ .Values.controller.defaultBackendService }}{{ end }}
-            - --nginx-configmap={{ .Release.Namespace }}/{{ template "controller.fullname" . }}
-            {{- if .Values.tcp }}
-            - --tcp-services-configmap={{ .Release.Namespace }}/{{ template "fullname" . }}-tcp
-            {{ end -}}
-            {{- if .Values.udp }}
-            - --udp-services-configmap={{ .Release.Namespace }}/{{ template "fullname" . }}-udp
-            {{ end -}}
+            - --default-backend-service={{ if .Values.defaultBackend.enabled }}{{ .Release.Namespace }}/{{ template "nginx-ingress.defaultBackend.fullname" . }}{{ else }}{{ .Values.controller.defaultBackendService }}{{ end }}
+          {{- if and (contains "0.9" .Values.controller.image.tag) .Values.controller.publishService.enabled }}
+            - --publish-service={{ template "nginx-ingress.controller.publishServicePath" . }}
+          {{- end }}
+          {{- if (contains "0.9" .Values.controller.image.tag) }}
+            - --election-id={{ .Values.controller.electionID }}
+          {{- end }}
+          {{- if (contains "0.9" .Values.controller.image.tag) }}
+            - --ingress-class={{ .Values.controller.ingressClass }}
+          {{- end }}
+          {{- if (contains "0.9" .Values.controller.image.tag) }}
+            - --configmap={{ .Release.Namespace }}/{{ template "nginx-ingress.controller.fullname" . }}
+          {{- else }}
+            - --nginx-configmap={{ .Release.Namespace }}/{{ template "nginx-ingress.controller.fullname" . }}
+          {{- end }}
+          {{- if .Values.tcp }}
+            - --tcp-services-configmap={{ .Release.Namespace }}/{{ template "nginx-ingress.fullname" . }}-tcp
+          {{- end }}
+          {{- if .Values.udp }}
+            - --udp-services-configmap={{ .Release.Namespace }}/{{ template "nginx-ingress.fullname" . }}-udp
+          {{- end }}
+          {{- if .Values.controller.scope.enabled }}
+            - --watch-namespace={{ default .Release.Namespace .Values.controller.scope.namespace }}
+          {{- end }}
           {{- range $key, $value := .Values.controller.extraArgs }}
+            {{- if $value }}
             - --{{ $key }}={{ $value }}
+            {{- else }}
+            - --{{ $key }}
+            {{- end }}
           {{- end }}
           env:
             - name: POD_NAME
@@ -48,6 +80,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          {{- range $key, $value := .Values.controller.extraEnvs }}
+            - name: {{ $key | upper | replace "." "_" }}
+              value: {{ $value }}
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz
@@ -59,11 +95,11 @@ spec:
             - name: http
               containerPort: 80
               protocol: TCP
-            - name: httpredirect
-              containerPort: 8000
-              protocol: TCP
             - name: https
               containerPort: 443
+              protocol: TCP
+            - name: httpredirect
+              containerPort: 8000
               protocol: TCP
           {{- if .Values.controller.stats.enabled }}
             - name: stats
@@ -85,14 +121,16 @@ spec:
               path: /healthz
               port: 10254
               scheme: HTTP
+{{- if .Values.controller.customTemplate.configMapName }}
           volumeMounts:
-          - name: nginxtmpl
-            mountPath: /etc/nginx/template
+            - mountPath: /etc/nginx/template
+              name: nginx-template-volume
+              readOnly: true
+{{- end }}
           resources:
 {{ toYaml .Values.controller.resources | indent 12 }}
-
       {{- if .Values.controller.stats.enabled }}
-        - name: {{ template "name" . }}-{{ .Values.statsExporter.name }}
+        - name: {{ template "nginx-ingress.name" . }}-{{ .Values.statsExporter.name }}
           image: "{{ .Values.statsExporter.image.repository }}:{{ .Values.statsExporter.image.tag }}"
           imagePullPolicy: "{{ .Values.statsExporter.image.pullPolicy }}"
           env:
@@ -111,17 +149,24 @@ spec:
           resources:
 {{ toYaml .Values.statsExporter.resources | indent 12 }}
       {{- end }}
+      hostNetwork: {{ .Values.controller.hostNetwork }}
     {{- if .Values.controller.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.controller.nodeSelector | indent 8 }}
     {{- end }}
+    {{- if .Values.controller.tolerations }}
+      tolerations:
+{{ toYaml .Values.controller.tolerations | indent 8 }}
+    {{- end }}
+      serviceAccountName: {{ if .Values.rbac.create }}{{ template "nginx-ingress.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
       terminationGracePeriodSeconds: 60
-
+{{- if .Values.controller.customTemplate.configMapName }}
       volumes:
-        - name: nginxtmpl
+        - name: nginx-template-volume
           configMap:
-            name: {{ template "fullname" . }}-nginxconf
+            name: {{ .Values.controller.customTemplate.configMapName }}
             items:
-            - key: nginx.tmpl
+            - key: {{ .Values.controller.customTemplate.configMapKey }}
               path: nginx.tmpl
+{{- end }}
 {{- end }}

--- a/charts/nginx-ingress/templates/controller-hpa.yaml
+++ b/charts/nginx-ingress/templates/controller-hpa.yaml
@@ -1,0 +1,26 @@
+{{- if eq .Values.controller.kind "Deployment" }}
+{{- if .Values.controller.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  labels:
+    app: {{ template "nginx-ingress.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: "{{ .Values.controller.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "nginx-ingress.controller.fullname" . }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1beta1
+    kind: Deployment
+    name: {{ template "nginx-ingress.controller.fullname" . }}
+  minReplicas: {{ .Values.controller.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.controller.autoscaling.maxReplicas }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      targetAverageUtilization: {{ .Values.controller.autoscaling.targetAverageUtilization }}
+{{- end }}
+{{- end }}

--- a/charts/nginx-ingress/templates/controller-metrics-service.yaml
+++ b/charts/nginx-ingress/templates/controller-metrics-service.yaml
@@ -7,12 +7,12 @@ metadata:
 {{ toYaml .Values.statsExporter.service.annotations | indent 4 }}
 {{- end }}
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "nginx-ingress.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "controller.fullname" . }}-metrics
+  name: {{ template "nginx-ingress.controller.fullname" . }}-metrics
 spec:
   clusterIP: "{{ .Values.statsExporter.service.clusterIP }}"
 {{- if .Values.statsExporter.service.externalIPs }}
@@ -29,9 +29,9 @@ spec:
   ports:
     - name: metrics
       port: {{ .Values.statsExporter.service.servicePort }}
-      targetPort: 9913
+      targetPort: {{ .Values.statsExporter.service.targetPort }}
   selector:
-    app: {{ template "name" . }}
+    app: {{ template "nginx-ingress.name" . }}
     component: "{{ .Values.controller.name }}"
     release: {{ .Release.Name }}
   type: "{{ .Values.statsExporter.service.type }}"

--- a/charts/nginx-ingress/templates/controller-service.yaml
+++ b/charts/nginx-ingress/templates/controller-service.yaml
@@ -3,18 +3,15 @@ kind: Service
 metadata:
 {{- if .Values.controller.service.annotations }}
   annotations:
-{{ toYaml .Values.controller.service.annotations | indent 4}}
-{{- if .Values.controller.service.SSLARN }}
-    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: "{{ .Values.controller.service.SSLARN }}"
-{{- end }}
+{{ toYaml .Values.controller.service.annotations | indent 4 }}
 {{- end }}
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "nginx-ingress.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "controller.fullname" . }}
+  name: {{ template "nginx-ingress.controller.fullname" . }}
 spec:
   clusterIP: "{{ .Values.controller.service.clusterIP }}"
 {{- if .Values.controller.service.externalIPs }}
@@ -28,18 +25,27 @@ spec:
   loadBalancerSourceRanges:
 {{ toYaml .Values.controller.service.loadBalancerSourceRanges | indent 4 }}
 {{- end }}
+{{- if and (ge .Capabilities.KubeVersion.Minor "7") (.Values.controller.service.externalTrafficPolicy) }}
+  externalTrafficPolicy: "{{ .Values.controller.service.externalTrafficPolicy }}"
+{{- end }}
+{{- if and (ge .Capabilities.KubeVersion.Minor "7") (.Values.controller.service.healthCheckNodePort) }}
+  healthCheckNodePort: {{ .Values.controller.service.healthCheckNodePort }}
+{{- end }}
   ports:
-    # HTTP directed to nginx server{} block that redirects everything to HTTPS
     - name: http
       port: 80
       protocol: TCP
-      targetPort: 8000
-
-    # HTTPS directed to nginx port 80, as ELB terminates TLS and proxies as HTTP
+      targetPort: {{ .Values.controller.service.targetPorts.http }}
+      {{- if (and (eq .Values.controller.service.type "NodePort") (not (empty .Values.controller.service.nodePorts.http))) }}
+      nodePort: {{ .Values.controller.service.nodePorts.http }}
+      {{- end }}
     - name: https
       port: 443
       protocol: TCP
-      targetPort: 80
+      targetPort: {{ .Values.controller.service.targetPorts.https }}
+      {{- if (and (eq .Values.controller.service.type "NodePort") (not (empty .Values.controller.service.nodePorts.https))) }}
+      nodePort: {{ .Values.controller.service.nodePorts.https }}
+      {{- end }}
   {{- range $key, $value := .Values.tcp }}
     - name: "{{ $key }}-tcp"
       port: {{ $key }}
@@ -53,7 +59,7 @@ spec:
       targetPort: {{ $key }}
   {{- end }}
   selector:
-    app: {{ template "name" . }}
+    app: {{ template "nginx-ingress.name" . }}
     component: "{{ .Values.controller.name }}"
     release: {{ .Release.Name }}
   type: "{{ .Values.controller.service.type }}"

--- a/charts/nginx-ingress/templates/controller-stats-service.yaml
+++ b/charts/nginx-ingress/templates/controller-stats-service.yaml
@@ -7,12 +7,12 @@ metadata:
 {{ toYaml .Values.controller.stats.service.annotations | indent 4 }}
 {{- end }}
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "nginx-ingress.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "controller.fullname" . }}-stats
+  name: {{ template "nginx-ingress.controller.fullname" . }}-stats
 spec:
   clusterIP: "{{ .Values.controller.stats.service.clusterIP }}"
 {{- if .Values.controller.stats.service.externalIPs }}
@@ -31,7 +31,7 @@ spec:
       port: {{ .Values.controller.stats.service.servicePort }}
       targetPort: 18080
   selector:
-    app: {{ template "name" . }}
+    app: {{ template "nginx-ingress.name" . }}
     component: "{{ .Values.controller.name }}"
     release: {{ .Release.Name }}
   type: "{{ .Values.controller.stats.service.type }}"

--- a/charts/nginx-ingress/templates/default-backend-deployment.yaml
+++ b/charts/nginx-ingress/templates/default-backend-deployment.yaml
@@ -3,32 +3,40 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "nginx-ingress.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     component: "{{ .Values.defaultBackend.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "defaultBackend.fullname" . }}
+  name: {{ template "nginx-ingress.defaultBackend.fullname" . }}
 spec:
   replicas: {{ .Values.defaultBackend.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   template:
     metadata:
     {{- if .Values.defaultBackend.podAnnotations }}
       annotations:
-{{ toYaml .Values.defaultBackend.podAnnotations | indent 8}}
+{{ toYaml .Values.defaultBackend.podAnnotations | indent 8 }}
     {{- end }}
       labels:
-        app: {{ template "name" . }}
+        app: {{ template "nginx-ingress.name" . }}
         component: "{{ .Values.defaultBackend.name }}"
         release: {{ .Release.Name }}
+        {{- if .Values.defaultBackend.podLabels }}
+{{ toYaml .Values.defaultBackend.podLabels | indent 8 }}
+        {{- end }}
     spec:
       containers:
-        - name: {{ template "name" . }}-{{ .Values.defaultBackend.name }}
+        - name: {{ template "nginx-ingress.name" . }}-{{ .Values.defaultBackend.name }}
           image: "{{ .Values.defaultBackend.image.repository }}:{{ .Values.defaultBackend.image.tag }}"
           imagePullPolicy: "{{ .Values.defaultBackend.image.pullPolicy }}"
           args:
           {{- range $key, $value := .Values.defaultBackend.extraArgs }}
+            {{- if $value }}
             - --{{ $key }}={{ $value }}
+            {{- else }}
+            - --{{ $key }}
+            {{- end }}
           {{- end }}
           livenessProbe:
             httpGet:
@@ -45,6 +53,10 @@ spec:
     {{- if .Values.defaultBackend.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.defaultBackend.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- if .Values.defaultBackend.tolerations }}
+      tolerations:
+{{ toYaml .Values.defaultBackend.tolerations | indent 8 }}
     {{- end }}
       terminationGracePeriodSeconds: 60
 {{- end }}

--- a/charts/nginx-ingress/templates/default-backend-service.yaml
+++ b/charts/nginx-ingress/templates/default-backend-service.yaml
@@ -7,12 +7,12 @@ metadata:
 {{ toYaml .Values.defaultBackend.service.annotations | indent 4 }}
 {{- end }}
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "nginx-ingress.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     component: "{{ .Values.defaultBackend.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "defaultBackend.fullname" . }}
+  name: {{ template "nginx-ingress.defaultBackend.fullname" . }}
 spec:
   clusterIP: "{{ .Values.defaultBackend.service.clusterIP }}"
 {{- if .Values.defaultBackend.service.externalIPs }}
@@ -30,8 +30,8 @@ spec:
     - port: {{ .Values.defaultBackend.service.servicePort }}
       targetPort: 8080
   selector:
-    app: {{ template "name" . }}
+    app: {{ template "nginx-ingress.name" . }}
     component: "{{ .Values.defaultBackend.name }}"
     release: {{ .Release.Name }}
-  type: ClusterIP
+  type: "{{ .Values.defaultBackend.service.type }}"
 {{- end }}

--- a/charts/nginx-ingress/templates/headers-configmap.yaml
+++ b/charts/nginx-ingress/templates/headers-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.udp }}
+{{- if .Values.controller.headers }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -8,7 +8,7 @@ metadata:
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "nginx-ingress.fullname" . }}-udp
+  name: {{ template "nginx-ingress.fullname" . }}-custom-headers
 data:
-{{ toYaml .Values.udp | indent 2 }}
+{{ toYaml .Values.controller.headers | indent 2 }}
 {{- end }}

--- a/charts/nginx-ingress/templates/role.yaml
+++ b/charts/nginx-ingress/templates/role.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  labels:
+    app: {{ template "nginx-ingress.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "nginx-ingress.fullname" . }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - namespaces
+      - pods
+      - secrets
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    resourceNames:
+      - {{ .Values.controller.electionID }}-{{ .Values.controller.ingressClass }}
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+    verbs:
+      - create
+      - get
+      - update
+{{- end -}}

--- a/charts/nginx-ingress/templates/rolebinding.yaml
+++ b/charts/nginx-ingress/templates/rolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  labels:
+    app: {{ template "nginx-ingress.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "nginx-ingress.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "nginx-ingress.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "nginx-ingress.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/charts/nginx-ingress/templates/serviceaccount.yaml
+++ b/charts/nginx-ingress/templates/serviceaccount.yaml
@@ -1,14 +1,11 @@
-{{- if .Values.udp }}
+{{- if .Values.rbac.create -}}
 apiVersion: v1
-kind: ConfigMap
+kind: ServiceAccount
 metadata:
   labels:
     app: {{ template "nginx-ingress.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "nginx-ingress.fullname" . }}-udp
-data:
-{{ toYaml .Values.udp | indent 2 }}
-{{- end }}
+  name: {{ template "nginx-ingress.fullname" . }}
+{{- end -}}

--- a/charts/nginx-ingress/templates/tcp-configmap.yaml
+++ b/charts/nginx-ingress/templates/tcp-configmap.yaml
@@ -3,14 +3,12 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "nginx-ingress.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "fullname" . }}-tcp
+  name: {{ template "nginx-ingress.fullname" . }}-tcp
 data:
-{{- if .Values.tcp }}
 {{ toYaml .Values.tcp | indent 2 }}
-{{- end }}
 {{- end }}

--- a/charts/nginx-ingress/values.yaml
+++ b/charts/nginx-ingress/values.yaml
@@ -4,28 +4,89 @@
 controller:
   name: controller
   image:
-    repository: gcr.io/google_containers/nginx-ingress-controller
-    tag: "0.8.3"
+    repository: k8s.gcr.io/nginx-ingress-controller
+    tag: "0.9.0-beta.15"
     pullPolicy: IfNotPresent
 
-  config:
-    use-proxy-protocol: "true"
-    enable-sticky-sessions: "true"
-    server-name-hash-bucket-size: "128"
-    proxy-read-timeout: "3600"
-    proxy-send-timeout: "3600"
-    body-size: 100m
+  config: {}
+  # Will add custom header to Nginx https://github.com/kubernetes/ingress-nginx/tree/master/docs/examples/customization/custom-headers
+  headers: {}
+
+  # Required for use with CNI based kubernetes installations (such as ones set up by kubeadm),
+  # since CNI and hostport don't mix yet. Can be deprecated once https://github.com/kubernetes/kubernetes/issues/23920
+  # is merged
+  hostNetwork: false
+
+  ## Use host ports 80 and 443
+  daemonset:
+    useHostPort: false
 
   ## Required only if defaultBackend.enabled = false
   ## Must be <namespace>/<service_name>
   ##
   defaultBackendService: ""
 
+  ## Election ID to use for status update
+  ##
+  electionID: ingress-controller-leader
+
+  ## Name of the ingress class to route through this controller
+  ##
+  ingressClass: nginx
+
+  # labels to add to the pod container metadata
+  podLabels: {}
+  #  key: value
+
+  ## Allows customization of the external service
+  ## the ingress will be bound to via DNS
+  publishService:
+    enabled: false
+    ## Allows overriding of the publish service to bind to
+    ## Must be <namespace>/<service_name>
+    ##
+    pathOverride: ""
+
+  ## Limit the scope of the controller
+  ##
+  scope:
+    enabled: false
+    namespace: ""   # defaults to .Release.Namespace
+
+  ## Additional command line arguments to pass to nginx-ingress-controller
+  ## E.g. to specify the default SSL certificate you can use
+  ## extraArgs:
+  ##   default-ssl-certificate: "<namespace>/<secret_name>"
   extraArgs: {}
+
+  ## Additional environment variables to set
+  ##
+  extraEnvs: {}
 
   ## DaemonSet or Deployment
   ##
   kind: Deployment
+
+  # The update strategy to apply to the Deployment or DaemonSet
+  ##
+  updateStrategy: {}
+  #  rollingUpdate:
+  #    maxUnavailable: 1
+  #  type: RollingUpdate
+
+  # minReadySeconds to avoid killing pods before we are ready
+  ##
+  minReadySeconds: 0
+
+
+  ## Node tolerations for server scheduling to nodes with taints
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  ##
+  tolerations: []
+  #  - key: "key"
+  #    operator: "Equal|Exists"
+  #    value: "value"
+  #    effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
 
   ## Node labels for controller pod assignment
   ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
@@ -39,20 +100,926 @@ controller:
   replicaCount: 1
 
   resources: {}
-    # limits:
-    #   cpu: 100m
-    #   memory: 64Mi
-    # requests:
-    #   cpu: 100m
-    #   memory: 64Mi
+  #  limits:
+  #    cpu: 100m
+  #    memory: 64Mi
+  #  requests:
+  #    cpu: 100m
+  #    memory: 64Mi
+
+  autoscaling:
+    enabled: false
+  #  minReplicas: 1
+  #  maxReplicas: 11
+  #  targetAverageUtilization: 50
+
+  ## Override NGINX template
+  customTemplate:
+    configMapName: "nginx-ingress-customconfig"
+    configMapKey: "template"
+    template: |-
+      {{ $all := . }}
+      {{ $servers := .Servers }}
+      {{ $cfg := .Cfg }}
+      {{ $IsIPV6Enabled := .IsIPV6Enabled }}
+      {{ $healthzURI := .HealthzURI }}
+      {{ $backends := .Backends }}
+      {{ $proxyHeaders := .ProxySetHeaders }}
+      {{ $addHeaders := .AddHeaders }}
+
+      {{ if $cfg.EnableModsecurity }}
+      load_module /etc/nginx/modules/ngx_http_modsecurity_module.so;
+      {{ end }}
+
+      {{ if $cfg.EnableOpentracing }}
+      load_module /etc/nginx/modules/ngx_http_opentracing_module.so;
+      {{ end }}
+
+      {{ if (and $cfg.EnableOpentracing (ne $cfg.ZipkinCollectorHost "")) }}
+      load_module /etc/nginx/modules/ngx_http_zipkin_module.so;
+      {{ end }}
+
+      daemon off;
+
+      worker_processes {{ $cfg.WorkerProcesses }};
+      pid /run/nginx.pid;
+      {{ if ne .MaxOpenFiles 0 }}
+      worker_rlimit_nofile {{ .MaxOpenFiles }};
+      {{ end}}
+
+      {{/* http://nginx.org/en/docs/ngx_core_module.html#worker_shutdown_timeout */}}
+      {{/* avoid waiting too long during a reload */}}
+      worker_shutdown_timeout {{ $cfg.WorkerShutdownTimeout }} ;
+
+      events {
+          multi_accept        on;
+          worker_connections  {{ $cfg.MaxWorkerConnections }};
+          use                 epoll;
+      }
+
+      http {
+          {{/* we use the value of the header X-Forwarded-For to be able to use the geo_ip module */}}
+          {{ if $cfg.UseProxyProtocol }}
+          real_ip_header      proxy_protocol;
+          {{ else }}
+          real_ip_header      {{ $cfg.ForwardedForHeader }};
+          {{ end }}
+
+          real_ip_recursive   on;
+          {{ range $trusted_ip := $cfg.ProxyRealIPCIDR }}
+          set_real_ip_from    {{ $trusted_ip }};
+          {{ end }}
+
+          {{/* databases used to determine the country depending on the client IP address */}}
+          {{/* http://nginx.org/en/docs/http/ngx_http_geoip_module.html */}}
+          {{/* this is require to calculate traffic for individual country using GeoIP in the status page */}}
+          geoip_country       /etc/nginx/GeoIP.dat;
+          geoip_city          /etc/nginx/GeoLiteCity.dat;
+          geoip_proxy_recursive on;
+
+          {{ if $cfg.EnableVtsStatus }}
+          vhost_traffic_status_zone shared:vhost_traffic_status:{{ $cfg.VtsStatusZoneSize }};
+          vhost_traffic_status_filter_by_set_key {{ $cfg.VtsDefaultFilterKey }};
+          {{ end }}
+
+          sendfile            on;
+
+          aio                 threads;
+          aio_write           on;
+
+          tcp_nopush          on;
+          tcp_nodelay         on;
+
+          log_subrequest      on;
+
+          reset_timedout_connection on;
+
+          keepalive_timeout  {{ $cfg.KeepAlive }}s;
+          keepalive_requests {{ $cfg.KeepAliveRequests }};
+
+          client_header_buffer_size       {{ $cfg.ClientHeaderBufferSize }};
+          client_header_timeout           {{ $cfg.ClientHeaderTimeout }}s;
+          large_client_header_buffers     {{ $cfg.LargeClientHeaderBuffers }};
+          client_body_buffer_size         {{ $cfg.ClientBodyBufferSize }};
+          client_body_timeout             {{ $cfg.ClientBodyTimeout }}s;
+
+          http2_max_field_size            {{ $cfg.HTTP2MaxFieldSize }};
+          http2_max_header_size           {{ $cfg.HTTP2MaxHeaderSize }};
+
+          types_hash_max_size             2048;
+          server_names_hash_max_size      {{ $cfg.ServerNameHashMaxSize }};
+          server_names_hash_bucket_size   {{ $cfg.ServerNameHashBucketSize }};
+          map_hash_bucket_size            {{ $cfg.MapHashBucketSize }};
+
+          proxy_headers_hash_max_size     {{ $cfg.ProxyHeadersHashMaxSize }};
+          proxy_headers_hash_bucket_size  {{ $cfg.ProxyHeadersHashBucketSize }};
+
+          variables_hash_bucket_size      {{ $cfg.VariablesHashBucketSize }};
+          variables_hash_max_size         {{ $cfg.VariablesHashMaxSize }};
+
+          underscores_in_headers          {{ if $cfg.EnableUnderscoresInHeaders }}on{{ else }}off{{ end }};
+          ignore_invalid_headers          {{ if $cfg.IgnoreInvalidHeaders }}on{{ else }}off{{ end }};
+
+          {{ if $cfg.EnableOpentracing }}
+          opentracing on;
+          {{ end }}
+
+          {{ if (and $cfg.EnableOpentracing (ne $cfg.ZipkinCollectorHost "")) }}
+          zipkin_collector_host           {{ $cfg.ZipkinCollectorHost }};
+          zipkin_collector_port           {{ $cfg.ZipkinCollectorPort }};
+          zipkin_service_name             {{ $cfg.ZipkinServiceName }};
+          {{ end }}
+
+          include /etc/nginx/mime.types;
+          default_type text/html;
+
+          {{ if $cfg.EnableBrotli }}
+          brotli on;
+          brotli_comp_level {{ $cfg.BrotliLevel }};
+          brotli_types {{ $cfg.BrotliTypes }};
+          {{ end }}
+
+          {{ if $cfg.UseGzip }}
+          gzip on;
+          gzip_comp_level 5;
+          gzip_http_version 1.1;
+          gzip_min_length 256;
+          gzip_types {{ $cfg.GzipTypes }};
+          gzip_proxied any;
+          gzip_vary on;
+          {{ end }}
+
+          # Custom headers for response
+          {{ range $k, $v := $addHeaders }}
+          add_header {{ $k }}            "{{ $v }}";
+          {{ end }}
+
+          server_tokens {{ if $cfg.ShowServerTokens }}on{{ else }}off{{ end }};
+
+          # disable warnings
+          uninitialized_variable_warn off;
+
+          # Additional available variables:
+          # $namespace
+          # $ingress_name
+          # $service_name
+          log_format upstreaminfo {{ if $cfg.LogFormatEscapeJSON }}escape=json {{ end }}'{{ buildLogFormatUpstream $cfg }}';
+
+          {{/* map urls that should not appear in access.log */}}
+          {{/* http://nginx.org/en/docs/http/ngx_http_log_module.html#access_log */}}
+          map $request_uri $loggable {
+              {{ range $reqUri := $cfg.SkipAccessLogURLs }}
+              {{ $reqUri }} 0;{{ end }}
+              default 1;
+          }
+
+          {{ if $cfg.DisableAccessLog }}
+          access_log off;
+          {{ else }}
+          access_log {{ $cfg.AccessLogPath }} upstreaminfo if=$loggable;
+          {{ end }}
+          error_log  {{ $cfg.ErrorLogPath }} {{ $cfg.ErrorLogLevel }};
+
+          {{ buildResolvers $cfg.Resolver }}
+
+          {{/* Whenever nginx proxies a request without a "Connection" header, the "Connection" header is set to "close" */}}
+          {{/* when making the target request.  This means that you cannot simply use */}}
+          {{/* "proxy_set_header Connection $http_connection" for WebSocket support because in this case, the */}}
+          {{/* "Connection" header would be set to "" whenever the original request did not have a "Connection" header, */}}
+          {{/* which would mean no "Connection" header would be in the target request.  Since this would deviate from */}}
+          {{/* normal nginx behavior we have to use this approach. */}}
+          # Retain the default nginx handling of requests without a "Connection" header
+          map $http_upgrade $connection_upgrade {
+              default          upgrade;
+              ''               close;
+          }
+
+          map {{ buildForwardedFor $cfg.ForwardedForHeader }} $the_real_ip {
+          {{ if $cfg.UseProxyProtocol }}
+              # Get IP address from Proxy Protocol
+              default          $proxy_protocol_addr;
+          {{ else }}
+              default          $remote_addr;
+          {{ end }}
+          }
+
+          # trust http_x_forwarded_proto headers correctly indicate ssl offloading
+          map $http_x_forwarded_proto $pass_access_scheme {
+              default          $http_x_forwarded_proto;
+              ''               $scheme;
+          }
+
+          map $http_x_forwarded_port $pass_server_port {
+              default           $http_x_forwarded_port;
+              ''                $server_port;
+          }
+
+          map $http_x_forwarded_host $best_http_host {
+              default          $http_x_forwarded_host;
+              ''               $this_host;
+          }
+
+          {{ if $all.IsSSLPassthroughEnabled }}
+          # map port {{ $all.ListenPorts.SSLProxy }} to 443 for header X-Forwarded-Port
+          map $pass_server_port $pass_port {
+              {{ $all.ListenPorts.SSLProxy }}              443;
+              default          $pass_server_port;
+          }
+          {{ else }}
+          map $pass_server_port $pass_port {
+              443              443;
+              default          $pass_server_port;
+          }
+          {{ end }}
+
+          # Obtain best http host
+          map $http_host $this_host {
+              default          $http_host;
+              ''               $host;
+          }
+
+          {{ if $cfg.ComputeFullForwardedFor }}
+          # We can't use $proxy_add_x_forwarded_for because the realip module
+          # replaces the remote_addr too soon
+          map $http_x_forwarded_for $full_x_forwarded_for {
+              {{ if $all.Cfg.UseProxyProtocol }}
+              default          "$http_x_forwarded_for, $proxy_protocol_addr";
+              ''               "$proxy_protocol_addr";
+              {{ else }}
+              default          "$http_x_forwarded_for, $realip_remote_addr";
+              ''               "$realip_remote_addr";
+              {{ end}}
+          }
+          {{ end }}
+
+          server_name_in_redirect off;
+          port_in_redirect        off;
+
+          ssl_protocols {{ $cfg.SSLProtocols }};
+
+          # turn on session caching to drastically improve performance
+          {{ if $cfg.SSLSessionCache }}
+          ssl_session_cache builtin:1000 shared:SSL:{{ $cfg.SSLSessionCacheSize }};
+          ssl_session_timeout {{ $cfg.SSLSessionTimeout }};
+          {{ end }}
+
+          # allow configuring ssl session tickets
+          ssl_session_tickets {{ if $cfg.SSLSessionTickets }}on{{ else }}off{{ end }};
+
+          {{ if not (empty $cfg.SSLSessionTicketKey ) }}
+          ssl_session_ticket_key /etc/nginx/tickets.key;
+          {{ end }}
+
+          # slightly reduce the time-to-first-byte
+          ssl_buffer_size {{ $cfg.SSLBufferSize }};
+
+          {{ if not (empty $cfg.SSLCiphers) }}
+          # allow configuring custom ssl ciphers
+          ssl_ciphers '{{ $cfg.SSLCiphers }}';
+          ssl_prefer_server_ciphers on;
+          {{ end }}
+
+          {{ if not (empty $cfg.SSLDHParam) }}
+          # allow custom DH file http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_dhparam
+          ssl_dhparam {{ $cfg.SSLDHParam }};
+          {{ end }}
+
+          {{ if not $cfg.EnableDynamicTLSRecords }}
+          ssl_dyn_rec_size_lo 0;
+          {{ end }}
+
+          ssl_ecdh_curve {{ $cfg.SSLECDHCurve }};
+
+          {{ if .CustomErrors }}
+          # Custom error pages
+          proxy_intercept_errors on;
+          {{ end }}
+
+          {{ range $errCode := $cfg.CustomHTTPErrors }}
+          error_page {{ $errCode }} = @custom_{{ $errCode }};{{ end }}
+
+          proxy_ssl_session_reuse on;
+
+          {{ if $cfg.AllowBackendServerHeader }}
+          proxy_pass_header Server;
+          {{ end }}
+
+          {{ if not (empty $cfg.HTTPSnippet) }}
+          # Custom code snippet configured in the configuration configmap
+          {{ $cfg.HTTPSnippet }}
+          {{ end }}
+
+          {{ range $name, $upstream := $backends }}
+          {{ if eq $upstream.SessionAffinity.AffinityType "cookie" }}
+          upstream sticky-{{ $upstream.Name }} {
+              sticky hash={{ $upstream.SessionAffinity.CookieSessionAffinity.Hash }} name={{ $upstream.SessionAffinity.CookieSessionAffinity.Name }}  httponly;
+
+              {{ if (gt $cfg.UpstreamKeepaliveConnections 0) }}
+              keepalive {{ $cfg.UpstreamKeepaliveConnections }};
+              {{ end }}
+
+              {{ range $server := $upstream.Endpoints }}server {{ $server.Address | formatIP }}:{{ $server.Port }} max_fails={{ $server.MaxFails }} fail_timeout={{ $server.FailTimeout }};
+              {{ end }}
+
+          }
+
+          {{ end }}
+
+
+          upstream {{ $upstream.Name }} {
+              # Load balance algorithm; empty for round robin, which is the default
+              {{ if ne $cfg.LoadBalanceAlgorithm "round_robin" }}
+              {{ $cfg.LoadBalanceAlgorithm }};
+              {{ end }}
+
+              {{ if $upstream.UpstreamHashBy }}
+              hash {{ $upstream.UpstreamHashBy }} consistent;
+              {{ end }}
+
+              {{ if (gt $cfg.UpstreamKeepaliveConnections 0) }}
+              keepalive {{ $cfg.UpstreamKeepaliveConnections }};
+              {{ end }}
+
+              {{ range $server := $upstream.Endpoints }}server {{ $server.Address | formatIP }}:{{ $server.Port }} max_fails={{ $server.MaxFails }} fail_timeout={{ $server.FailTimeout }};
+              {{ end }}
+          }
+
+          {{ end }}
+
+          {{/* build the maps that will be use to validate the Whitelist */}}
+          {{ range $index, $server := $servers }}
+          {{ range $location := $server.Locations }}
+          {{ $path := buildLocation $location }}
+
+          {{ if isLocationAllowed $location }}
+          {{ if gt (len $location.Whitelist.CIDR) 0 }}
+
+          # Deny for {{ print $server.Hostname  $path }}
+          geo $the_real_ip {{ buildDenyVariable (print $server.Hostname "_"  $path) }} {
+              default 1;
+
+              {{ range $ip := $location.Whitelist.CIDR }}
+              {{ $ip }} 0;{{ end }}
+          }
+          {{ end }}
+          {{ end }}
+          {{ end }}
+          {{ end }}
+
+          {{ range $rl := (filterRateLimits $servers ) }}
+          # Ratelimit {{ $rl.Name }}
+          geo $the_real_ip $whitelist_{{ $rl.ID }} {
+              default 0;
+              {{ range $ip := $rl.Whitelist }}
+              {{ $ip }} 1;{{ end }}
+          }
+
+          # Ratelimit {{ $rl.Name }}
+          map $whitelist_{{ $rl.ID }} $limit_{{ $rl.ID }} {
+              0 {{ $cfg.LimitConnZoneVariable }};
+              1 "";
+          }
+          {{ end }}
+
+          {{/* build all the required rate limit zones. Each annotation requires a dedicated zone */}}
+          {{/* 1MB -> 16 thousand 64-byte states or about 8 thousand 128-byte states */}}
+          {{ range $zone := (buildRateLimitZones $servers) }}
+          {{ $zone }}
+          {{ end }}
+
+          {{/* Build server redirects (from/to www) */}}
+          {{ range $hostname, $to := .RedirectServers }}
+          server {
+              {{ range $address := $all.Cfg.BindAddressIpv4 }}
+              listen {{ $address }}:{{ $all.ListenPorts.HTTP }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }};
+              listen {{ $address }}:{{ if $all.IsSSLPassthroughEnabled }}{{ $all.ListenPorts.SSLProxy }} proxy_protocol{{ else }}{{ $all.ListenPorts.HTTPS }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }}{{ end }} ssl;
+              {{ else }}
+              listen {{ $all.ListenPorts.HTTP }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }};
+              listen {{ if $all.IsSSLPassthroughEnabled }}{{ $all.ListenPorts.SSLProxy }} proxy_protocol{{ else }}{{ $all.ListenPorts.HTTPS }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }}{{ end }} ssl;
+              {{ end }}
+              {{ if $IsIPV6Enabled }}
+              {{ range $address := $all.Cfg.BindAddressIpv6 }}
+              listen {{ $address }}:{{ $all.ListenPorts.HTTP }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }};
+              listen {{ $address }}:{{ if $all.IsSSLPassthroughEnabled }}{{ $all.ListenPorts.SSLProxy }} proxy_protocol{{ else }}{{ $all.ListenPorts.HTTPS }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }}{{ end }};
+              {{ else }}
+              listen [::]:{{ $all.ListenPorts.HTTP }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }};
+              listen [::]:{{ if $all.IsSSLPassthroughEnabled }}{{ $all.ListenPorts.SSLProxy }} proxy_protocol{{ else }}{{ $all.ListenPorts.HTTPS }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }}{{ end }};
+              {{ end }}
+              {{ end }}
+              server_name {{ $hostname }};
+
+              {{ if ne $all.ListenPorts.HTTPS 443 }}
+              {{ $redirect_port := (printf ":%v" $all.ListenPorts.HTTPS) }}
+              return {{ $all.Cfg.HTTPRedirectCode }} $scheme://{{ $to }}{{ $redirect_port }}$request_uri;
+              {{ else }}
+              return {{ $all.Cfg.HTTPRedirectCode }} $scheme://{{ $to }}$request_uri;
+              {{ end }}
+          }
+          {{ end }}
+
+          {{/* Handles HTTP traffic from ELB and redirects to HTTPS */}}
+          server {
+             listen 8000 proxy_protocol;
+             server_tokens off;
+             return 301 https://$host$request_uri;
+          }
+
+          {{ range $index, $server := $servers }}
+
+          ## start server {{ $server.Hostname }}
+          server {
+              server_name {{ $server.Hostname }} {{ $server.Alias }};
+              {{ template "SERVER" serverConfig $all $server }}
+
+              {{ if not (empty $cfg.ServerSnippet) }}
+              # Custom code snippet configured in the configuration configmap
+              {{ $cfg.ServerSnippet }}
+              {{ end }}
+
+              {{ template "CUSTOM_ERRORS" $all }}
+          }
+          ## end server {{ $server.Hostname }}
+
+          {{ end }}
+
+          # default server, used for NGINX healthcheck and access to nginx stats
+          server {
+              # Use the port {{ $all.ListenPorts.Status }} (random value just to avoid known ports) as default port for nginx.
+              # Changing this value requires a change in:
+              # https://github.com/kubernetes/ingress-nginx/blob/master/controllers/nginx/pkg/cmd/controller/nginx.go
+              listen {{ $all.ListenPorts.Status }} default_server reuseport backlog={{ $all.BacklogSize }};
+              {{ if $IsIPV6Enabled }}listen [::]:{{ $all.ListenPorts.Status }} default_server reuseport backlog={{ $all.BacklogSize }};{{ end }}
+              set $proxy_upstream_name "-";
+
+              location {{ $healthzURI }} {
+                  access_log off;
+                  return 200;
+              }
+
+              location /nginx_status {
+                  set $proxy_upstream_name "internal";
+
+                  {{ if $cfg.EnableVtsStatus }}
+                  vhost_traffic_status_display;
+                  vhost_traffic_status_display_format html;
+                  {{ else }}
+                  access_log off;
+                  stub_status on;
+                  {{ end }}
+              }
+
+              location / {
+                  {{ if .CustomErrors }}
+                  proxy_set_header    X-Code 404;
+                  {{ end }}
+                  set $proxy_upstream_name "upstream-default-backend";
+                  proxy_pass          http://upstream-default-backend;
+              }
+
+              {{ template "CUSTOM_ERRORS" $all }}
+          }
+      }
+
+      stream {
+          log_format log_stream {{ $cfg.LogFormatStream }};
+
+          {{ if $cfg.DisableAccessLog }}
+          access_log off;
+          {{ else }}
+          access_log {{ $cfg.AccessLogPath }} log_stream;
+          {{ end }}
+
+          error_log  {{ $cfg.ErrorLogPath }};
+
+          # TCP services
+          {{ range $i, $tcpServer := .TCPBackends }}
+          upstream tcp-{{ $tcpServer.Port }}-{{ $tcpServer.Backend.Namespace }}-{{ $tcpServer.Backend.Name }}-{{ $tcpServer.Backend.Port }} {
+          {{ range $j, $endpoint := $tcpServer.Endpoints }}
+              server                  {{ $endpoint.Address }}:{{ $endpoint.Port }};
+          {{ end }}
+          }
+          server {
+              {{ range $address := $all.Cfg.BindAddressIpv4 }}
+              listen                  {{ $address }}:{{ $tcpServer.Port }}{{ if $tcpServer.Backend.ProxyProtocol.Decode }} proxy_protocol{{ end }};
+              {{ else }}
+              listen                  {{ $tcpServer.Port }}{{ if $tcpServer.Backend.ProxyProtocol.Decode }} proxy_protocol{{ end }};
+              {{ end }}
+              {{ if $IsIPV6Enabled }}
+              {{ range $address := $all.Cfg.BindAddressIpv6 }}
+              listen                  {{ $address }}:{{ $tcpServer.Port }}{{ if $tcpServer.Backend.ProxyProtocol.Decode }} proxy_protocol{{ end }};
+              {{ else }}
+              listen                  [::]:{{ $tcpServer.Port }}{{ if $tcpServer.Backend.ProxyProtocol.Decode }} proxy_protocol{{ end }};
+              {{ end }}
+              {{ end }}
+              proxy_timeout           {{ $cfg.ProxyStreamTimeout }};
+              proxy_pass              tcp-{{ $tcpServer.Port }}-{{ $tcpServer.Backend.Namespace }}-{{ $tcpServer.Backend.Name }}-{{ $tcpServer.Backend.Port }};
+              {{ if $tcpServer.Backend.ProxyProtocol.Encode }}
+              proxy_protocol          on;
+              {{ end }}
+          }
+
+          {{ end }}
+
+          # UDP services
+          {{ range $i, $udpServer := .UDPBackends }}
+          upstream udp-{{ $udpServer.Port }}-{{ $udpServer.Backend.Namespace }}-{{ $udpServer.Backend.Name }}-{{ $udpServer.Backend.Port }} {
+          {{ range $j, $endpoint := $udpServer.Endpoints }}
+              server                  {{ $endpoint.Address }}:{{ $endpoint.Port }};
+          {{ end }}
+          }
+
+          server {
+              {{ range $address := $all.Cfg.BindAddressIpv4 }}
+              listen                  {{ $address }}:{{ $udpServer.Port }} udp;
+              {{ else }}
+              listen                  {{ $udpServer.Port }} udp;
+              {{ end }}
+              {{ if $IsIPV6Enabled }}
+              {{ range $address := $all.Cfg.BindAddressIpv6 }}
+              listen                  {{ $address }}:{{ $udpServer.Port }} udp;
+              {{ else }}
+              listen                  [::]:{{ $udpServer.Port }} udp;
+              {{ end }}
+              {{ end }}
+              proxy_responses         {{ $cfg.ProxyStreamResponses }};
+              proxy_timeout           {{ $cfg.ProxyStreamTimeout }};
+              proxy_pass              udp-{{ $udpServer.Port }}-{{ $udpServer.Backend.Namespace }}-{{ $udpServer.Backend.Name }}-{{ $udpServer.Backend.Port }};
+          }
+
+          {{ end }}
+      }
+
+      {{/* definition of templates to avoid repetitions */}}
+      {{ define "CUSTOM_ERRORS" }}
+              {{ $proxySetHeaders := .ProxySetHeaders }}
+              {{ range $errCode := .Cfg.CustomHTTPErrors }}
+              location @custom_{{ $errCode }} {
+                  internal;
+
+                  proxy_intercept_errors off;
+
+                  proxy_set_header       X-Code             {{ $errCode }};
+                  proxy_set_header       X-Format           $http_accept;
+                  proxy_set_header       X-Original-URI     $request_uri;
+                  proxy_set_header       X-Namespace        $namespace;
+                  proxy_set_header       X-Ingress-Name     $ingress_name;
+                  proxy_set_header       X-Service-Name     $service_name;
+
+                  rewrite                (.*) / break;
+                  proxy_pass             http://upstream-default-backend;
+              }
+              {{ end }}
+      {{ end }}
+
+      {{/* CORS support from https://michielkalkman.com/snippets/nginx-cors-open-configuration.html */}}
+      {{ define "CORS" }}
+           {{ $cors := .CorsConfig }}
+           # Cors Preflight methods needs additional options and different Return Code
+           if ($request_method = 'OPTIONS') {
+              add_header 'Access-Control-Allow-Origin' '{{ $cors.CorsAllowOrigin }}' always;
+              {{ if $cors.CorsAllowCredentials }} add_header 'Access-Control-Allow-Credentials' '{{ $cors.CorsAllowCredentials }}' always; {{ end }}
+              add_header 'Access-Control-Allow-Methods' '{{ $cors.CorsAllowMethods }}' always;
+              add_header 'Access-Control-Allow-Headers' '{{ $cors.CorsAllowHeaders }}' always;
+              add_header 'Access-Control-Max-Age' 1728000;
+              add_header 'Content-Type' 'text/plain charset=UTF-8';
+              add_header 'Content-Length' 0;
+              return 204;
+           }
+
+              add_header 'Access-Control-Allow-Origin' '{{ $cors.CorsAllowOrigin }}' always;
+              {{ if $cors.CorsAllowCredentials }} add_header 'Access-Control-Allow-Credentials' '{{ $cors.CorsAllowCredentials }}' always; {{ end }}
+              add_header 'Access-Control-Allow-Methods' '{{ $cors.CorsAllowMethods }}' always;
+              add_header 'Access-Control-Allow-Headers' '{{ $cors.CorsAllowHeaders }}' always;
+
+      {{ end }}
+
+      {{/* definition of server-template to avoid repetitions with server-alias */}}
+      {{ define "SERVER" }}
+              {{ $all := .First }}
+              {{ $server := .Second }}
+              {{ range $address := $all.Cfg.BindAddressIpv4 }}
+              listen {{ $address }}:{{ $all.ListenPorts.HTTP }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }}{{ if eq $server.Hostname "_"}} default_server reuseport backlog={{ $all.BacklogSize }}{{end}};
+              {{ else }}
+              listen {{ $all.ListenPorts.HTTP }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }}{{ if eq $server.Hostname "_"}} default_server reuseport backlog={{ $all.BacklogSize }}{{end}};
+              {{ end }}
+              {{ if $all.IsIPV6Enabled }}
+              {{ range $address := $all.Cfg.BindAddressIpv6 }}
+              listen {{ $address }}:{{ $all.ListenPorts.HTTP }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }}{{ if eq $server.Hostname "_"}} default_server reuseport backlog={{ $all.BacklogSize }}{{ end }};
+              {{ else }}
+              listen [::]:{{ $all.ListenPorts.HTTP }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }}{{ if eq $server.Hostname "_"}} default_server reuseport backlog={{ $all.BacklogSize }}{{ end }};
+              {{ end }}
+              {{ end }}
+              set $proxy_upstream_name "-";
+
+              {{/* Listen on {{ $all.ListenPorts.SSLProxy }} because port {{ $all.ListenPorts.HTTPS }} is used in the TLS sni server */}}
+              {{/* This listener must always have proxy_protocol enabled, because the SNI listener forwards on source IP info in it. */}}
+              {{ if not (empty $server.SSLCertificate) }}
+              {{ range $address := $all.Cfg.BindAddressIpv4 }}
+              listen {{ $address }}:{{ if $all.IsSSLPassthroughEnabled }}{{ $all.ListenPorts.SSLProxy }} proxy_protocol {{ else }}{{ $all.ListenPorts.HTTPS }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }}{{ end }} {{ if eq $server.Hostname "_"}} default_server reuseport backlog={{ $all.BacklogSize }}{{end}} ssl {{ if $all.Cfg.UseHTTP2 }}http2{{ end }};
+              {{ else }}
+              listen {{ if $all.IsSSLPassthroughEnabled }}{{ $all.ListenPorts.SSLProxy }} proxy_protocol {{ else }}{{ $all.ListenPorts.HTTPS }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }}{{ end }} {{ if eq $server.Hostname "_"}} default_server reuseport backlog={{ $all.BacklogSize }}{{end}} ssl {{ if $all.Cfg.UseHTTP2 }}http2{{ end }};
+              {{ end }}
+              {{ if $all.IsIPV6Enabled }}
+              {{ range $address := $all.Cfg.BindAddressIpv6 }}
+              {{ if not (empty $server.SSLCertificate) }}listen {{ $address }}:{{ if $all.IsSSLPassthroughEnabled }}{{ $all.ListenPorts.SSLProxy }} proxy_protocol{{ else }}{{ $all.ListenPorts.HTTPS }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }}{{ end }}{{ end }} {{ if eq $server.Hostname "_"}} default_server reuseport backlog={{ $all.BacklogSize }}{{end}} ssl {{ if $all.Cfg.UseHTTP2 }}http2{{ end }};
+              {{ else }}
+              {{ if not (empty $server.SSLCertificate) }}listen [::]:{{ if $all.IsSSLPassthroughEnabled }}{{ $all.ListenPorts.SSLProxy }} proxy_protocol{{ else }}{{ $all.ListenPorts.HTTPS }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }}{{ end }}{{ end }} {{ if eq $server.Hostname "_"}} default_server reuseport backlog={{ $all.BacklogSize }}{{end}} ssl {{ if $all.Cfg.UseHTTP2 }}http2{{ end }};
+              {{ end }}
+              {{ end }}
+              {{/* comment PEM sha is required to detect changes in the generated configuration and force a reload */}}
+              # PEM sha: {{ $server.SSLPemChecksum }}
+              ssl_certificate                         {{ $server.SSLCertificate }};
+              ssl_certificate_key                     {{ $server.SSLCertificate }};
+              {{ if not (empty $server.SSLFullChainCertificate)}}
+              ssl_trusted_certificate                 {{ $server.SSLFullChainCertificate }};
+              ssl_stapling                            on;
+              ssl_stapling_verify                     on;
+              {{ end }}
+              {{ end }}
+
+              {{ if (and (not (empty $server.SSLCertificate)) $all.Cfg.HSTS) }}
+              more_set_headers                        "Strict-Transport-Security: max-age={{ $all.Cfg.HSTSMaxAge }}{{ if $all.Cfg.HSTSIncludeSubdomains }}; includeSubDomains{{ end }};{{ if $all.Cfg.HSTSPreload }} preload{{ end }}";
+              {{ end }}
+
+
+              {{ if not (empty $server.CertificateAuth.CAFileName) }}
+              # PEM sha: {{ $server.CertificateAuth.PemSHA }}
+              ssl_client_certificate                  {{ $server.CertificateAuth.CAFileName }};
+              ssl_verify_client                       {{ $server.CertificateAuth.VerifyClient }};
+              ssl_verify_depth                        {{ $server.CertificateAuth.ValidationDepth }};
+              {{ if not (empty $server.CertificateAuth.ErrorPage)}}
+              error_page 495 496 = {{ $server.CertificateAuth.ErrorPage }};
+              {{ end }}
+              {{ end }}
+
+              {{ if not (empty $server.ServerSnippet) }}
+              {{ $server.ServerSnippet }}
+              {{ end }}
+
+              {{ range $location := $server.Locations }}
+              {{ $path := buildLocation $location }}
+              {{ $authPath := buildAuthLocation $location }}
+
+              {{ if not (empty $location.Rewrite.AppRoot)}}
+              if ($uri = /) {
+                  return 302 {{ $location.Rewrite.AppRoot }};
+              }
+              {{ end }}
+
+              {{ if not (empty $authPath) }}
+              location = {{ $authPath }} {
+                  internal;
+                  set $proxy_upstream_name "external-authentication";
+
+                  proxy_pass_request_body     off;
+                  proxy_set_header            Content-Length "";
+
+                  {{ if not (empty $location.ExternalAuth.Method) }}
+                  proxy_method                {{ $location.ExternalAuth.Method }};
+                  proxy_set_header            X-Original-URI          $request_uri;
+                  proxy_set_header            X-Scheme                $pass_access_scheme;
+                  {{ end }}
+
+                  proxy_set_header            Host                    {{ $location.ExternalAuth.Host }};
+                  proxy_set_header            X-Original-URL          $scheme://$http_host$request_uri;
+                  proxy_set_header            X-Original-Method       $request_method;
+                  proxy_set_header            X-Auth-Request-Redirect $request_uri;
+                  proxy_set_header            X-Sent-From             "nginx-ingress-controller";
+
+                  proxy_http_version          1.1;
+                  proxy_ssl_server_name       on;
+                  proxy_pass_request_headers  on;
+                  client_max_body_size        "{{ $location.Proxy.BodySize }}";
+                  {{ if isValidClientBodyBufferSize $location.ClientBodyBufferSize }}
+                  client_body_buffer_size     {{ $location.ClientBodyBufferSize }};
+                  {{ end }}
+
+                  set $target {{ $location.ExternalAuth.URL }};
+                  proxy_pass $target;
+              }
+              {{ end }}
+
+              location {{ $path }} {
+                  {{ if $all.Cfg.EnableVtsStatus }}{{ if $location.VtsFilterKey }} vhost_traffic_status_filter_by_set_key {{ $location.VtsFilterKey }};{{ end }}{{ end }}
+
+                  set $proxy_upstream_name "{{ buildUpstreamName $server.Hostname $all.Backends $location }}";
+
+                  {{ $ing := (getIngressInformation $location.Ingress $path) }}
+                  {{/* $ing.Metadata contains the Ingress metadata */}}
+                  set $namespace      "{{ $ing.Namespace }}";
+                  set $ingress_name   "{{ $ing.Rule }}";
+                  set $service_name   "{{ $ing.Service }}";
+
+                  {{ if (or $location.Rewrite.ForceSSLRedirect (and (not (empty $server.SSLCertificate)) $location.Rewrite.SSLRedirect)) }}
+                  # enforce ssl on server side
+                  if ($pass_access_scheme = http) {
+                      {{ if ne $all.ListenPorts.HTTPS 443 }}
+                      {{ $redirect_port := (printf ":%v" $all.ListenPorts.HTTPS) }}
+                      return {{ $all.Cfg.HTTPRedirectCode }} https://$best_http_host{{ $redirect_port }}$request_uri;
+                      {{ else }}
+                      return {{ $all.Cfg.HTTPRedirectCode }} https://$best_http_host$request_uri;
+                      {{ end }}
+                  }
+                  {{ end }}
+
+                  {{ if $all.Cfg.EnableModsecurity }}
+                  modsecurity on;
+
+                  modsecurity_rules_file /etc/nginx/modsecurity/modsecurity.conf;
+                  {{ if $all.Cfg.EnableOWASPCoreRules }}
+                  modsecurity_rules_file /etc/nginx/owasp-modsecurity-crs/nginx-modsecurity.conf;
+                  {{ end }}
+                  {{ end }}
+
+                  {{ if isLocationAllowed $location }}
+                  {{ if gt (len $location.Whitelist.CIDR) 0 }}
+                  if ({{ buildDenyVariable (print $server.Hostname "_"  $path) }}) {
+                      return 403;
+                  }
+                  {{ end }}
+
+                  port_in_redirect {{ if $location.UsePortInRedirects }}on{{ else }}off{{ end }};
+
+                  {{ if not (empty $authPath) }}
+                  # this location requires authentication
+                  auth_request        {{ $authPath }};
+                  auth_request_set    $auth_cookie $upstream_http_set_cookie;
+                  add_header          Set-Cookie $auth_cookie;
+                  {{- range $idx, $line := buildAuthResponseHeaders $location }}
+                  {{ $line }}
+                  {{- end }}
+                  {{ end }}
+
+                  {{ if not (empty $location.ExternalAuth.SigninURL) }}
+                  error_page 401 = {{ buildAuthSignURL $location.ExternalAuth.SigninURL }};
+                  {{ end }}
+
+                  {{/* if the location contains a rate limit annotation, create one */}}
+                  {{ $limits := buildRateLimit $location }}
+                  {{ range $limit := $limits }}
+                  {{ $limit }}{{ end }}
+
+                  {{ if $location.BasicDigestAuth.Secured }}
+                  {{ if eq $location.BasicDigestAuth.Type "basic" }}
+                  auth_basic "{{ $location.BasicDigestAuth.Realm }}";
+                  auth_basic_user_file {{ $location.BasicDigestAuth.File }};
+                  {{ else }}
+                  auth_digest "{{ $location.BasicDigestAuth.Realm }}";
+                  auth_digest_user_file {{ $location.BasicDigestAuth.File }};
+                  {{ end }}
+                  proxy_set_header Authorization "";
+                  {{ end }}
+
+                  {{ if $location.CorsConfig.CorsEnabled }}
+                  {{ template "CORS" $location }}
+                  {{ end }}
+
+                  {{ if not (empty $location.Redirect.URL) }}
+                  if ($uri ~* {{ $path }}) {
+                      return {{ $location.Redirect.Code }} {{ $location.Redirect.URL }};
+                  }
+                  {{ end }}
+
+                  client_max_body_size                    "{{ $location.Proxy.BodySize }}";
+                  {{ if isValidClientBodyBufferSize $location.ClientBodyBufferSize }}
+                  client_body_buffer_size                 {{ $location.ClientBodyBufferSize }};
+                  {{ end }}
+
+                  {{/* By default use vhost as Host to upstream, but allow overrides */}}
+                  {{ if not (empty $location.UpstreamVhost) }}
+                  proxy_set_header Host                   "{{ $location.UpstreamVhost }}";
+                  {{ else }}
+                  proxy_set_header Host                   $best_http_host;
+                  {{ end }}
+
+
+                  # Pass the extracted client certificate to the backend
+                  {{ if not (empty $server.CertificateAuth.CAFileName) }}
+                  {{ if $server.CertificateAuth.PassCertToUpstream }}
+                  proxy_set_header ssl-client-cert        $ssl_client_escaped_cert;
+                  {{ else }}
+                  proxy_set_header ssl-client-cert        "";
+                  {{ end }}
+                  proxy_set_header ssl-client-verify      $ssl_client_verify;
+                  proxy_set_header ssl-client-dn          $ssl_client_s_dn;
+                  {{ else }}
+                  proxy_set_header ssl-client-cert        "";
+                  proxy_set_header ssl-client-verify      "";
+                  proxy_set_header ssl-client-dn          "";
+                  {{ end }}
+
+                  # Allow websocket connections
+                  proxy_set_header                        Upgrade           $http_upgrade;
+                  proxy_set_header                        Connection        $connection_upgrade;
+
+                  proxy_set_header X-Real-IP              $the_real_ip;
+                  {{ if $all.Cfg.ComputeFullForwardedFor }}
+                  proxy_set_header X-Forwarded-For        $full_x_forwarded_for;
+                  {{ else }}
+                  proxy_set_header X-Forwarded-For        $the_real_ip;
+                  {{ end }}
+                  proxy_set_header X-Forwarded-Host       $best_http_host;
+                  proxy_set_header X-Forwarded-Port       $pass_port;
+                  proxy_set_header X-Forwarded-Proto      $pass_access_scheme;
+                  proxy_set_header X-Original-URI         $request_uri;
+                  proxy_set_header X-Scheme               $pass_access_scheme;
+
+                  # Pass the original X-Forwarded-For
+                  proxy_set_header X-Original-Forwarded-For {{ buildForwardedFor $all.Cfg.ForwardedForHeader }};
+
+                  # mitigate HTTPoxy Vulnerability
+                  # https://www.nginx.com/blog/mitigating-the-httpoxy-vulnerability-with-nginx/
+                  proxy_set_header Proxy                  "";
+
+                  # Custom headers to proxied server
+                  {{ range $k, $v := $all.ProxySetHeaders }}
+                  proxy_set_header {{ $k }}                    "{{ $v }}";
+                  {{ end }}
+
+                  proxy_connect_timeout                   {{ $location.Proxy.ConnectTimeout }}s;
+                  proxy_send_timeout                      {{ $location.Proxy.SendTimeout }}s;
+                  proxy_read_timeout                      {{ $location.Proxy.ReadTimeout }}s;
+
+                  {{ if (or (eq $location.Proxy.ProxyRedirectFrom "default") (eq $location.Proxy.ProxyRedirectFrom "off")) }}
+                  proxy_redirect                          {{ $location.Proxy.ProxyRedirectFrom }};
+                  {{ else }}
+                  proxy_redirect                          {{ $location.Proxy.ProxyRedirectFrom }} {{ $location.Proxy.ProxyRedirectTo }};
+                  {{ end }}
+                  proxy_buffering                         off;
+                  proxy_buffer_size                       "{{ $location.Proxy.BufferSize }}";
+                  proxy_buffers                           4 "{{ $location.Proxy.BufferSize }}";
+                  proxy_request_buffering                 "{{ $location.Proxy.RequestBuffering }}";
+
+                  proxy_http_version                      1.1;
+
+                  proxy_cookie_domain                     {{ $location.Proxy.CookieDomain }};
+                  proxy_cookie_path                       {{ $location.Proxy.CookiePath }};
+
+                  # In case of errors try the next upstream server before returning an error
+                  proxy_next_upstream                     {{ buildNextUpstream $location.Proxy.NextUpstream $all.Cfg.RetryNonIdempotent }};
+
+                  {{/* rewrite only works if the content is not compressed */}}
+                  {{ if $location.Rewrite.AddBaseURL }}
+                  proxy_set_header                        Accept-Encoding     "";
+                  {{ end }}
+
+                  {{/* Add any additional configuration defined */}}
+                  {{ $location.ConfigurationSnippet }}
+
+                  {{ if not (empty $all.Cfg.LocationSnippet) }}
+                  # Custom code snippet configured in the configuration configmap
+                  {{ $all.Cfg.LocationSnippet }}
+                  {{ end }}
+
+                  {{/* if we are sending the request to a custom default backend, we add the required headers */}}
+                  {{ if (hasPrefix $location.Backend "custom-default-backend-") }}
+                  proxy_set_header       X-Code             503;
+                  proxy_set_header       X-Format           $http_accept;
+                  proxy_set_header       X-Namespace        $namespace;
+                  proxy_set_header       X-Ingress-Name     $ingress_name;
+                  proxy_set_header       X-Service-Name     $service_name;
+                  {{ end }}
+
+
+                  {{ if not (empty $location.Backend) }}
+                  {{ buildProxyPass $server.Hostname $all.Backends $location }}
+                  {{ else }}
+                  # No endpoints available for the request
+                  return 503;
+                  {{ end }}
+                  {{ else }}
+                  # Location denied. Reason: {{ $location.Denied }}
+                  return 503;
+                  {{ end }}
+              }
+
+              {{ end }}
+
+              {{ if eq $server.Hostname "_" }}
+              # health checks in cloud providers require the use of port {{ $all.ListenPorts.HTTP }}
+              location {{ $all.HealthzURI }} {
+                  access_log off;
+                  return 200;
+              }
+
+              # this is required to avoid error if nginx is being monitored
+              # with an external software (like sysdig)
+              location /nginx_status {
+                  allow 127.0.0.1;
+                  {{ if $all.IsIPV6Enabled }}allow ::1;{{ end }}
+                  deny all;
+
+                  access_log off;
+                  stub_status on;
+              }
+
+              {{ end }}
+
+      {{ end }}
+
 
   service:
-    SSLARN: ""
-    annotations:
-      service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
-      service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
-      service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
-      service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
+    annotations: {}
     clusterIP: ""
 
     ## List of IP addresses at which the controller services are available
@@ -62,7 +1029,27 @@ controller:
 
     loadBalancerIP: ""
     loadBalancerSourceRanges: []
+
+    ## Set external traffic policy to: "Local" to preserve source IP on
+    ## providers supporting it
+    ## Ref: https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typeloadbalancer
+    externalTrafficPolicy: ""
+
+    healthCheckNodePort: 0
+
+    targetPorts:
+      http: 80
+      https: 443
+
     type: LoadBalancer
+
+    # type: NodePort
+    # nodePorts:
+    #   http: 32080
+    #   https: 32443
+    nodePorts:
+      http: ""
+      https: ""
 
   stats:
     enabled: false
@@ -81,384 +1068,11 @@ controller:
       servicePort: 18080
       type: ClusterIP
 
-  serverConfigFile:
-    nginx.tmpl: |
-      {{ $cfg := .cfg }}
-      daemon off;
-
-      worker_processes {{ $cfg.workerProcesses }};
-
-      pid /run/nginx.pid;
-
-      worker_rlimit_nofile 131072;
-
-      pcre_jit on;
-
-      events {
-          multi_accept        on;
-          worker_connections  {{ $cfg.maxWorkerConnections }};
-          use                 epoll;
-      }
-
-      http {
-          {{/* we use the value of the header X-Forwarded-For to be able to use the geo_ip module */}}
-          {{ if $cfg.useProxyProtocol -}}
-          set_real_ip_from    {{ $cfg.proxyRealIpCidr }};
-          real_ip_header      proxy_protocol;
-          {{ else }}
-          real_ip_header      X-Forwarded-For;
-          set_real_ip_from    0.0.0.0/0;
-          {{ end -}}
-
-          real_ip_recursive   on;
-
-          {{/* databases used to determine the country depending on the client IP address */}}
-          {{/* http://nginx.org/en/docs/http/ngx_http_geoip_module.html */}}
-          {{/* this is require to calculate traffic for individual country using GeoIP in the status page */}}
-          geoip_country       /etc/nginx/GeoIP.dat;
-          geoip_city          /etc/nginx/GeoLiteCity.dat;
-          geoip_proxy_recursive on;
-
-          {{- if $cfg.enableVtsStatus }}
-          vhost_traffic_status_zone shared:vhost_traffic_status:{{ $cfg.vtsStatusZoneSize }};
-          vhost_traffic_status_filter_by_set_key $geoip_country_code country::*;
-          {{ end -}}
-
-          # lua section to return proper error codes when custom pages are used
-          lua_package_path '.?.lua;./etc/nginx/lua/?.lua;/etc/nginx/lua/vendor/lua-resty-http/lib/?.lua;';
-          init_by_lua_block {
-              require("error_page")
-          }
-
-          sendfile            on;
-          aio                 threads;
-          tcp_nopush          on;
-          tcp_nodelay         on;
-
-          log_subrequest      on;
-
-          reset_timedout_connection on;
-
-          keepalive_timeout {{ $cfg.keepAlive }}s;
-
-          types_hash_max_size 2048;
-          server_names_hash_max_size {{ $cfg.serverNameHashMaxSize }};
-          server_names_hash_bucket_size {{ $cfg.serverNameHashBucketSize }};
-
-          include /etc/nginx/mime.types;
-          default_type text/html;
-          {{ if $cfg.useGzip -}}
-          gzip on;
-          gzip_comp_level 5;
-          gzip_http_version 1.1;
-          gzip_min_length 256;
-          gzip_types {{ $cfg.gzipTypes }};
-          gzip_proxied any;
-          {{- end }}
-
-          client_max_body_size "{{ $cfg.bodySize }}";
-
-          log_format upstreaminfo '{{ if $cfg.useProxyProtocol }}$proxy_protocol_addr{{ else }}$remote_addr{{ end }} - '
-              '[$proxy_add_x_forwarded_for] - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" '
-              '$request_length $request_time $upstream_addr $upstream_response_length $upstream_response_time $upstream_status';
-
-          {{/* map urls that should not appear in access.log */}}
-          {{/* http://nginx.org/en/docs/http/ngx_http_log_module.html#access_log */}}
-          map $request $loggable {
-              {{- range $reqUri := $cfg.skipAccessLogUrls }}
-              {{ $reqUri }} 0;{{ end }}
-              default 1;
-          }
-
-          access_log /var/log/nginx/access.log upstreaminfo if=$loggable;
-          error_log  /var/log/nginx/error.log {{ $cfg.errorLogLevel }};
-
-          {{ if not (empty .defResolver) }}# Custom dns resolver.
-          resolver {{ .defResolver }} valid=30s;
-          {{ end }}
-
-          map $http_upgrade $connection_upgrade {
-              default upgrade;
-              ''      close;
-          }
-
-          # trust http_x_forwarded_proto headers correctly indicate ssl offloading
-          map $http_x_forwarded_proto $pass_access_scheme {
-            default $http_x_forwarded_proto;
-            ''      $scheme;
-          }
-
-          # Map a response error watching the header Content-Type
-          map $http_accept $httpAccept {
-              default          html;
-              application/json json;
-              application/xml  xml;
-              text/plain       text;
-          }
-
-          map $httpAccept $httpReturnType {
-              default          text/html;
-              json             application/json;
-              xml              application/xml;
-              text             text/plain;
-          }
-
-          server_name_in_redirect off;
-          port_in_redirect off;
-
-          ssl_protocols {{ $cfg.sslProtocols }};
-
-          # turn on session caching to drastically improve performance
-          {{ if $cfg.sslSessionCache }}
-          ssl_session_cache builtin:1000 shared:SSL:{{ $cfg.sslSessionCacheSize }};
-          ssl_session_timeout {{ $cfg.sslSessionTimeout }};
-          {{ end }}
-
-          # allow configuring ssl session tickets
-          ssl_session_tickets {{ if $cfg.sslSessionTickets }}on{{ else }}off{{ end }};
-
-          # slightly reduce the time-to-first-byte
-          ssl_buffer_size {{ $cfg.sslBufferSize }};
-
-          {{ if not (empty $cfg.sslCiphers) }}
-          # allow configuring custom ssl ciphers
-          ssl_ciphers '{{ $cfg.sslCiphers }}';
-          ssl_prefer_server_ciphers on;
-          {{ end }}
-
-          {{ if not (empty .sslDHParam) }}
-          # allow custom DH file http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_dhparam
-          ssl_dhparam {{ .sslDHParam }};
-          {{ end }}
-
-          {{- if not $cfg.enableDynamicTlsRecords }}
-          ssl_dyn_rec_size_lo 0;
-          {{ end }}
-
-          {{- if .customErrors }}
-          # Custom error pages
-          proxy_intercept_errors on;
-          {{ end }}
-
-          {{- range $errCode := $cfg.customHttpErrors }}
-          error_page {{ $errCode }} = @custom_{{ $errCode }};{{ end }}
-
-          # In case of errors try the next upstream server before returning an error
-          proxy_next_upstream                     error timeout invalid_header http_502 http_503 http_504{{ if $cfg.retryNonIdempotent }} non_idempotent{{ end }};
-
-          {{range $name, $upstream := .upstreams}}
-          upstream {{$upstream.Name}} {
-              {{ if $cfg.enableStickySessions -}}
-              sticky hash=sha1 httponly;
-              {{ else -}}
-              least_conn;
-              {{- end }}
-              {{ range $server := $upstream.Backends }}server {{ $server.Address }}:{{ $server.Port }} max_fails={{ $server.MaxFails }} fail_timeout={{ $server.FailTimeout }};
-              {{ end }}
-          }
-          {{ end }}
-
-          {{/* build all the required rate limit zones. Each annotation requires a dedicated zone */}}
-          {{/* 1MB -> 16 thousand 64-byte states or about 8 thousand 128-byte states */}}
-          {{- range $zone := (buildRateLimitZones .servers) }}
-          {{ $zone }}
-          {{ end }}
-
-          {{/* Handles HTTP traffic from ELB and redirects to HTTPS */}}
-          server {
-             listen 8000 proxy_protocol;
-             server_tokens off;
-             return 301 https://$host$request_uri;
-          }
-
-          {{ range $server := .servers }}
-          server {
-              server_name {{ $server.Name }};
-              listen 80{{ if $cfg.useProxyProtocol }} proxy_protocol{{ end }};
-              {{ if $server.SSL }}listen 443 {{ if $cfg.useProxyProtocol }}proxy_protocol{{ end }} ssl {{ if $cfg.enableSpdy }}spdy{{ end }} {{ if $cfg.useHttp2 }}http2{{ end }};
-              {{/* comment PEM sha is required to detect changes in the generated configuration and force a reload */}}
-              # PEM sha: {{ $server.SSLPemChecksum }}
-              ssl_certificate {{ $server.SSLCertificate }};
-              ssl_certificate_key {{ $server.SSLCertificateKey }};
-              {{- end }}
-
-              {{ if (and $server.SSL $cfg.hsts) -}}
-              more_set_headers                            "Strict-Transport-Security: max-age={{ $cfg.hstsMaxAge }}{{ if $cfg.hstsIncludeSubdomains }}; includeSubDomains{{ end }}; preload";
-              {{- end }}
-
-              {{ if $cfg.enableVtsStatus }}vhost_traffic_status_filter_by_set_key $geoip_country_code country::$server_name;{{ end }}
-
-              {{- range $location := $server.Locations }}
-              {{ $path := buildLocation $location }}
-              location {{ $path }} {
-                  {{ if gt (len $location.Whitelist.CIDR) 0 }}
-                  {{- range $ip := $location.Whitelist.CIDR }}
-                  allow {{ $ip }};{{ end }}
-                  deny all;
-                  {{ end -}}
-
-                  {{ if (and $server.SSL $location.Redirect.SSLRedirect) -}}
-                  # enforce ssl on server side
-                  if ($scheme = http) {
-                      return 301 https://$host$request_uri;
-                  }
-                  {{- end }}
-                  {{/* if the location contains a rate limit annotation, create one */}}
-                  {{ $limits := buildRateLimit $location }}
-                  {{- range $limit := $limits }}
-                  {{ $limit }}{{ end }}
-
-                  {{ if $location.Auth.Secured }}
-                  {{ if eq $location.Auth.Type "basic" }}
-                  auth_basic "{{ $location.Auth.Realm }}";
-                  auth_basic_user_file {{ $location.Auth.File }};
-                  {{ else }}
-                  #TODO: add nginx-http-auth-digest module
-                  auth_digest "{{ $location.Auth.Realm }}";
-                  auth_digest_user_file {{ $location.Auth.File }};
-                  {{ end }}
-                  proxy_set_header Authorization "";
-                  {{- end }}
-
-                  proxy_set_header Host                   $host;
-
-                  # Pass Real IP
-                  proxy_set_header X-Real-IP              $remote_addr;
-
-                  # Allow websocket connections
-                  proxy_set_header                        Upgrade           $http_upgrade;
-                  proxy_set_header                        Connection        $connection_upgrade;
-
-                  proxy_set_header X-Forwarded-For        $proxy_add_x_forwarded_for;
-                  proxy_set_header X-Forwarded-Host       $host;
-                  proxy_set_header X-Forwarded-Port       $server_port;
-                  proxy_set_header X-Forwarded-Proto      $pass_access_scheme;
-
-                  # mitigate HTTPoxy Vulnerability
-                  # https://www.nginx.com/blog/mitigating-the-httpoxy-vulnerability-with-nginx/
-                  proxy_set_header Proxy                  "";
-
-                  proxy_connect_timeout                   {{ $cfg.proxyConnectTimeout }}s;
-                  proxy_send_timeout                      {{ $cfg.proxySendTimeout }}s;
-                  proxy_read_timeout                      {{ $cfg.proxyReadTimeout }}s;
-
-                  proxy_redirect                          off;
-                  proxy_buffering                         off;
-
-                  proxy_http_version                      1.1;
-
-                  {{/* rewrite only works if the content is not compressed */}}
-                  {{ if $location.Redirect.AddBaseURL -}}
-                  proxy_set_header                        Accept-Encoding     "";
-                  {{- end }}
-
-                  {{- buildProxyPass $location }}
-              }
-              {{ end }}
-
-              {{ if eq $server.Name "_" }}
-              # this is required to avoid error if nginx is being monitored
-              # with an external software (like sysdig)
-              location /nginx_status {
-                  allow 127.0.0.1;
-                  deny all;
-
-                  access_log off;
-                  stub_status on;
-              }
-              {{ end }}
-              {{ template "CUSTOM_ERRORS" $cfg }}
-          }
-          {{ end }}
-
-          # default server, used for NGINX healthcheck and access to nginx stats
-          server {
-              # Use the port 18080 (random value just to avoid known ports) as default port for nginx.
-              # Changing this value requires a change in:
-              # https://github.com/kubernetes/contrib/blob/master/ingress/controllers/nginx/nginx/command.go#L104
-              listen 18080 default_server reuseport backlog={{ .backlogSize }};
-
-              location /healthz {
-                  access_log off;
-                  return 200;
-              }
-
-              location /nginx_status {
-                  {{ if $cfg.enableVtsStatus -}}
-                  vhost_traffic_status_display;
-                  vhost_traffic_status_display_format html;
-                  {{ else }}
-                  access_log off;
-                  stub_status on;
-                  {{- end }}
-              }
-
-              location / {
-                  proxy_pass             http://upstream-default-backend;
-              }
-              {{- template "CUSTOM_ERRORS" $cfg }}
-          }
-
-          # default server for services without endpoints
-          server {
-              listen 8181;
-
-              location / {
-                  {{ if .customErrors }}
-                  content_by_lua_block {
-                      openURL(503)
-                  }
-                  {{ else }}
-                  return 503;
-                  {{ end }}
-              }
-          }
-      }
-
-      stream {
-      # TCP services
-      {{ range $i, $tcpServer := .tcpUpstreams }}
-          upstream tcp-{{ $tcpServer.Upstream.Name }} {
-              {{ range $server := $tcpServer.Upstream.Backends }}server {{ $server.Address }}:{{ $server.Port }};
-              {{ end }}
-          }
-
-          server {
-              listen {{ $tcpServer.Path }};
-              proxy_connect_timeout  {{ $cfg.proxyConnectTimeout }};
-              proxy_timeout          {{ $cfg.proxyReadTimeout }};
-              proxy_pass             tcp-{{ $tcpServer.Upstream.Name }};
-          }
-      {{ end }}
-
-      # UDP services
-      {{ range $i, $udpServer := .udpUpstreams }}
-          upstream udp-{{ $udpServer.Upstream.Name }} {
-              {{ range $server := $udpServer.Upstream.Backends }}server {{ $server.Address }}:{{ $server.Port }};
-              {{ end }}
-          }
-
-          server {
-              listen {{ $udpServer.Path }} udp;
-              proxy_timeout          10s;
-              proxy_responses        1;
-              proxy_pass             udp-{{ $udpServer.Upstream.Name }};
-          }
-      {{ end }}
-      }
-
-      {{/* definition of templates to avoid repetitions */}}
-      {{ define "CUSTOM_ERRORS" }}
-              {{ range $errCode := .customHttpErrors }}
-              location @custom_{{ $errCode }} {
-                  internal;
-                  content_by_lua_block {
-                      openURL({{ $errCode }})
-                  }
-              }
-              {{ end }}
-      {{ end }}
-
+  lifecycle: {}
+
+## Rollback limit
+##
+revisionHistoryLimit: 10
 
 ## Default 404 backend
 ##
@@ -470,11 +1084,24 @@ defaultBackend:
 
   name: default-backend
   image:
-    repository: gcr.io/google_containers/defaultbackend
-    tag: "1.2"
+    repository: k8s.gcr.io/defaultbackend
+    tag: "1.3"
     pullPolicy: IfNotPresent
 
   extraArgs: {}
+
+  ## Node tolerations for server scheduling to nodes with taints
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  ##
+  tolerations: []
+  #  - key: "key"
+  #    operator: "Equal|Exists"
+  #    value: "value"
+  #    effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
+
+  # labels to add to the pod container metadata
+  podLabels: {}
+  #  key: value
 
   ## Node labels for default backend pod assignment
   ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
@@ -488,12 +1115,12 @@ defaultBackend:
   replicaCount: 1
 
   resources: {}
-    # limits:
-    #   cpu: 10m
-    #   memory: 20Mi
-    # requests:
-    #   cpu: 10m
-    #   memory: 20Mi
+  # limits:
+  #   cpu: 10m
+  #   memory: 20Mi
+  # requests:
+  #   cpu: 10m
+  #   memory: 20Mi
 
   service:
     annotations: {}
@@ -509,14 +1136,19 @@ defaultBackend:
     servicePort: 80
     type: ClusterIP
 
+## Enable RBAC as per https://github.com/kubernetes/ingress/tree/master/examples/rbac/nginx and https://github.com/kubernetes/ingress/issues/266
+rbac:
+  create: false
+  serviceAccountName: default
+
 ## If controller.stats.enabled = true, Prometheus metrics will be exported
 ## Ref: https://github.com/hnlq715/nginx-vts-exporter
 ##
 statsExporter:
   name: stats-exporter
   image:
-    repository: quay.io/cy-play/vts-nginx-exporter
-    tag: v0.0.3
+    repository: sophos/nginx-vts-exporter
+    tag: v0.6
     pullPolicy: IfNotPresent
 
   endpoint: /metrics
@@ -525,12 +1157,12 @@ statsExporter:
   statusPage: http://localhost:18080/nginx_status/format/json
 
   resources: {}
-    # limits:
-    #   cpu: 10m
-    #   memory: 20Mi
-    # requests:
-    #   cpu: 10m
-    #   memory: 20Mi
+  # limits:
+  #   cpu: 10m
+  #   memory: 20Mi
+  # requests:
+  #   cpu: 10m
+  #   memory: 20Mi
 
   service:
     annotations: {}
@@ -544,16 +1176,17 @@ statsExporter:
     loadBalancerIP: ""
     loadBalancerSourceRanges: []
     servicePort: 9913
+    targetPort: 9913
     type: ClusterIP
 
 # TCP service key:value pairs
 # Ref: https://github.com/kubernetes/contrib/tree/master/ingress/controllers/nginx/examples/tcp
 ##
 tcp: {}
-  # 8080: "default/example-tcp-svc:9000"
+#  8080: "default/example-tcp-svc:9000"
 
 # UDP service key:value pairs
 # Ref: https://github.com/kubernetes/contrib/tree/master/ingress/controllers/nginx/examples/udp
 ##
 udp: {}
-  # 53: "kube-system/kube-dns:53"
+#  53: "kube-system/kube-dns:53"


### PR DESCRIPTION
Turns out we're still not able to use the nginx-ingress chart from the main k8s repo due to issues with Websockets when terminating TLS at the ELB. So I've updated our customised chart using the latest version of the main repo chart.