### PR TITLE
FluentD Temp Fork

### DIFF
--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -1,6 +1,6 @@
 image:
-  repository: fluent/fluentd-kubernetes-daemonset
-  tag: "stable-elasticsearch"
+  repository: quay.io/mojanalytics/fluentd # Temporary until we can get upstream working again See: https://github.com/ministryofjustice/analytics-platform-helm-charts/pull/127
+  tag: tempFork
   pullPolicy: Always
 elasticsearch:
   host: elasticsearch-logging
@@ -12,10 +12,10 @@ elasticsearch:
 resources:
   limits:
     cpu: 100m
-    memory: 256Mi
+    memory: 1Gi
   requests:
     cpu: 100m
-    memory: 256Mi
+    memory: 512Mi
 fluentdconffiles:
   kubernetes.conf: |
     <match fluent.**>


### PR DESCRIPTION
Trello: https://trello.com/c/W5NVPEQ0

After upgrading K8s to 1.8.9 we fell victim to
https://github.com/kubernetes/kubernetes/pull/58720

Ideally the fluentd container should source values from env vars instead
of writing them to a config file. See:
[entryPoint](https://github.com/fluent/fluentd-kubernetes-daemonset/blob/master/docker-image/v0.12/debian-elasticsearch/entrypoint.sh)

The `set -e` does not help either.

The resource change adresses the logs mentioned in the [trello](https://trello.com/c/W5NVPEQ0) ticket.

Upstream Ref: https://github.com/kubernetes/kubernetes/pull/48970

Ruby (Particularly in Alpha) is throwing OOM events as it exceeds it's
limits of 256MB and sometimes spikes well above.  When this occurs the
Kubelet daemon kills the pod and recreates it (As it is supposed to).
However, this event happens so often that the `kubelet` and `docker`
daemon are not able to keep up with clearing up the network sanbox and this
causes CNI errors to occur.

**Deployed** in alpha and dev