### PR TITLE
Prometheus Doc

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -97,7 +97,7 @@ Collects metrics, monitor systems and can send alerts.
 ```bash
 $ helm repo add coreos https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 $ helm install coreos/prometheus-operator --name prometheus-operator --namespace monitoring
-$ helm install coreos/kube-prometheus --name kube-prometheus --set rbacEnable=true --namespace monitoring -f chart-env-config/{env}/prometheus.yml
+$ helm install coreos/kube-prometheus --name kube-prometheus --namespace monitoring -f analytics-platform-config/chart-env-config/{env}/prometheus.yml
 ```
 #### Note
 `prometheus.yml` file can be found [here](https://github.com/ministryofjustice/analytics-platform-config/tree/master/chart-env-config)


### PR DESCRIPTION
Adding path for clarity.

Upstream [PR](https://github.com/coreos/prometheus-operator/pull/917) means we do not have to set rbac anymore as it is now true by default.
