### PR TITLE
cpfrontent 1.3.4: Removed `APP_PORT` environment variable

### DIFF
--- a/charts/cpfrontend/CHANGELOG.md
+++ b/charts/cpfrontend/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [1.3.4] - 2018-02-14
+### Removed
+Removed `APP_PORT` environment variable, it's causing problems with the
+logout in `dev`/`alpha`. See PR [Fixed logout in dev/alpha](https://github.com/ministryofjustice/analytics-platform-control-panel-frontend/pull/131).
+
+
 ## [1.3.0] - 2017-12-12
 ### Added
 Added `TOOLS_DOMAIN` environment variable

--- a/charts/cpfrontend/Chart.yaml
+++ b/charts/cpfrontend/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Analytics Platform Control Panel webapp
 name: cpfrontend
-version: 1.3.3
+version: 1.3.4

--- a/charts/cpfrontend/templates/deployment.yaml
+++ b/charts/cpfrontend/templates/deployment.yaml
@@ -26,8 +26,6 @@ spec:
               value: {{ .Values.Frontend.Protocol }}
             - name: APP_HOST
               value: "cpanel{{- if .Values.Frontend.Branch -}}-{{ .Values.Frontend.Branch }}{{- end -}}.{{ .Values.ServicesDomain }}"
-            - name: APP_PORT
-              value: "{{ .Values.Frontend.ServicePort }}"
             - name: AUTH0_CLIENT_ID
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
See related PR: https://github.com/ministryofjustice/analytics-platform-control-panel-frontend/pull/131