### PR TITLE
Add chart for setting up Concourse pipeline for a Github org

### DIFF
--- a/charts/concourse-org-pipeline/Chart.yaml
+++ b/charts/concourse-org-pipeline/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Concourse pipeline for creating deployment pipelines for Github org repos
 name: concourse-org-pipeline
-version: 0.1.0
+version: 0.1.1

--- a/charts/concourse-org-pipeline/Chart.yaml
+++ b/charts/concourse-org-pipeline/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: Concourse pipeline for creating deployment pipelines for Github org repos
+name: concourse-org-pipeline
+version: 0.1.0

--- a/charts/concourse-org-pipeline/files/pipeline.yaml
+++ b/charts/concourse-org-pipeline/files/pipeline.yaml
@@ -11,14 +11,11 @@ resources:
   type: github-org
   source:
     name: ((github-org))
+    team_name: ((team_name))
+    concourse_url: ((concourse_url))
+    username: ((fly.username))
+    password: ((fly.password))
     access_token: ((github-access-token))
-    concourse_url: ((concourse-url))
-    username: ((fly-username))
-    password: ((fly-password))
-    team_name: ((concourse-team))
-    cookie-secret: ((cookie-secret))
-    cluster-ca: ((kubernetes-ca-cert))
-    token: ((kubernetes-token))
   webhook_token: ((github-webhook-token))
 
 resource_types:

--- a/charts/concourse-org-pipeline/files/pipeline.yaml
+++ b/charts/concourse-org-pipeline/files/pipeline.yaml
@@ -1,0 +1,29 @@
+---
+jobs:
+- name: update-org-pipelines
+  plan:
+  - get: org
+    trigger: true
+  - put: org
+
+resources:
+- name: org
+  type: github-org
+  source:
+    name: ((github-org))
+    access_token: ((github-access-token))
+    concourse_url: ((concourse-url))
+    username: ((fly-username))
+    password: ((fly-password))
+    team_name: ((concourse-team))
+    cookie-secret: ((cookie-secret))
+    cluster-ca: ((kubernetes-ca-cert))
+    token: ((kubernetes-token))
+  webhook_token: ((github-webhook-token))
+
+resource_types:
+- name: github-org
+  type: docker-image
+  source:
+    repository: ((github-org-resource-image))
+    tag: ((github-org-resource-tag))

--- a/charts/concourse-org-pipeline/files/set-pipeline.sh
+++ b/charts/concourse-org-pipeline/files/set-pipeline.sh
@@ -18,8 +18,10 @@ fly -t default set-pipeline \
     -v concourse-url=$CONCOURSE_URL \
     -v fly-username=$FLY_USERNAME \
     -v fly-password=$FLY_PASSWORD \
+    -v github-access-token=$GITHUB_ACCESS_TOKEN \
     -v github-org=$1 \
     -v github-org-resource-image=$GITHUB_ORG_RESOURCE_IMAGE \
     -v github-org-resource-tag=$GITHUB_ORG_RESOURCE_TAG \
+    -v github-webhook-token=$GITHUB_WEBHOOK_TOKEN \
     -v kubernetes-ca-cert=$KUBERNETES_CA_CERT \
     -v kubernetes-token=$KUBERNETES_TOKEN

--- a/charts/concourse-org-pipeline/files/set-pipeline.sh
+++ b/charts/concourse-org-pipeline/files/set-pipeline.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+curl -o /usr/local/bin/fly "$CONCOURSE_URL/api/v1/cli?arch=amd64&platform=linux"
+
+chmod +x /usr/local/bin/fly
+
+fly -t default login \
+    -c $CONCOURSE_URL \
+    -u $FLY_USERNAME \
+    -p $FLY_PASSWORD \
+    -n $CONCOURSE_TEAM
+
+fly -t default set-pipeline \
+    -n $CONCOURSE_TEAM \
+    -p $1 \
+    -c /scripts/pipeline.yaml \
+    -v concourse-team=$CONCOURSE_TEAM \
+    -v concourse-url=$CONCOURSE_URL \
+    -v fly-username=$FLY_USERNAME \
+    -v fly-password=$FLY_PASSWORD \
+    -v github-org=$1 \
+    -v github-org-resource-image=$GITHUB_ORG_RESOURCE_IMAGE \
+    -v github-org-resource-tag=$GITHUB_ORG_RESOURCE_TAG \
+    -v kubernetes-ca-cert=$KUBERNETES_CA_CERT \
+    -v kubernetes-token=$KUBERNETES_TOKEN

--- a/charts/concourse-org-pipeline/files/set-pipeline.sh
+++ b/charts/concourse-org-pipeline/files/set-pipeline.sh
@@ -14,14 +14,10 @@ fly -t default set-pipeline \
     -n $CONCOURSE_TEAM \
     -p $1 \
     -c /scripts/pipeline.yaml \
