### PR TITLE
rstudio-1.5.2: Fix auth-proxy/hoek vulnerability

### DIFF
--- a/charts/rstudio/CHANGELOG.md
+++ b/charts/rstudio/CHANGELOG.md
@@ -4,9 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+## [1.5.2] - 2018-05-10
+### Changed
+Use `rstudio-auth-proxy` [`v1.4.3`](https://github.com/ministryofjustice/analytics-platform-rstudio-auth-proxy/releases/tag/v1.4.3.).
+This version of the proxy updates some dependencies and fixes [CVE-2018-3728](https://nvd.nist.gov/vuln/detail/CVE-2018-3728).
+
+
 ## [1.5.1] - 2018-04-27
 ### RStudio Image
-- Modified `values.yaml` to use v1.3.2 RStudio image. 
+- Modified `values.yaml` to use v1.3.2 RStudio image.
+
 
 ## [1.5.0] - 2018-04-26
 ### New RStudio Image

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: RStudio with Auth0 authentication proxy
 name: rstudio
-version: 1.5.1
+version: 1.5.2

--- a/charts/rstudio/migrations/set_rstudio_image_tag.sh
+++ b/charts/rstudio/migrations/set_rstudio_image_tag.sh
@@ -17,6 +17,7 @@ while true; do
 done
 
 APP=rstudio
+IMAGE=rstudio
 TAG=v1.3.2
 POD_CONTAINER=r-studio-server
 NAMESPACES=$(kubectl get ns | grep user- | grep -v user-init-platform | cut -f1 -d' ')
@@ -25,7 +26,7 @@ NAMESPACES=$(kubectl get ns | grep user- | grep -v user-init-platform | cut -f1 
 
 for ns in $NAMESPACES; do
 
-	kubectl set image deployments -l app=$APP $POD_CONTAINER=quay.io/mojanalytics/$APP:$TAG \
+	kubectl set image deployments -l app=$APP $POD_CONTAINER=quay.io/mojanalytics/$IMAGE:$TAG \
 	--namespace $ns \
 	--dry-run=$DRY_RUN
 

--- a/charts/rstudio/values.yaml
+++ b/charts/rstudio/values.yaml
@@ -16,7 +16,7 @@ authProxy:
     port: 3000
   image:
     repository: quay.io/mojanalytics/rstudio-auth-proxy
-    tag: "v1.4.2"
+    tag: "v1.4.3"
     pullPolicy: "IfNotPresent"
   resources:
     limits:


### PR DESCRIPTION
Use `rstudio-auth-proxy` `v1.4.3`, this version of the proxy updates some
dependencies and fixes CVE-2018-3728.

See
- Proxy tag: https://github.com/ministryofjustice/analytics-platform-rstudio-auth-proxy/releases/tag/v1.4.3
- CVE-2018-3728: https://nvd.nist.gov/vuln/detail/CVE-2018-3728