### PR TITLE
kibana-auth-proxy 1.1.3: Updated proxy dependencies

### DIFF
--- a/charts/kibana-auth-proxy/CHANGELOG.md
+++ b/charts/kibana-auth-proxy/CHANGELOG.md
@@ -5,6 +5,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [1.1.3] - 2018-05-09
+### Changed
+Use [`kibana-auth-proxy` v1.1.2](https://github.com/ministryofjustice/analytics-platform-kibana-auth-proxy/releases/tag/v1.1.2).
+
+This version of the proxy bumps some dependencies and fixes
+[hoek vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2018-3728).
+
+
 ## [1.1.2] - 2018-03-19
 ### Fixed
 - Fixed redirect loop caused by `nginx.ingress.kubernetes.io/force-ssl-redirect`

--- a/charts/kibana-auth-proxy/Chart.yaml
+++ b/charts/kibana-auth-proxy/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: kibana-auth-proxy
-version: 1.1.2
+version: 1.1.3

--- a/charts/kibana-auth-proxy/values.yaml
+++ b/charts/kibana-auth-proxy/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 image:
   repository: quay.io/mojanalytics/kibana-auth-proxy
-  tag: "v1.1.1"
+  tag: "v1.1.2"
   pullPolicy: IfNotPresent
 service:
   type: ClusterIP


### PR DESCRIPTION
Use [`kibana-auth-proxy` v1.1.2](https://github.com/ministryofjustice/analytics-platform-kibana-auth-proxy/releases/tag/v1.1.2).

This version of the proxy bumps some dependencies and fixes
[hoek vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2018-3728).

Part of ticket: https://trello.com/c/k2V2MJf8/794-hoek-vulnerability-in-authproxy