### PR TITLE
webapp 1.3.7: Fixed proxy healthcheck

### DIFF
--- a/charts/webapp/CHANGELOG.md
+++ b/charts/webapp/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [1.3.7] - 2018-03-23
+### Changed
+- Use [auth-proxy `v0.1.2`](https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v0.1.2) which fixes
+  a syntax error and adds a proper healthcheck endpoint
+- Use `/healthz` endpoint added by above version of auth-proxy
+
+
 ## [1.2.0] - 2017-08-31
 ### Added
 - webapps can assume an IAM role passed via `AWS.IAMRole` value, see README

--- a/charts/webapp/Chart.yaml
+++ b/charts/webapp/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: webapp Helm chart for Kubernetes
 name: webapp
-version: 1.3.6
+version: 1.3.7

--- a/charts/webapp/templates/deployment.yaml
+++ b/charts/webapp/templates/deployment.yaml
@@ -63,7 +63,7 @@ spec:
               value: "3000"
           readinessProbe:
             httpGet:
-              path: /login?healthz
+              path: /healthz
               port: http
             initialDelaySeconds: 5
             periodSeconds: 5

--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -21,7 +21,7 @@ AuthProxy:
     Domain: "AUTH0_USER.eu.auth0.com"
   Image:
     Repository: quay.io/mojanalytics/auth-proxy
-    Tag: "v0.0.2"
+    Tag: "v0.1.2"
     PullPolicy: "IfNotPresent"
 AWS:
   IAMRole: ""


### PR DESCRIPTION
Some deployed apps (shiny apps specifically) broke because somehow
they were using `latest` as proxy tag. Not sure why (probably they
were installed before we pinned the version)

Their healthcheck was also broken because they were hitting `/login`
as a surrogate healthcheck test. We're now using the `/healthz`
endpoint introduced by `auth-proxy-v0.1.2`.