### PR TITLE
Add env vars for clank to access auth0

### DIFF
--- a/charts/hubot/templates/deployment.yaml
+++ b/charts/hubot/templates/deployment.yaml
@@ -21,6 +21,31 @@ spec:
             - name: http
               containerPort: 8080
           env:
+            - name: AUTH0_AUTHZ_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "fullname" . }}
+                  key: auth0-authz-audience
+            - name: AUTH0_AUTHZ_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "fullname" . }}
+                  key: auth0-authz-url
+            - name: AUTH0_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "fullname" . }}
+                  key: auth0-client-id
+            - name: AUTH0_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "fullname" . }}
+                  key: auth0-client-secret
+            - name: AUTH0_DOMAIN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "fullname" . }}
+                  key: auth0-domain
             - name: HUBOT_SLACK_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/charts/hubot/templates/secrets.yaml
+++ b/charts/hubot/templates/secrets.yaml
@@ -7,4 +7,9 @@ metadata:
     app: {{ template "fullname" . }}
 type: Opaque
 data:
+  auth0-authz-audience: {{ .Values.env.AUTH0_AUTHZ_AUDIENCE | b64enc | quote }}
+  auth0-authz-url: {{ .Values.env.AUTH0_AUTHZ_URL | b64enc | quote }}
+  auth0-client-id: {{ .Values.env.AUTH0_CLIENT_ID | b64enc | quote }}
+  auth0-client-secret: {{ .Values.env.AUTH0_CLIENT_SECRET | b64enc | quote }}
+  auth0-domain: {{ .Values.env.AUTH0_DOMAIN | b64enc | quote }}
   slack_token: {{ .Values.SlackToken | b64enc | quote }}

--- a/charts/hubot/values.yaml
+++ b/charts/hubot/values.yaml
@@ -7,3 +7,9 @@ Image:
   Repository: ""
   Tag: ":latest"
   PullPolicy: Always
+env:
+  AUTH0_AUTHZ_AUDIENCE: ""
+  AUTH0_AUTHZ_URL: ""
+  AUTH0_CLIENT_ID: ""
+  AUTH0_CLIENT_SECRET: ""
+  AUTH0_DOMAIN: ""


### PR DESCRIPTION
* Add Auth0 management and authorization API connection details to Clank's environment as Helm secrets, so that he can do Auth0 chatops commands.