### PR TITLE
Fix concourse-admin-team secrets

### DIFF
--- a/charts/concourse-admin-team/CHANGELOG.md
+++ b/charts/concourse-admin-team/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [0.1.1] - 2018-06-04
+### Changed
+Fix secrets template: secret names must be lower case alphanumerics, '-' or '.'
+
 ## [0.1.0] - 2018-06-01
 ### Added
 Added concourse-admin-team chart, for setting up the `admin` team in the Analytical Platform Concourse.

--- a/charts/concourse-admin-team/Chart.yaml
+++ b/charts/concourse-admin-team/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Concourse admin team secrets
 name: concourse-admin-team
-version: 0.1.0
+version: 0.1.1

--- a/charts/concourse-admin-team/templates/secrets.yaml
+++ b/charts/concourse-admin-team/templates/secrets.yaml
@@ -1,15 +1,16 @@
+{{- $chart_fullname := cat .Chart.Name .Chart.Version | replace " " "-" -}}
 {{- range $key, $val := .Values }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ $key }}
-  namespace: concourse-{{ .Values.concourse.team }}
+  name: {{ $key | snakecase | replace "_" "-" }}
+  namespace: concourse-admin
   labels:
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    chart: {{ $chart_fullname }}
 type: Opaque
 data:
   {{- range $name, $secret := $val }}
-  {{ $name }}: {{ $secret | b64enc | quote }}
+  {{ $name | snakecase | replace "_" "-" }}: {{ $secret | b64enc | quote }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
* Fix secrets template. Secrets names must be lowercase alphanumeric, `-` or `.`