### PR TITLE
idler-0.2.4 - Added value to easily change log level

### DIFF
--- a/charts/idler/CHANGELOG.md
+++ b/charts/idler/CHANGELOG.md
@@ -5,6 +5,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [0.2.4] - 2018-04-27
+### Changed
+- Using a new version of idler (`v0.2.4`) with more debug logging: https://github.com/ministryofjustice/analytics-platform-idler/pull/11
+
+### Added
+- Added `logLevel` value and setting `LOG_LEVEL` in the job
+
+
 ## [0.2.3] - 2018-04-25
 ### Fixed
 - Added permissions required to list pods and pods' metrics

--- a/charts/idler/Chart.yaml
+++ b/charts/idler/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: idler cronjob
 name: idler
-version: 0.2.3
+version: 0.2.4

--- a/charts/idler/README.md
+++ b/charts/idler/README.md
@@ -31,6 +31,8 @@ helm install mojanalytics/idler \
 
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
-| `schedule` | Cron format string defining time and frequency of runs | `0 22 * * *` (every day at 22:00) |
-| `labelSelector` | Kubernetes label selector for deployments to consider for idling | `app=rstudio` |
 | `cpuActivityThreshold` | Percentage of CPU usage to consider an "active" deployment which should not be idled | 10 |
+| `labelSelector` | Kubernetes label selector for deployments to consider for idling | `app=rstudio` |
+| `logLevel` | Log level. See [Python 3 log levels](https://docs.python.org/3/library/logging.html#levels) for valid values | `INFO` |
+| `schedule` | Cron format string defining time and frequency of runs | `0 22 * * *` (every day at 22:00) |
+

--- a/charts/idler/templates/cronjob.yaml
+++ b/charts/idler/templates/cronjob.yaml
@@ -18,6 +18,8 @@ spec:
           - name: {{ .Release.Name }}
             image: "{{ .Values.image }}"
             env:
+            - name: LOG_LEVEL
+              value: '{{ .Values.logLevel }}'
             - name: LABEL_SELECTOR
               value: '{{ .Values.labelSelector }}'
             - name: RSTUDIO_ACTIVITY_CPU_THRESHOLD

--- a/charts/idler/values.yaml
+++ b/charts/idler/values.yaml
@@ -1,5 +1,5 @@
 # Docker image version
-image: quay.io/mojanalytics/idler:v0.2.3
+image: quay.io/mojanalytics/idler:v0.2.4
 
 # Schedule when to run
 #   min    hour   day    month (Sun-Sat)
@@ -13,6 +13,8 @@ schedule: "0 22 * * *"
 concurrencyPolicy: Forbid
 
 labelSelector: 'app=rstudio'
+
+logLevel: 'INFO'
 
 # percentage of a CPU in the last minute which marks an active instance
 # (which should not be idled)


### PR DESCRIPTION
This was [supported by the idler](https://github.com/ministryofjustice/analytics-platform-idler/pull/10/files#diff-225132354aa2a9f4d7ecebb48833c06bR26) but wasn't added to the helm chart.

Using [new version of idler](https://github.com/ministryofjustice/analytics-platform-idler/pull/11) with more debug logging.