### PR TITLE
Create User Home Namespace

### DIFF
--- a/charts/init-user/templates/create-user-home-job.yml
+++ b/charts/init-user/templates/create-user-home-job.yml
@@ -2,6 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: create-user-home-{{ .Values.Username }}
+  namespace: default
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
 spec:


### PR DESCRIPTION
The persistent volume claim `nfs-homes` lives in the default namspace.  Running the
Job works fine if the namespace in your context is set to default but in
the event that it is not.  The job will fail.