### PR TITLE
Add RStudio migration which increses session expiration to 8h

### DIFF
--- a/charts/rstudio/.helmignore
+++ b/charts/rstudio/.helmignore
@@ -19,3 +19,5 @@
 .project
 .idea/
 *.tmproj
+# Don't add migrations to tarballs
+migrations/

--- a/charts/rstudio/migrations/20180411-1155_increase_cookie_maxage.sh
+++ b/charts/rstudio/migrations/20180411-1155_increase_cookie_maxage.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# Increses RStudio session lifespan to 8 hours
+#
+# For each of the user namespaces (`user-*`), set `COOKIE_MAXAGE=28800`
+# on each of the `rstudio-auth-proxy` containers for RStudio (selected using
+# `app=rstudio` label)
+
+
+set -ex
+
+[[ -z "${DRYRUN}" ]] && DRYRUN='false'
+
+COOKIE_MAXAGE=28800
+
+
+NAMESPACES=`kubectl get ns | grep user- | cut -f1 -d' '`
+
+for NAMESPACE in $NAMESPACES; do
+  kubectl set env deployment --dry-run=${DRYRUN} \
+    --namespace=${NAMESPACE} \
+    --selector=app=rstudio --containers="rstudio-auth-proxy" \
+    COOKIE_MAXAGE=${COOKIE_MAXAGE}
+done


### PR DESCRIPTION
### What
The migration script will set `COOKIE_MAXAGE=28800` on each of the
`rstudio-auth-proxy` containers for deployments matching the label
`app=rstudio` in each of the namespaces starting with `user-*`.

You caThe script has also a `DRYRUN` "o"

### How to use it

- Be sure you're pointing to the right k8s cluster (I strongly advice to
point to `dev` cluster before playing with it)
- Be sure the script is executable

```bash
./charts/rstudio/migrations/20180411-1155_increase_cookie_maxage.sh
```

The script also has a `DRYRUN` option which is useful to see what the effect
of the changes will be without actually making changes:

```bash
DRYRUN=true ./charts/rstudio/migrations/20180411-1155_increase_cookie_maxage.sh
```

### Related
This will retro-apply change added in [`rstudio-1.4.2`](https://github.com/ministryofjustice/analytics-platform-helm-charts/pull/131).

### Ticket
https://trello.com/c/CP1tWlzK/726-2-rstudio-unable-to-establish-a-connection-with-the-r-session-every-hour