### PR TITLE
idler-0.2.3 - various fixes to docker image/permissions/logging

### DIFF
--- a/charts/idler/CHANGELOG.md
+++ b/charts/idler/CHANGELOG.md
@@ -5,13 +5,28 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [0.2.3] - 2018-04-25
+### Fixed
+- Added permissions required to list pods and pods' metrics
+- Fixes logging
+
+### Changed
+- Better handling of unhealthy pods (missing metrics data)
+- See [related PR](https://github.com/ministryofjustice/analytics-platform-idler/pull/10)
+
+
+## [0.2.2] - 2018-04-25
+### Fixed
+- Fixes Docker image missing `metrics_api` package
+- See [PR](https://github.com/ministryofjustice/analytics-platform-idler/pull/9)
+
+
 ## [0.2.1] - 2018-04-20
 ### Fixed
 - Fixes idler incorrectly idling RStudio instances using more CPU
   than the threshold (`RSTUDIO_ACTIVIY_CPU_THRESHOLD`).
   See [PR with fix](https://github.com/ministryofjustice/analytics-platform-idler/pull/8)
 - Don't use `latest` as idler image tag as it's not predictable
-
 
 
 ## [0.2.0] - 2018-03-16

--- a/charts/idler/Chart.yaml
+++ b/charts/idler/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: idler cronjob
 name: idler
-version: 0.2.1
+version: 0.2.3

--- a/charts/idler/templates/clusterrole.yaml
+++ b/charts/idler/templates/clusterrole.yaml
@@ -9,10 +9,14 @@ rules:
     resources: ["deployments"]
     verbs: ["list", "patch"]
 
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["list"]
+
   - apiGroups: ["extensions"]
     resources: ["ingresses"]
     verbs: ["list", "patch"]
 
-  - apiGroups: ["metrics"]
+  - apiGroups: ["metrics.k8s.io"]
     resources: ["pods"]
     verbs: ["list"]

--- a/charts/idler/values.yaml
+++ b/charts/idler/values.yaml
@@ -1,5 +1,5 @@
 # Docker image version
-image: quay.io/mojanalytics/idler:v0.2.1
+image: quay.io/mojanalytics/idler:v0.2.3
 
 # Schedule when to run
 #   min    hour   day    month (Sun-Sat)


### PR DESCRIPTION
- Better handling of unhealthy pods (missing metrics data)
- Fixes logging
- Added required to list pods and pods' metrics

(plus the fix to the missing `metrics_api` file in Docker image)