### PR TITLE
RBAC: CPANEL

### DIFF
--- a/charts/cpanel/templates/cluster-role.yaml
+++ b/charts/cpanel/templates/cluster-role.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "fullname" . }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - "pods"
+    verbs:
+      - "list"
+  - apiGroups:
+      - ""
+    resources:
+      - "pods/portforward"
+    verbs:
+      - "create"

--- a/charts/cpanel/templates/deployment.yaml
+++ b/charts/cpanel/templates/deployment.yaml
@@ -14,6 +14,7 @@ spec:
       annotations:
         iam.amazonaws.com/role: {{ .Values.AWS.IAMRole }}
     spec:
+      serviceAccountName: {{ template "fullname" . }}
       containers:
         - name: api
           image: "{{ .Values.API.Image.Repository }}:{{ .Values.API.Image.Tag }}"

--- a/charts/cpanel/templates/role-binding.yaml
+++ b/charts/cpanel/templates/role-binding.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "fullname" . }}
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  name: {{ template "fullname" . }}
+  kind: ClusterRole
+subjects:
+  - apiGroup: ""
+    name: {{ template "fullname" . }}
+    kind: ServiceAccount
+    namespace: {{ .Release.Namespace }}
+
+# This allows a service account in the Release's namespace (i.e. default) to manage resources in the kube-system namespace

--- a/charts/cpanel/templates/service-account.yaml
+++ b/charts/cpanel/templates/service-account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "fullname" . }}
+  namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
In the backgroud the control panel invokes `helm` commands to manage a
user's applications like rstudio. `helm` itself requires that the
account invoking it be able to discover `tiller`. To discover `tiller` the account
at the very least will need to be able to __list__ `pods` in `kube-system` (perhaps
because helm assumes that is where tiller is?) and forward ports.