### PR TITLE
Add chart for concourse-admin team

### DIFF
--- a/charts/concourse-admin-team/CHANGELOG.md
+++ b/charts/concourse-admin-team/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+
+## [0.1.0] - 2018-06-01
+### Added
+Added concourse-admin-team chart, for setting up the `admin` team in the Analytical Platform Concourse.

--- a/charts/concourse-admin-team/Chart.yaml
+++ b/charts/concourse-admin-team/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: Concourse admin team secrets
+name: concourse-admin-team
+version: 0.1.0

--- a/charts/concourse-admin-team/README.md
+++ b/charts/concourse-admin-team/README.md
@@ -26,7 +26,6 @@ helm install mojanalytics/concourse-admin-team \
 | github.accessToken | Personal access token for the Github API | "" |
 | kubernetes.apiUrl | Kubernetes cluster API URL | "" |
 | kubernetes.caCert | Kubernetes cluster CA certificate for API access | "" |
-| kubernetes.clusterName | The name of the Kubernetes cluster (eg `dev` or `alpha`) | `dev` |
 | kubernetes.token | Kubernetes token for API access | "" |
 | quay.password | Password / token for quay.io | "" |
 | quay.username | Username for quay.io | "" |

--- a/charts/concourse-admin-team/README.md
+++ b/charts/concourse-admin-team/README.md
@@ -1,0 +1,32 @@
+# Analytical Platform Concourse admin team
+
+Installing this chart will create an admin team in a specified Concourse
+installation, setting up secrets shared by the pipelines used to deploy platform
+components.
+
+
+## Installing the Chart
+
+To install the chart:
+```bash
+helm install mojanalytics/concourse-admin-team \
+  --name concourse-admin-team \
+  --values /path/to/chart/configs/concourse-admin-team.yaml
+```
+
+
+## Configuration
+
+| Parameter  | Description  | Default  |
+| ---------- | ------------ | -------- |
+| concourse.url | Concourse URL (not the in-cluster address) | "" |
+| concourse.password | Basic authentication password for Concourse | "" |
+| concourse.username | Basic authentication username for Concourse | "" |
+| gitcryptKeys.config | The key used to unlock the gitcrypt encrypted config repo | "" |
+| github.accessToken | Personal access token for the Github API | "" |
+| kubernetes.apiUrl | Kubernetes cluster API URL | "" |
+| kubernetes.caCert | Kubernetes cluster CA certificate for API access | "" |
+| kubernetes.clusterName | The name of the Kubernetes cluster (eg `dev` or `alpha`) | `dev` |
+| kubernetes.token | Kubernetes token for API access | "" |
+| quay.password | Password / token for quay.io | "" |
+| quay.username | Username for quay.io | "" |

--- a/charts/concourse-admin-team/templates/secrets.yaml
+++ b/charts/concourse-admin-team/templates/secrets.yaml
@@ -1,0 +1,15 @@
+{{- range $key, $val := .Values }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $key }}
+  namespace: concourse-{{ .Values.concourse.team }}
+  labels:
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+type: Opaque
+data:
+  {{- range $name, $secret := $val }}
+  {{ $name }}: {{ $secret | b64enc | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/concourse-admin-team/values.yaml
+++ b/charts/concourse-admin-team/values.yaml
@@ -1,0 +1,20 @@
+concourse:
+  url: ""
+  password: ""
+  team: "admin"
+  username: ""
+
+gitcryptKeys:
+  config: ""
+
+github:
+  accessToken: ""
+
+kubernetes:
+  apiUrl: ""
+  caCert: ""
+  token: ""
+
+quay:
+  password: ""
+  username: ""


### PR DESCRIPTION
* Add a Helm chart to create secrets used by Concourse pipelines owned by the `concourse-admin` team (see https://github.com/ministryofjustice/analytics-platform-concourse-pipelines)
* See [values](https://github.com/ministryofjustice/analytics-platform-config/pull/60)