-    -v concourse-team=$CONCOURSE_TEAM \
-    -v concourse-url=$CONCOURSE_URL \
-    -v fly-username=$FLY_USERNAME \
-    -v fly-password=$FLY_PASSWORD \
+    -v team_name=$CONCOURSE_TEAM \
+    -v concourse_url=$CONCOURSE_URL \
     -v github-access-token=$GITHUB_ACCESS_TOKEN \
     -v github-org=$1 \
     -v github-org-resource-image=$GITHUB_ORG_RESOURCE_IMAGE \
     -v github-org-resource-tag=$GITHUB_ORG_RESOURCE_TAG \
-    -v github-webhook-token=$GITHUB_WEBHOOK_TOKEN \
-    -v kubernetes-ca-cert=$KUBERNETES_CA_CERT \
-    -v kubernetes-token=$KUBERNETES_TOKEN
+    -v github-webhook-token=$GITHUB_WEBHOOK_TOKEN

--- a/charts/concourse-org-pipeline/templates/configmap.yaml
+++ b/charts/concourse-org-pipeline/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: scripts
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+data:
+{{ (.Files.Glob "files/*").AsConfig | indent 2 }}

--- a/charts/concourse-org-pipeline/templates/configmap.yaml
+++ b/charts/concourse-org-pipeline/templates/configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: scripts
-  namespace: {{ .Release.Namespace }}
+  namespace: concourse-{{ .Values.concourse.team }}
   labels:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
 data:

