### PR TITLE
kibana-auth-proxy 1.1.0: Proxy to use Auth0 hosted login page

### DIFF
--- a/charts/kibana-auth-proxy/CHANGELOG.md
+++ b/charts/kibana-auth-proxy/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+
+## [1.1.0] - 2018-03-14
+### Changed
+- Fixed proxy version/tag instead of using `latest`
+- Use newly added `/healthz` endpoint for healthcheck
+- Proxy was updated to:
+  - use Auth0 hosted login page instead of local login page
+  - enabled silent SSO enabled
+  - session cookies expire after 1 hour
+  - Other changes, see: https://github.com/ministryofjustice/analytics-platform-kibana-auth-proxy/pull/1

--- a/charts/kibana-auth-proxy/CHANGELOG.md
+++ b/charts/kibana-auth-proxy/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [1.1.1] - 2018-03-16
+### Changed
+- Disable *silent* SSO by using `kibana-auth-proxy` `v1.1.1`
+
+See: https://github.com/ministryofjustice/analytics-platform-kibana-auth-proxy/pull/2
+
+
 ## [1.1.0] - 2018-03-14
 ### Changed
 - Fixed proxy version/tag instead of using `latest`

--- a/charts/kibana-auth-proxy/Chart.yaml
+++ b/charts/kibana-auth-proxy/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: kibana-auth-proxy
-version: 1.0.3
+version: 1.1.0

--- a/charts/kibana-auth-proxy/Chart.yaml
+++ b/charts/kibana-auth-proxy/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: kibana-auth-proxy
-version: 1.1.0
+version: 1.1.1

--- a/charts/kibana-auth-proxy/README.md
+++ b/charts/kibana-auth-proxy/README.md
@@ -1,0 +1,40 @@
+# Kibana Auth Proxy
+
+Authentication layer in front of kibana.
+
+
+## Installing the Chart
+
+To install the chart:
+
+```bash
+helm install mojanalytics/kibana-auth-proxy \
+  --name cluster-logviewer \
+  --namespace kube-system \
+  --set auth.domain=$AUTH_DOMAIN \
+  --set auth.clientID=$AUTH_CLIENT_ID \
+  --set auth.clientSecret=$AUTH_CLIENT_SECRET \
+  --set kibana.url=$KIBANA_URL \
+  --set kibana.admin.username=$KIBANA_ADMIN_USERNAME \
+  --set kibana.admin.password=$KIBANA_ADMIN_PASSWORD \
+  --set kibana.user.username=$KIBANA_USER_USERNAME \
+  --set kibana.user.password=$KIBANA_USER_PASSWORD \
+  --set ingress.host=$INGRESS_HOST \
+```
+
+The proxy will be available at the host specified via `ingress.host` value.
+
+
+## Configuration
+
+| Parameter  | Description     | Default |
+| ---------- | --------------- | ------- |
+| `auth.domain` | Auth0 client domain | `""` |
+| `auth.clientID` | Auth0 client ID | `""` |
+| `auth.clientSecret` | Auth0 client secret | `""` |
+| `kibana.url` | URL where Kibaba is | `"http://localhost/"` |
+| `kibana.admin.username` | Kibana admin username | `""` |
+| `kibana.admin.password` | Kibana admin password | `""` |
+| `kibana.user.username` | Kibana non-admin username | `""` |
+| `kibana.user.password` | Kibana non-admin password | `""` |
+| `ingress.host` | Host where the proxy will be available | `"example.com"` |

--- a/charts/kibana-auth-proxy/templates/deployment.yaml
+++ b/charts/kibana-auth-proxy/templates/deployment.yaml
@@ -19,9 +19,17 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
-        - name: {{ .Values.service.name }}
+        - name: http
           containerPort: {{ .Values.service.internalPort }}
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: http
+          initialDelaySeconds: 5
+          periodSeconds: 5
         env:
+          - name: APP_HOST
+            value: {{ .Values.ingress.host }}
           - name: AUTH0_CLIENT_SECRET
             valueFrom:
               secretKeyRef:

--- a/charts/kibana-auth-proxy/values.yaml
+++ b/charts/kibana-auth-proxy/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 image:
   repository: quay.io/mojanalytics/kibana-auth-proxy
-  tag: "v1.1.0"
+  tag: "v1.1.1"
   pullPolicy: IfNotPresent
 service:
   type: ClusterIP

--- a/charts/kibana-auth-proxy/values.yaml
+++ b/charts/kibana-auth-proxy/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 image:
   repository: quay.io/mojanalytics/kibana-auth-proxy
-  tag: latest
+  tag: "v1.1.0"
   pullPolicy: IfNotPresent
 service:
   type: ClusterIP
@@ -12,7 +12,6 @@ auth:
   clientSecret: ""
   clientID: ""
   domain: ""
-  callbackURL: ""
   cookieSecret: ""
 kibana:
   url: "http://localhost/"


### PR DESCRIPTION
### What
- Fixed proxy version/tag instead of using `latest`
- Use newly added `/healthz` endpoint for healthcheck
- Proxy was updated to:
  - use Auth0 hosted login page instead of local login page
  - enabled silent SSO enabled
  - session cookies expire after 1 hour
  - Other changes, see: https://github.com/ministryofjustice/analytics-platform-kibana-auth-proxy/pull/1

### Ticket
https://trello.com/c/robNgbzG/651-3-update-kibana-auth-proxy-to-use-hosted-auth0-login