### PR TITLE
Update helm repo URL for cpanel pipeline

### DIFF
--- a/charts/cpanelapi-pipeline/files/pipeline.yaml
+++ b/charts/cpanelapi-pipeline/files/pipeline.yaml
@@ -69,7 +69,7 @@ resources:
     release: cpanel-master
     repos:
     - name: mojanalytics
-      url: https://ministryofjustice.github.io/analytics-platform-helm-charts/charts
+      url: http://moj-analytics-helm-repo.s3-website-eu-west-1.amazonaws.com
 
 resource_types:
 - name: helm


### PR DESCRIPTION
* Helm repo moved to S3, so this change updates the URL used in the pipeline