### PR TITLE
Default Package Home

### DIFF
--- a/charts/jupyter-lab/CHANGELOG.md
+++ b/charts/jupyter-lab/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.1.3] - 2018-5-18
+## Package Home
+- Profile failed to auto load alias. Amended `pip-user-home.sh` to create `.bash_aliases` file which `.bashrc` checks exists
+- [Trello](https://trello.com/c/NKz0zS0m) 
+
 ## [0.1.2] - 2018-04-10
 ## Jupyter Auth0 CallBack URL
 -  Fixing auth proxy callback envvar to point to the correct endpoint

--- a/charts/jupyter-lab/Chart.yaml
+++ b/charts/jupyter-lab/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Jupyter Lab with Auth0 authentication proxy
 name: jupyter-lab
-version: 0.1.2
+version: 0.1.3

--- a/charts/jupyter-lab/files/pip-user-home.sh
+++ b/charts/jupyter-lab/files/pip-user-home.sh
@@ -1,3 +1,9 @@
 #!/bin/env sh
 
-/bin/grep -q -F 'pipcorn' $HOME/.profile || /bin/echo "alias pip='pipcorn() { if [[ \"\$1\" =~ ^[install]$ ]]; then /opt/conda/bin/pip install --user \"\${@:2}\"; else /opt/conda/bin/pip \"\$@\"; fi }; pipcorn'" >> $HOME/.profile
+set -x
+
+/bin/grep -q -F 'pipcorn' $HOME/.bash_aliases || \
+    /bin/echo "alias pip='pipcorn() { if [ \$1 == \"install\" ]; then /opt/conda/bin/pip install --user \"\${@:2}\"; else /opt/conda/bin/pip \"\$@\"; fi }; pipcorn'" \
+    >> $HOME/.bash_aliases
+
+chown 1001:100 $HOME/.bash_aliases

--- a/charts/jupyter-lab/values.yaml
+++ b/charts/jupyter-lab/values.yaml
@@ -24,7 +24,7 @@ authProxy:
 
 jupyter:
   image: quay.io/mojanalytics/datascience-notebook
-  tag: v0.3.1
+  tag: v0.3.2
   imagePullPolicy: IfNotPresent
   containerPort: 8888
   resources:


### PR DESCRIPTION
Jupyter was failing to autoload `.profile`

Adding `.bash_aliases` file instead which `.bashrc` checks exists.

Sanity checked and simplified evaluation as we're just matching an exact
string.

bumping Jupyter image with modified `PATH`.
See: ministryofjustice/analytics-platform-jupyter-notebook#5