### PR TITLE
RStudio v1.3.0 proxy to use Auth0 hosted login page

### DIFF
--- a/charts/rstudio/CHANGELOG.md
+++ b/charts/rstudio/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [1.3.3] - 2018-02-16
+### Changed
+- Bumped rstudio-auth-proxy docker image used to v1.3.0.
+  This is the version using Auth0 hosted login page
+
+
 ## [1.3.0] - 2018-02-14
 ### Added
 - Pass `APP_PROTOCOL` and `APP_HOST` to rstudio-auth-proxy container.

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: RStudio with Auth0 authentication proxy
 name: rstudio
-version: 1.3.2
+version: 1.3.3

--- a/charts/rstudio/values.yaml
+++ b/charts/rstudio/values.yaml
@@ -15,7 +15,7 @@ authProxy:
     port: 3000
   image:
     repository: quay.io/mojanalytics/rstudio-auth-proxy
-    tag: "v1.2.0"
+    tag: "v1.3.0"
     pullPolicy: "IfNotPresent"
   resources:
     limits:


### PR DESCRIPTION
See quay.io/mojanalytics/rstudio-auth-proxy tag v1.3.0