### PR TITLE
FluentD Crash

### DIFF
--- a/charts/webapp/CHANGELOG.md
+++ b/charts/webapp/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.3.8] - 2018-05-24
+### Changed
+- Increased memory resources from 256MB(default if unspecified) to 512MB
+- Modified image repo tag to reflect quay.  Sorry (my bad)
 
 ## [1.3.7] - 2018-03-23
 ### Changed

--- a/charts/webapp/Chart.yaml
+++ b/charts/webapp/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: webapp Helm chart for Kubernetes
 name: webapp
-version: 1.3.7
+version: 1.3.8

--- a/charts/webapp/templates/deployment.yaml
+++ b/charts/webapp/templates/deployment.yaml
@@ -135,7 +135,8 @@ spec:
               mountPath: /var/log/nginx
             - name: varlogshinyserver
               mountPath: /var/log/shiny-server
-
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
       volumes:
         - name: varlognginx
           emptyDir: {}

--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -35,3 +35,10 @@ Elasticsearch:
   Port: "9200"
   Username: ""
   Password: ""
+resources:
+  limits:
+    cpu: 100m
+    memory: 512Mi
+  requests:
+    cpu: 100m
+    memory: 512Mi


### PR DESCRIPTION
Fluentd keeps crashing due to upstream daemonset image not working with
config changes introduced with K8s 1.8.  i.e. mounts now default to
read-only.

FluentD will also crash due to OOM errors from ruby evident by viewing
kubelet journal.  Default limit is 256MB whereas fluentD uses on
avaerage 265MB.