### PR TITLE
Only check Github org once per day

### DIFF
--- a/charts/concourse-org-pipeline/files/pipeline.yaml
+++ b/charts/concourse-org-pipeline/files/pipeline.yaml
@@ -9,6 +9,7 @@ jobs:
 resources:
 - name: org
   type: github-org
+  check_every: 24h
   source:
     name: ((github-org))
     team_name: ((team_name))


### PR DESCRIPTION
* Change automatic check frequency from default of once per minute, to once per day
* Checks are performed via the Github webhook on creation of a release, so polling every minute is unnecessary and runs the risk of using up our Github API rate limit.
* Can't actually turn off polling - setting to `0` results in continuous polling 👎 