### PR TITLE
pip: Package Home

### DIFF
--- a/charts/jupyter-lab/files/pip-user-home.sh
+++ b/charts/jupyter-lab/files/pip-user-home.sh
@@ -1,0 +1,3 @@
+#!/bin/env sh
+
+/bin/grep -q -F 'pipcorn' $HOME/.profile || /bin/echo "alias pip='pipcorn() { if [[ \"\$1\" =~ ^[install]$ ]]; then /opt/conda/bin/pip install --user \"\${@:2}\"; else /opt/conda/bin/pip \"\$@\"; fi }; pipcorn'" >> $HOME/.profile

--- a/charts/jupyter-lab/templates/configmap-bash-profile.yaml
+++ b/charts/jupyter-lab/templates/configmap-bash-profile.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app: {{ .Chart.Name }}
+data:
+{{ (.Files.Glob "files/*").AsConfig | indent 2 }} # Flatten script into yaml map

--- a/charts/jupyter-lab/templates/job-bash-profile.yaml
+++ b/charts/jupyter-lab/templates/job-bash-profile.yaml
@@ -1,0 +1,34 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app: {{ .Chart.Name }}
+spec:
+  template:
+    metadata:
+      name: {{ template "fullname" . }}-job
+    spec:
+      serviceAccountName: {{ .Values.Username }}-jupyter
+      restartPolicy: Never
+      containers:
+        - name: {{ template "fullname" . }}-bash-profile-config
+          image: busybox
+          command: [ "/bin/sh" ]
+          args:
+            - /{{ template "fullname" . }}/pip-user-home.sh
+          volumeMounts:
+            - name: nfs-home
+              mountPath: /root
+            - name: {{ template "fullname" . }}
+              mountPath: /{{ template "fullname" . }}
+      volumes:
+        - name: nfs-home
+          persistentVolumeClaim:
+            claimName: nfs-home
+        - name: {{ template "fullname" . }}
+          configMap:
+            name: {{ template "fullname" . }}
+            defaultMode: 500


### PR DESCRIPTION
Trello: https://trello.com/c/HCdzYjGQ

Adds a shell `alias` to include `--user` flag when running `pip` with
`install` command.

This results in packages being installed to the invoking user's home
directory.  Usually under `$HOME/.local/`.

All other `pip` commands are left as is.