### PR TITLE
Jupyter-Lab: Initial Commit

### DIFF
--- a/charts/jupyter-lab/Chart.yaml
+++ b/charts/jupyter-lab/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: Jupyter Lab with Auth0 authentication proxy
+name: jupyter-lab
+version: 0.1.0

--- a/charts/jupyter-lab/README.md
+++ b/charts/jupyter-lab/README.md
@@ -1,0 +1,33 @@
+# Jupyter-Lab Helm Chart
+
+
+## Installing the Chart
+
+To install an jupyter instance for the user specified in the Username variable (Github username):
+
+```bash
+$ helm install charts/jupyter-lab -f chart-env-config/ENV/jupyter.yml --set Username=USERNAME --namespace user-USERNAME --name=USERNAME-jupyter
+```
+
+The instance will be available in <https://USERNAME-jupyter.tools.ENV.mojanalytics.xyz>.
+
+**NOTE**: Change the environment config file to deploy in a different environment
+          (the URL will change accordingly)
+
+
+## Upgrading the Chart
+
+To upgrade a user jupyter chart:
+```bash
+$ helm upgrade USERNAME-jupyter charts/jupyter-lab -f chart-env-config/ENV/jupyter.yml --set Username=USERNAME
+```
+
+
+## Configuration
+
+Listing only the required params here. See `/chart-env-config/` for more
+details.
+
+| Parameter  | Description     | Default |
+| ---------- | --------------- | ------- |
+| `Username` | Github username | ``      |

--- a/charts/jupyter-lab/templates/_helpers.tpl
+++ b/charts/jupyter-lab/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 24 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 24 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/jupyter-lab/templates/deployment.yaml
+++ b/charts/jupyter-lab/templates/deployment.yaml
@@ -1,0 +1,97 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app: {{ .Chart.Name }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ .Chart.Name }}
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: {{ .Chart.Name }}
+      annotations:
+        iam.amazonaws.com/role: {{ .Values.aws.iamRole }}
+    spec:
+      serviceAccountName: {{ .Values.Username }}-jupyter
+      containers:
+        - name: {{ .Chart.Name }}-auth-proxy
+          image: {{ .Values.authProxy.image }}:{{ .Values.authProxy.tag }}
+          imagePullPolicy: {{ .Values.authProxy.imagePullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.authProxy.containerPort }}
+          env:
+            - name: TARGET_URL
+              value: http://localhost:{{ .Values.jupyter.containerPort }}
+            - name: AUTH0_DOMAIN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "fullname" . }}
+                  key: auth0_domain
+            - name: AUTH0_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "fullname" . }}
+                  key: auth0_client_id
+            - name: AUTH0_CALLBACK_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "fullname" . }}
+                  key: auth0_callback_url
+            - name: AUTH0_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "fullname" . }}
+                  key: auth0_client_secret
+            - name: COOKIE_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "fullname" . }}
+                  key: cookie_secret
+            - name: NICKNAME_RE
+              value: {{ .Values.Username }}
+          readinessProbe:
+            httpGet:
+              path: /login?healthz
+              port: http
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          resources:
+{{ toYaml .Values.authProxy.resources | indent 12 }}
+        - name: {{ .Chart.Name }}
+          image: {{ .Values.jupyter.image }}:{{ .Values.jupyter.tag }}
+          imagePullPolicy: {{ .Values.jupyter.imagePullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.jupyter.containerPort }}
+          command:
+            - "start.sh"
+          args:
+            - "jupyter lab"
+            - "--NotebookApp.token=''"
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          volumeMounts:
+            - name: workspace
+              mountPath: /home/jovyan
+          resources:
+{{ toYaml .Values.jupyter.resources | indent 12 }}
+      volumes:
+        - name: nfs-home
+          persistentVolumeClaim:
+            claimName: nfs-home

--- a/charts/jupyter-lab/templates/ingress.yaml
+++ b/charts/jupyter-lab/templates/ingress.yaml
@@ -1,0 +1,19 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app: {{ .Chart.Name }}
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+spec:
+  rules:
+    - host: {{ .Values.Username | lower }}-jupyter.{{ .Values.toolsDomain }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ template "fullname" . }}
+              servicePort: {{ .Values.service.port }}

--- a/charts/jupyter-lab/templates/secrets.yaml
+++ b/charts/jupyter-lab/templates/secrets.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app: {{ .Chart.Name }}
+type: Opaque
+data:
+  auth0_domain: {{ .Values.authProxy.auth0_domain | b64enc | quote }}
+  auth0_client_id: {{ .Values.authProxy.auth0_client_id | b64enc | quote }}
+  auth0_client_secret: {{ .Values.authProxy.auth0_client_secret | b64enc | quote }}
+  auth0_callback_url: {{ printf "https://%s-jupyter.%s/callback" .Values.Username .Values.toolsDomain | lower | b64enc | quote }}
+  cookie_secret: {{ .Values.cookie_secret | b64enc | quote }}

--- a/charts/jupyter-lab/templates/service-account.yaml
+++ b/charts/jupyter-lab/templates/service-account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.Username }}-jupyter
+  namespace: {{ .Release.Namespace }}

--- a/charts/jupyter-lab/templates/service.yaml
+++ b/charts/jupyter-lab/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app: {{ .Chart.Name }}
+spec:
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: {{ .Values.authProxy.containerPort }}
+  selector:
+    app: {{ .Chart.Name }}
+  type: ClusterIP

--- a/charts/jupyter-lab/values.yaml
+++ b/charts/jupyter-lab/values.yaml
@@ -1,0 +1,38 @@
+Username: ""
+
+aws:
+  iamRole: ""
+  defaultRegion: "eu-west-1"
+
+service:
+  port: 80
+
+authProxy:
+  image: quay.io/mojanalytics/auth-proxy
+  tag: v0.0.2
+  imagePullPolicy: IfNotPresent
+  containerPort: 3000
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 25m
+      memory: 64Mi
+  auth0_domain: ""
+  auth0_client_id: ""
+
+jupyter:
+  image: quay.io/mojanalytics/jupyter
+  tag: latest
+  imagePullPolicy: IfNotPresent
+  containerPort: 8888
+  resources:
+    limits:
+      cpu: 1.5
+      memory: 12Gi
+    requests:
+      cpu: 200m
+      memory: 1Gi
+
+cookie_secret: ""


### PR DESCRIPTION
Jupyter Lab Helm Chart

Deploys Jupyter lab data-science notebook [stack](https://github.com/jupyter/docker-stacks/tree/master/datascience-notebook) 

Shares the same storage(PVC) as rstudio-server.

Uses image: https://github.com/ministryofjustice/analytics-platform-jupyter-notebook
