### PR TITLE
webapp chart: added session affinity ingress annotation

### DIFF
--- a/charts/webapp/Chart.yaml
+++ b/charts/webapp/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: webapp Helm chart for Kubernetes
 name: webapp
-version: 1.3.4
+version: 1.3.5

--- a/charts/webapp/templates/ingress.yaml
+++ b/charts/webapp/templates/ingress.yaml
@@ -8,6 +8,7 @@ metadata:
     repo: {{ .Values.WebApp.GithubRepo }}
   annotations:
     kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/affinity: "cookie"
 spec:
   rules:
   - host: {{ .Values.WebApp.Name }}.{{ .Values.WebApp.BaseHost }}


### PR DESCRIPTION
The current version of nginx-ingress-controller no longer supports enabling sticky sessions globally, so an ingress annotation is required instead.