### PR TITLE
RStudio 1.4.0: Enabled Silent SSO

### DIFF
--- a/charts/rstudio/CHANGELOG.md
+++ b/charts/rstudio/CHANGELOG.md
@@ -5,6 +5,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [1.4.0] - 2018-02-22
+### Changed
+- Bumped rstudio-auth-proxy docker image used to v1.4.1.
+  This version enable silent SSO for RStudio
+- Use newly added rstudio-auth-proxy's `GET /healthz` endpoint as
+  readiness probe
+
+
 ## [1.3.3] - 2018-02-16
 ### Changed
 - Bumped rstudio-auth-proxy docker image used to v1.3.0.

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: RStudio with Auth0 authentication proxy
 name: rstudio
-version: 1.3.3
+version: 1.4.0

--- a/charts/rstudio/templates/deployment.yml
+++ b/charts/rstudio/templates/deployment.yml
@@ -78,7 +78,7 @@ spec:
               value: "{{ .Values.authProxy.express.port }}"
           readinessProbe:
             httpGet:
-              path: /login?healthz
+              path: /healthz
               port: http
             initialDelaySeconds: 5
             periodSeconds: 5

--- a/charts/rstudio/values.yaml
+++ b/charts/rstudio/values.yaml
@@ -15,7 +15,7 @@ authProxy:
     port: 3000
   image:
     repository: quay.io/mojanalytics/rstudio-auth-proxy
-    tag: "v1.3.0"
+    tag: "v1.4.1"
     pullPolicy: "IfNotPresent"
   resources:
     limits:


### PR DESCRIPTION
By using [new version of rstudio-auth-proxy](https://github.com/ministryofjustice/analytics-platform-rstudio-auth-proxy/pull/13) (`v1.4.1`)

Also using [rstudio-auth-proxy's `GET /healthz` endpoint](https://github.com/ministryofjustice/analytics-platform-rstudio-auth-proxy/pull/14) instead of `GET /login` as readiness probe.