### PR TITLE
Add cpanel-api-url secret for org pipeline

### DIFF
--- a/charts/concourse-org-pipeline/CHANGELOG.md
+++ b/charts/concourse-org-pipeline/CHANGELOG.md
@@ -5,6 +5,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [0.1.4] - 2018-05-11
+### Added
+Added `secrets.cpanel-api-url` secret, intended to be overridden in config repo.
+This contains the base URL of the Control Panel API.
+
+### Changed
+Bumped the version of the Concourse Github Org resource to 0.3.9
+Reduced org polling interval to once every 24 hours - checks are intended to be
+triggered via Github webhook instead.
+
+
 ## [0.1.3] - 2018-04-26
 ### Added
 Added IP range secrets for DOM1, QUANTUM and 102PF for use in webapp

--- a/charts/concourse-org-pipeline/Chart.yaml
+++ b/charts/concourse-org-pipeline/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Concourse pipeline for creating deployment pipelines for Github org repos
 name: concourse-org-pipeline
-version: 0.1.3
+version: 0.1.4

--- a/charts/concourse-org-pipeline/templates/secrets.yaml
+++ b/charts/concourse-org-pipeline/templates/secrets.yaml
@@ -15,6 +15,7 @@ data:
   auth0-domain: {{ .Values.auth0.domain | b64enc | quote }}
   aws-region: {{ .Values.aws.region | b64enc | quote }}
   cookie-secret: {{ .Values.cookieSecret | b64enc | quote }}
+  cpanel-api-url: {{ .Values.cpanelApiUrl | b64enc | quote }}
   ecr-access-key-id: {{ .Values.aws.ecrAccessKeyId | b64enc | quote }}
   ecr-secret-access-key: {{ .Values.aws.ecrSecretAccessKey | b64enc | quote }}
   github-access-token: {{ .Values.github.accessToken | b64enc | quote }}

--- a/charts/concourse-org-pipeline/values.yaml
+++ b/charts/concourse-org-pipeline/values.yaml
@@ -22,6 +22,8 @@ concourse:
 
 cookieSecret: ""
 
+cpanelApiUrl: ""
+
 github:
   org: moj-analytical-services
   accessToken: ""
@@ -29,7 +31,7 @@ github:
 
 githubOrgResource:
   image: quay.io/mojanalytics/github-org-resource
-  tag: v0.3.5
+  tag: v0.3.9
 
 ipRanges:
   wifi102pf: ""


### PR DESCRIPTION
# What
* Added `secrets.cpanel-api-url` secret, intended to be overridden in config repo. This contains the base URL of the Control Panel API which is used to fetch the app IAM role during webapp deployment.
* Bumped the version of the [Concourse Github Org resource to 0.3.9](https://github.com/ministryofjustice/analytics-platform-concourse-github-org-resource/pull/6)
  * Introduces the task to fetch the IAM role and pass it to helm
  * Reduces org polling interval to once every 24 hours - checks are intended to be
triggered via Github webhook instead.