### PR TITLE
kibana-auth-proxy: Fixed redirect loop caused by ingress annotation

### DIFF
--- a/charts/kibana-auth-proxy/CHANGELOG.md
+++ b/charts/kibana-auth-proxy/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [1.1.2] - 2018-03-19
+### Fixed
+- Fixed redirect loop caused by `nginx.ingress.kubernetes.io/force-ssl-redirect`
+annotation on ingress resource
+
+
 ## [1.1.1] - 2018-03-16
 ### Changed
 - Disable *silent* SSO by using `kibana-auth-proxy` `v1.1.1`

--- a/charts/kibana-auth-proxy/Chart.yaml
+++ b/charts/kibana-auth-proxy/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: kibana-auth-proxy
-version: 1.1.1
+version: 1.1.2

--- a/charts/kibana-auth-proxy/templates/ingress.yaml
+++ b/charts/kibana-auth-proxy/templates/ingress.yaml
@@ -7,7 +7,6 @@ metadata:
     app: {{ template "fullname" . }}
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
 spec:
   rules:
   - host: "{{ .Values.ingress.host }}"


### PR DESCRIPTION
Ingress resource doesn't need the following annotation anymore

    nginx.ingress.kubernetes.io/force-ssl-redirect: true

Bumped chart to version `1.1.2`