### PR TITLE
Jupyter Ingress Host

### DIFF
--- a/charts/jupyter-lab/templates/ingress.yaml
+++ b/charts/jupyter-lab/templates/ingress.yaml
@@ -10,7 +10,7 @@ metadata:
     kubernetes.io/ingress.class: "nginx"
 spec:
   rules:
-    - host: {{ .Values.Username | lower }}-jupyter.{{ .Values.toolsDomain }}
+    - host: {{ .Values.Username | lower }}-jupyter-lab.{{ .Values.toolsDomain }}
       http:
         paths:
           - path: /


### PR DESCRIPTION
The control panel constructs a URL for an app not based on the the
ingress host. Possibly by chart name.

Modifying ingress host to match behaviour of control panel.