### PR TITLE
idler 0.2.1: Fix idling of used RStudio instances

### DIFF
--- a/charts/idler/CHANGELOG.md
+++ b/charts/idler/CHANGELOG.md
@@ -5,6 +5,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [0.2.1] - 2018-04-20
+### Fixed
+- Fixes idler incorrectly idling RStudio instances using more CPU
+  than the threshold (`RSTUDIO_ACTIVIY_CPU_THRESHOLD`).
+  See [PR with fix](https://github.com/ministryofjustice/analytics-platform-idler/pull/8)
+- Don't use `latest` as idler image tag as it's not predictable
+
+
+
 ## [0.2.0] - 2018-03-16
 ### Changed
 - Add env var `RSTUDIO_ACTIVIY_CPU_THRESHOLD` to configure what counts as an

--- a/charts/idler/Chart.yaml
+++ b/charts/idler/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: idler cronjob
 name: idler
-version: 0.2.0
+version: 0.2.1

--- a/charts/idler/README.md
+++ b/charts/idler/README.md
@@ -12,6 +12,14 @@ over the last minute (ie: it is active).
 ```bash
 helm install mojanalytics/idler \
   --name idler \
+  --namespace default
+```
+
+You can optionally override some of the values, e.g.
+
+```bash
+helm install mojanalytics/idler \
+  --name idler \
   --namespace default \
   --set schedule=$SCHEDULE \
   --set labelSelector=$LABEL_SELECTOR \

--- a/charts/idler/values.yaml
+++ b/charts/idler/values.yaml
@@ -1,5 +1,5 @@
 # Docker image version
-image: quay.io/mojanalytics/idler:latest
+image: quay.io/mojanalytics/idler:v0.2.1
 
 # Schedule when to run
 #   min    hour   day    month (Sun-Sat)


### PR DESCRIPTION
Fixes a bug causing the idler to idle RStudio instances even if their
CPU usage is above the threashold.

Related PR
========

https://github.com/ministryofjustice/analytics-platform-idler/pull/8

Ticket
====

https://trello.com/c/jgHhwqcF/736-fix-bug-with-hibernations-idling-so-that-users-can-run-jobs-overnight