### PR TITLE
Fix rstudio service account typo

### DIFF
--- a/charts/rstudio/templates/service-account.yaml
+++ b/charts/rstudio/templates/service-account.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.Username }}-rstudio
+  name: {{ .Values.username }}-rstudio
   namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
The value is `username` not `Username`