### PR TITLE
 Jupyter Auth0 CallBack URL

### DIFF
--- a/charts/jupyter-lab/CHANGELOG.md
+++ b/charts/jupyter-lab/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] - 2018-04-10
+## Jupyter Auth0 CallBack URL
+-  Fixing auth proxy callback envvar to point to the correct endpoint
+
 ## [0.1.1] - 2018-02-15
 ## Image Tag 
 - Modifying Image tag to point to latest image

--- a/charts/jupyter-lab/Chart.yaml
+++ b/charts/jupyter-lab/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Jupyter Lab with Auth0 authentication proxy
 name: jupyter-lab
-version: 0.1.1
+version: 0.1.2

--- a/charts/jupyter-lab/templates/secrets.yaml
+++ b/charts/jupyter-lab/templates/secrets.yaml
@@ -11,5 +11,5 @@ data:
   auth0_domain: {{ .Values.authProxy.auth0_domain | b64enc | quote }}
   auth0_client_id: {{ .Values.authProxy.auth0_client_id | b64enc | quote }}
   auth0_client_secret: {{ .Values.authProxy.auth0_client_secret | b64enc | quote }}
-  auth0_callback_url: {{ printf "https://%s-jupyter.%s/callback" .Values.Username .Values.toolsDomain | lower | b64enc | quote }}
+  auth0_callback_url: {{ printf "https://%s-%s.%s/callback" .Values.Username .Chart.Name .Values.toolsDomain | lower | b64enc | quote }}
   cookie_secret: {{ .Values.cookie_secret | b64enc | quote }}


### PR DESCRIPTION
Fixing auth proxy callback envvar to point to the correct endpoint.

Currently callback url has just `jupyter` instead of `jupyter-lab`
causing users to be redirected to default backend.