--- a/charts/concourse-org-pipeline/templates/job.yaml
+++ b/charts/concourse-org-pipeline/templates/job.yaml
@@ -2,6 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: org-pipeline-{{ .Values.github.org }}
+  namespace: concourse-{{ .Values.concourse.team }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
 spec:
@@ -21,17 +22,17 @@ spec:
           - name: FLY_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: org-pipeline-{{ .Values.github.org }}
-                key: fly-password
+                name: fly
+                key: password
           - name: FLY_USERNAME
             valueFrom:
               secretKeyRef:
-                name: org-pipeline-{{ .Values.github.org }}
-                key: fly-username
+                name: fly
+                key: username
           - name: GITHUB_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
-                name: org-pipeline-{{ .Values.github.org }}
+                name: secrets
                 key: github-access-token
           - name: GITHUB_ORG_RESOURCE_IMAGE
             value: {{ .Values.githubOrgResource.image }}
@@ -40,18 +41,8 @@ spec:
           - name: GITHUB_WEBHOOK_TOKEN
             valueFrom:
               secretKeyRef:
-                name: org-pipeline-{{ .Values.github.org }}
+                name: secrets
                 key: github-webhook-token
-          - name: KUBERNETES_CA_CERT
-            valueFrom:
-              secretKeyRef:
-                name: org-pipeline-{{ .Values.github.org }}
-                key: kubernetes-ca-cert
-          - name: KUBERNETES_TOKEN
-            valueFrom:
-              secretKeyRef:
-                name: org-pipeline-{{ .Values.github.org }}
-                key: kubernetes-token
         command: [ "/bin/sh" ]
         args:
           - /scripts/set-pipeline.sh

--- a/charts/concourse-org-pipeline/templates/job.yaml
+++ b/charts/concourse-org-pipeline/templates/job.yaml
@@ -28,10 +28,20 @@ spec:
               secretKeyRef:
                 name: org-pipeline-{{ .Values.github.org }}
                 key: fly-username
+          - name: GITHUB_ACCESS_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: org-pipeline-{{ .Values.github.org }}
+                key: github-access-token
           - name: GITHUB_ORG_RESOURCE_IMAGE
             value: {{ .Values.githubOrgResource.image }}
           - name: GITHUB_ORG_RESOURCE_TAG
             value: {{ .Values.githubOrgResource.tag }}
+          - name: GITHUB_WEBHOOK_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: org-pipeline-{{ .Values.github.org }}
+                key: github-webhook-token
           - name: KUBERNETES_CA_CERT
             valueFrom:
               secretKeyRef:

--- a/charts/concourse-org-pipeline/templates/job.yaml
+++ b/charts/concourse-org-pipeline/templates/job.yaml
@@ -1,0 +1,57 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: org-pipeline-{{ .Values.github.org }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+spec:
+  template:
+    metadata:
+      name: set-pipeline
+    spec:
+      containers:
+      - name: set-pipeline
+        image: appropriate/curl:3.1
+        imagePullPolicy: IfNotPresent
+        env:
+          - name: CONCOURSE_TEAM
+            value: {{ .Values.concourse.team }}
+          - name: CONCOURSE_URL
+            value: {{ .Values.concourse.externalURL }}
+          - name: FLY_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: org-pipeline-{{ .Values.github.org }}
+                key: fly-password
+          - name: FLY_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: org-pipeline-{{ .Values.github.org }}
+                key: fly-username
+          - name: GITHUB_ORG_RESOURCE_IMAGE
+            value: {{ .Values.githubOrgResource.image }}
+          - name: GITHUB_ORG_RESOURCE_TAG
+            value: {{ .Values.githubOrgResource.tag }}
+          - name: KUBERNETES_CA_CERT
+            valueFrom:
+              secretKeyRef:
+                name: org-pipeline-{{ .Values.github.org }}
+                key: kubernetes-ca-cert
+          - name: KUBERNETES_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: org-pipeline-{{ .Values.github.org }}
+                key: kubernetes-token
+        command: [ "/bin/sh" ]
+        args:
+          - /scripts/set-pipeline.sh
+          - {{ .Values.github.org }}
+        volumeMounts:
+          - name: scripts
+            mountPath: /scripts
+      restartPolicy: Never
+      volumes:
+      - name: scripts
+        configMap:
+          name: scripts
+          defaultMode: 500

--- a/charts/concourse-org-pipeline/templates/secrets.yaml
+++ b/charts/concourse-org-pipeline/templates/secrets.yaml
@@ -1,14 +1,37 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: org-pipeline-{{ .Values.github.org }}
+  name: secrets
+  namespace: concourse-{{ .Values.concourse.team }}
   labels:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
 type: Opaque
 data:
-  fly-password: {{ .Values.concourse.password | b64enc | quote }}
-  fly-username: {{ .Values.concourse.username | b64enc | quote }}
+  app-domain: {{ .Values.appDomain | b64enc | quote }}
+  auth0-authz-audience: {{ .Values.auth0.authzAudience | b64enc | quote }}
+  auth0-authz-url: {{ .Values.auth0.authzUrl | b64enc | quote }}
+  auth0-client-id: {{ .Values.auth0.clientId | b64enc | quote }}
+  auth0-client-secret: {{ .Values.auth0.clientSecret | b64enc | quote }}
+  auth0-domain: {{ .Values.auth0.domain | b64enc | quote }}
+  aws-region: {{ .Values.aws.region | b64enc | quote }}
+  cookie-secret: {{ .Values.cookieSecret | b64enc | quote }}
+  ecr-access-key-id: {{ .Values.aws.ecrAccessKeyId | b64enc | quote }}
+  ecr-secret-access-key: {{ .Values.aws.ecrSecretAccessKey | b64enc | quote }}
   github-access-token: {{ .Values.github.accessToken | b64enc | quote }}
   github-webhook-token: {{ .Values.github.webhookToken | b64enc | quote }}
+  kubernetes-api-url: {{ .Values.kubernetes.apiUrl | b64enc | quote }}
   kubernetes-ca-cert: {{ .Values.kubernetes.caCert | b64enc | quote }}
   kubernetes-token: {{ .Values.kubernetes.token | b64enc | quote }}
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: fly
+  namespace: concourse-{{ .Values.concourse.team }}
+  labels:
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+type: Opaque
+data:
+  password: {{ .Values.concourse.password | b64enc | quote }}
+  username: {{ .Values.concourse.username | b64enc | quote }}

--- a/charts/concourse-org-pipeline/templates/secrets.yaml
+++ b/charts/concourse-org-pipeline/templates/secrets.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: org-pipeline-{{ .Values.github.org }}
+  labels:
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+type: Opaque
+data:
+  fly-password: {{ .Values.concourse.password | b64enc | quote }}
+  fly-username: {{ .Values.concourse.username | b64enc | quote }}
+  github-access-token: {{ .Values.github.accessToken | b64enc | quote }}
+  github-webhook-token: {{ .Values.github.webhookToken | b64enc | quote }}
+  kubernetes-ca-cert: {{ .Values.kubernetes.caCert | b64enc | quote }}
+  kubernetes-token: {{ .Values.kubernetes.token | b64enc | quote }}

--- a/charts/concourse-org-pipeline/values.yaml
+++ b/charts/concourse-org-pipeline/values.yaml
@@ -1,7 +1,22 @@
+appDomain: ""
+
+# Auth0 client credentials for accessing the Auth0 Management API
+auth0:
+  authzAudience: ""
+  authzUrl: ""
+  clientId: ""
+  clientSecret: ""
+  domain: ""
+
+aws:
+  ecrAccessKeyId: ""
+  ecrSecretAccessKey: ""
+  region: "eu-west-1"
+
 concourse:
+  # externalURL is the same value as for the concourse helm chart
   externalURL: ""
   password: ""
-  secretsName: ""
   team: main
   username: ""
 
@@ -14,8 +29,9 @@ github:
 
 githubOrgResource:
   image: quay.io/mojanalytics/github-org-resource
-  tag: v0.3.3
+  tag: v0.3.4
 
 kubernetes:
+  apiUrl: ""
   caCert: ""
   token: ""

--- a/charts/concourse-org-pipeline/values.yaml
+++ b/charts/concourse-org-pipeline/values.yaml
@@ -1,0 +1,21 @@
+concourse:
+  externalURL: ""
+  password: ""
+  secretsName: ""
+  team: main
+  username: ""
+
+cookieSecret: ""
+
+github:
+  org: moj-analytical-services
+  accessToken: ""
+  webhookToken: ""
+
+githubOrgResource:
+  image: quay.io/mojanalytics/github-org-resource
+  tag: v0.3.3
+
+kubernetes:
+  caCert: ""
+  token: ""


### PR DESCRIPTION
* Runs a Kubernetes Job, in which a script sets a Concourse pipeline for a specified Github org, which scans the org repos for build files (currently `Jenkinsfile`, but soon to change) and creates a deploy pipeline for those repos.