### PR TITLE
Kubernetes MetaData Plugin

### DIFF
--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -146,7 +146,7 @@ fluentdconffiles:
       </exclude>
     </filter>
 
-    <filter kubernetes.**>
+    <filter kubernetes.var.log.pods.**.log>
       @type kubernetes_metadata
     </filter>
   fluent.conf: |


### PR DESCRIPTION
See: https://github.com/kubernetes/kubernetes/issues/53022#issuecomment-332150416

Also

See: https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter

Symlink `/var/log/containers` has been deprecated in favour of `/var/log/pods`
for our version of the docker daemon for kubernetes metadata.

No noticeable symptoms other than log errors.