### PR TITLE
FluentD Fork

### DIFF
--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -30,8 +30,8 @@ AWS:
   DefaultRegion: "eu-west-1"
 Fluentd:
   Image:
-    Repository: fluent/fluentd-kubernetes-daemonset
-    Tag: stable-elasticsearch
+    Repository: quay.io/mojanalytics/fluentd
+    Tag: tempFork
     PullPolicy: "IfNotPresent"
 Elasticsearch:
   Scheme: "http"


### PR DESCRIPTION
After upgrading K8s to 1.8.9 we fell victim to https://github.com/kubernetes/kubernetes/pull/58720

Ideally the fluentd container should source values from env vars instead
of writing themto a config file. See: [entryPoint](https://github.com/fluent/fluentd-kubernetes-daemonset/blob/master/docker-image/v0.12/debian-elasticsearch/entrypoint.sh)

The `set -e` does not help either.

**Deployed** in alpha