### PR TITLE
Dashboard Role: configmap

### DIFF
--- a/charts/kubernetes-dashboard/templates/cluster-role.yaml
+++ b/charts/kubernetes-dashboard/templates/cluster-role.yaml
@@ -35,7 +35,7 @@ rules:
     resources: ["deployments", "ingresses", "statefulsets", "daemonsets", "replicasets"]
     verbs: ["get", "watch", "list"]
   - apiGroups: [""]
-    resources: ["pods", "services", "persistentvolumes", "persistentvolumeclaims", "endpoints", "namespaces", "limitranges", "resourcequotas", "configmaps", "nodes", "events", "replicationcontrollers"]
+    resources: ["pods", "services", "persistentvolumes", "persistentvolumeclaims", "endpoints", "namespaces", "limitranges", "resourcequotas", "nodes", "events", "replicationcontrollers"]
     verbs: ["get", "watch", "list"]
   - apiGroups: ["batch"]
     resources: ["cronjobs", "jobs"]


### PR DESCRIPTION
Removing read-only on all `configmaps` from kube-dashboard read-only
role.  Might be over-kill but will protect us if anyone accidentally
deploys a secret in one.