### PR TITLE
rstudio 1.4.2: Sessions last 8 hours

### DIFF
--- a/charts/rstudio/CHANGELOG.md
+++ b/charts/rstudio/CHANGELOG.md
@@ -5,6 +5,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [1.4.2] - 2018-04-10
+### Changed
+- Cookie session lasts 8h instead of 1h (`COOKIE_MAXAGE` environment
+variable).
+  The reason is because RStudio is not making new HTTP requests and therefore
+  not triggering the silent re-logging for users keeping RStudio open for
+  more than 1h.
+
+
 ## [1.4.1] - 2018-02-28
 ### Added
 - sets `COOKIE_MAXAGE` variable in auth proxy to expire session cookies after

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: RStudio with Auth0 authentication proxy
 name: rstudio
-version: 1.4.1
+version: 1.4.2

--- a/charts/rstudio/values.yaml
+++ b/charts/rstudio/values.yaml
@@ -9,7 +9,7 @@ authProxy:
     clientSecret: ""
     clientId: ""
     domain: "AUTH0_USER.eu.auth0.com"
-  cookieMaxAge: "3600" # 1 Hour in seconds
+  cookieMaxAge: "28800" # 8 hours in seconds
   cookieSecret: ""
   express:
     host: "0.0.0.0"


### PR DESCRIPTION
### What
Users get a `unable to establish a connection with the R session` when
trying to interact with RStudio console once session expired.

### Why
The RStudio auth-proxy session cookies expired after 1h but as users keep
they RStudio tab open for longer and because of how RStudio works (it's
essentially a single page app not making new HTTP requests).

### Solution
Session now lasts 8 hours.

### Ticket
https://trello.com/c/CP1tWlzK/726-2-rstudio-unable-to-establish-a-connection-with-the-r-session-every-hour