### PR TITLE
Rstudio Service Account

### DIFF
--- a/charts/rstudio/templates/deployment.yml
+++ b/charts/rstudio/templates/deployment.yml
@@ -19,6 +19,7 @@ spec:
       annotations:
         iam.amazonaws.com/role: {{ .Values.aws.iamRole }}
     spec:
+      serviceAccountName: {{ .Values.Username }}-rstudio
       containers:
 
         - name: rstudio-auth-proxy

--- a/charts/rstudio/templates/service-account.yaml
+++ b/charts/rstudio/templates/service-account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.Username }}-rstudio
+  namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
Adding service account for auditing purposes.  The RStudio instances do not need
to access api resources therefore need no permissions.

However all rstudio pods run as __default__ service-account for that
namespace which is fine but makes querying a little confusing when
trying to match accounts with bindings.