### PR TITLE
Improve logic of script which updates helm chart repository

### DIFF
--- a/update-packages
+++ b/update-packages
@@ -11,17 +11,16 @@ function commit_time {
 
 REPO_URL=https://ministryofjustice.github.io/analytics-platform-helm-charts/charts/
 CHARTS=$(find charts/* -type d -maxdepth 0)
-LAST_UPDATED=$(commit_time charts/index.yaml)
 UPDATED=n
 
 for CHART in $CHARTS; do
-
-    if [ $(commit_time $CHART) -gt $LAST_UPDATED ]; then
+    LAST_UPDATED_CHART_CODE=$(commit_time $CHART)
+    LAST_UPDATED_CHART_PACKAGE=$(commit_time "$CHART-*")
+    if [ $LAST_UPDATED_CHART_CODE -gt $LAST_UPDATED_CHART_PACKAGE ]; then
         echo "Packaging $CHART"
         helm package -d charts $CHART
         UPDATED=y
     fi
-
 done
 
 if [ $UPDATED == 'y' ]; then
@@ -36,5 +35,4 @@ if [ $UPDATED == 'y' ]; then
 
 else
     echo "No updates"
-
 fi


### PR DESCRIPTION
Old logic/problem
=================

The existing logic to determine if a package for an helm chart
needed update was comparing the time of the last commit for the
helm chart with the time of the last commit of the index file.

This was mostly working but not always. It wasn't updating an helm
chart package when another PR was merged before.
In this case the index was rebuilt and therefore commits older than
this time were not causing the re-build of the index/packages.

New logic
=========

I've tweaked the `update-packages` script to compare the time when
the chart code was last updated with the time one of the chart's tarballs
was last updated.

This means that each chart package is treated independently and the risk
of non-update is limited.

Caveat (spelled right this time)
================================

Potentially non-updates are still possible if there are multiple PRs for
the same helm chart. This is obviously less likely.