### PR TITLE
Set Rstudio Image Tag

### DIFF
--- a/charts/rstudio/migrations/set_rstudio_image_tag.sh
+++ b/charts/rstudio/migrations/set_rstudio_image_tag.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Generic script that sets the image+tag of a container in a deployment's pod spec in user namespaces
+# As is.  Will set deployment's "r-studio-server" container's image tag to "v1.3.2" in all user namespaces
+
+set -e
+
+DRY_RUN=true
+
+while true; do
+	read -p "Is this a DRY RUN? i.e. NO-OP [y/N]: " dry_run
+	case $dry_run in
+	    [y]*    ) DRY_RUN=true; break;;
+	    [N]*    ) DRY_RUN=false; break;;
+	    *       ) echo "Answer y to simulate the operation.  Answer N to perform the operation."; exit;;
+    esac
+done
+
+APP=rstudio
+TAG=v1.3.2
+POD_CONTAINER=r-studio-server
+NAMESPACES=$(kubectl get ns | grep user- | grep -v user-init-platform | cut -f1 -d' ')
+
+
+
+for ns in $NAMESPACES; do
+
+	kubectl set image deployments -l app=$APP $POD_CONTAINER=quay.io/mojanalytics/$APP:$TAG \
+	--namespace $ns \
+	--dry-run=$DRY_RUN
+
+done


### PR DESCRIPTION
[trello](https://trello.com/c/R5DeH04g)

Script to modify rstudio image tags.  Useful for rolling out versions or
just serving as an example.

Gated with `dry-run` flag for no-op runs to what will be changed if run.

## Test

1. Execute the script and answer `y` to invoke a dry run.  You will see output for deployments that will be affected.  i.e. __Does not match __ the image defined in the script. 

In dev, that will be my deployment