### PR TITLE
Rstudio Image Tag

### DIFF
--- a/charts/rstudio/CHANGELOG.md
+++ b/charts/rstudio/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.5.1] - 2018-04-27
+### RStudio Image
+- Modified `values.yaml` to use v1.3.2 RStudio image. 
+
 ## [1.5.0] - 2018-04-26
 ### New RStudio Image
 - Modified `values.yaml` to use latest RStudio image. [Trello](https://trello.com/c/RvX3onRE)

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: RStudio with Auth0 authentication proxy
 name: rstudio
-version: 1.5.0
+version: 1.5.1

--- a/charts/rstudio/values.yaml
+++ b/charts/rstudio/values.yaml
@@ -30,7 +30,7 @@ rstudio:
   port: "8787"
   image:
     repository: quay.io/mojanalytics/rstudio
-    tag: "3.4.2-1"
+    tag: "v1.3.2"
     pullPolicy: "Always"
   resources:
     limits:


### PR DESCRIPTION
New RStudio image accidentally deployed to all users after previous
merge which included new Rstudio image.  It builds
the latest tag off master.

Reverting and pinning version.