### PR TITLE
cpfrontend 1.3.5: Using /healthz endpoint

### DIFF
--- a/charts/cpfrontend/CHANGELOG.md
+++ b/charts/cpfrontend/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [1.3.5] - 2018-02-14
+### Changed
+Using newly added `/healthz` endpoint instead of the `/login`.
+Since we enabled Silent SSO the `/login` endpoint is not suitable
+as a healtcheck endpoint anymore.
+
+
 ## [1.3.4] - 2018-02-14
 ### Removed
 Removed `APP_PORT` environment variable, it's causing problems with the

--- a/charts/cpfrontend/Chart.yaml
+++ b/charts/cpfrontend/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Analytics Platform Control Panel webapp
 name: cpfrontend
-version: 1.3.4
+version: 1.3.5

--- a/charts/cpfrontend/templates/deployment.yaml
+++ b/charts/cpfrontend/templates/deployment.yaml
@@ -62,7 +62,7 @@ spec:
                   key: tools-domain
           readinessProbe:
             httpGet:
-              path: /login?healthz
+              path: /healthz
               port: http
             initialDelaySeconds: 5
             periodSeconds: 5


### PR DESCRIPTION
This should fix the `503` errors caused by the use of `/login` as
a readiness probe after enabling silent SSO.

Ticket: https://trello.com/c/fPZGrSYt/695-1-add-healtcheck-to-cp-ui