### PR TITLE
rstudio 1.4.1: Session cookies expire after 1 hour (by default)

### DIFF
--- a/charts/rstudio/CHANGELOG.md
+++ b/charts/rstudio/CHANGELOG.md
@@ -5,6 +5,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [1.4.1] - 2018-02-28
+### Added
+- sets `COOKIE_MAXAGE` variable in auth proxy to expire session cookies after
+  1 hour (can be configured via `authProxy.cookieMaxAge` value which by default
+  is `3600` seconds)
+
+### Changed
+- Bumped `rstudio-auth-proxy` docker image used to `v1.4.2`.
+  This version expires session cookies (after 1 hour by default).
+
+
 ## [1.4.0] - 2018-02-22
 ### Changed
 - Bumped rstudio-auth-proxy docker image used to v1.4.1.

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: RStudio with Auth0 authentication proxy
 name: rstudio
-version: 1.4.0
+version: 1.4.1

--- a/charts/rstudio/README.md
+++ b/charts/rstudio/README.md
@@ -30,4 +30,5 @@ details.
 
 | Parameter  | Description     | Default |
 | ---------- | --------------- | ------- |
-| `username` | Github username | ``      |
+| `username` | Github username | `""`    |
+| `authProxy.cookieMaxAge` | Seconds after which session cookies will expire | `3600` (1 hour) |

--- a/charts/rstudio/templates/deployment.yml
+++ b/charts/rstudio/templates/deployment.yml
@@ -68,6 +68,8 @@ spec:
                 secretKeyRef:
                   name: {{ template "fullname" . }}
                   key: secure_cookie_key
+            - name: COOKIE_MAXAGE
+              value: "{{ .Values.authProxy.cookieMaxAge }}"
             - name: PROXY_TARGET_HOST
               value: localhost
             - name: PROXY_TARGET_PORT

--- a/charts/rstudio/values.yaml
+++ b/charts/rstudio/values.yaml
@@ -9,13 +9,14 @@ authProxy:
     clientSecret: ""
     clientId: ""
     domain: "AUTH0_USER.eu.auth0.com"
+  cookieMaxAge: "3600" # 1 Hour in seconds
   cookieSecret: ""
   express:
     host: "0.0.0.0"
     port: 3000
   image:
     repository: quay.io/mojanalytics/rstudio-auth-proxy
-    tag: "v1.4.1"
+    tag: "v1.4.2"
     pullPolicy: "IfNotPresent"
   resources:
     limits:


### PR DESCRIPTION
Using new version of `rstudio-auth-proxy` (`v1.4.2`) which now
sets session cookies' `Max-Age` to expire session after 1h.

This can be optionally be configured via `authProxy.cookieMaxAge` chart value.

See also: https://github.com/ministryofjustice/analytics-platform-rstudio-auth-proxy/pull/15