### PR TITLE
RStudio 1.3.0: Pass env variable necessary for hosted login page logout

### DIFF
--- a/charts/rstudio/CHANGELOG.md
+++ b/charts/rstudio/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+
+## [1.3.0] - 2018-02-14
+### Added
+- Pass `APP_PROTOCOL` and `APP_HOST` to rstudio-auth-proxy container.
+  This is required in order to Auth0 hosted login page logout to work.
+- Added `CHANGELOG.md`

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: RStudio with Auth0 authentication proxy
 name: rstudio
-version: 1.2.8
+version: 1.3.0

--- a/charts/rstudio/templates/deployment.yml
+++ b/charts/rstudio/templates/deployment.yml
@@ -31,6 +31,13 @@ spec:
           env:
             - name: USER
               value: {{ .Values.username }}
+            - name: APP_PROTOCOL
+              value: {{ .Values.authProxy.appProtocol }}
+            - name: APP_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "fullname" . }}
+                  key: app_host
             - name: AUTH0_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:

--- a/charts/rstudio/templates/secrets.yml
+++ b/charts/rstudio/templates/secrets.yml
@@ -10,6 +10,7 @@ data:
   client_secret: {{ .Values.authProxy.auth0.clientSecret | b64enc | quote }}
   client_id: {{ .Values.authProxy.auth0.clientId | b64enc | quote }}
   domain: {{ .Values.authProxy.auth0.domain | b64enc | quote }}
+  app_host: {{ printf "%s-rstudio.%s" .Values.username .Values.toolsDomain | lower | b64enc | quote }}
   callback_url: {{ printf "https://%s-rstudio.%s/callback" .Values.username .Values.toolsDomain | lower | b64enc | quote }}
   cookie_secret: {{ .Values.authProxy.cookieSecret | b64enc | quote }}
   secure_cookie_key: {{ .Values.rstudio.secureCookieKey | b64enc | quote }}

--- a/charts/rstudio/values.yaml
+++ b/charts/rstudio/values.yaml
@@ -4,6 +4,7 @@ aws:
   iamRole: ""
   defaultRegion: "eu-west-1"
 authProxy:
+  appProtocol: "https"
   auth0:
     clientSecret: ""
     clientId: ""


### PR DESCRIPTION
### What
Set environment variables used by [rstudio-auth-proxy](https://github.com/ministryofjustice/analytics-platform-rstudio-auth-proxy/pull/12/files):
- `APP_PROTOCOL` will always be `https`
- `APP_HOST` is something like `joe-rstudio.tools.example.com`

### NOTES
This needs to be merged before the [rstudio-auth-proxy changes](https://github.com/ministryofjustice/analytics-platform-rstudio-auth-proxy/pull/12/files) (if not logout would be broken, rest should still be fine so not a massive deal really)

### Part of ticket
https://trello.com/c/t90fEmBs/647-4-update-rstudio-auth-proxy-to-use-hosted-auth0-login