### PR TITLE
Fix ElasticSearch env var in CPanel API

### DIFF
--- a/charts/cpanel/CHANGELOG.md
+++ b/charts/cpanel/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [0.12.1] - 2018-05-29
+### Added
+Added `ELASTICSEARCH_CONN` env var to deployment. Only secret was added before.
+
 ## [0.12.0] - 2018-05-04
 ### Added
 Added `ELASTICSEARCH_CONN` env var. Connection string with read-only username and password.

--- a/charts/cpanel/Chart.yaml
+++ b/charts/cpanel/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Analytics Platform Control Panel API webapp
 name: cpanel
-version: 0.12.0
+version: 0.12.1

--- a/charts/cpanel/templates/deployment.yaml
+++ b/charts/cpanel/templates/deployment.yaml
@@ -53,6 +53,11 @@ spec:
               value: "{{ .Values.API.Environment.DEBUG }}"
             - name: DJANGO_SETTINGS_MODULE
               value: "control_panel_api.settings"
+            - name: ELASTICSEARCH_CONN
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ template "fullname" . }}"
+                  key: ELASTICSEARCH_CONN
             - name: ENABLE_K8S_RBAC
               value: "{{ .Values.API.Environment.ENABLE_K8S_RBAC }}"
             - name: ENV


### PR DESCRIPTION
* Add missing environment variable to deployment. Value and secret were already there, just missing the deployment.