### PR TITLE
Adjust RStudio Resources

### DIFF
--- a/charts/rstudio/CHANGELOG.md
+++ b/charts/rstudio/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [1.5.3] - 2018-06-05
+### Changed
+- Adjusted memory resource limits and requests from `request: 1GB => 5GB` & `limit: 12GB => 20GB`
+
 ## [1.5.2] - 2018-05-10
 ### Changed
 Use `rstudio-auth-proxy` [`v1.4.3`](https://github.com/ministryofjustice/analytics-platform-rstudio-auth-proxy/releases/tag/v1.4.3.).

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: RStudio with Auth0 authentication proxy
 name: rstudio
-version: 1.5.2
+version: 1.5.3

--- a/charts/rstudio/values.yaml
+++ b/charts/rstudio/values.yaml
@@ -35,7 +35,7 @@ rstudio:
   resources:
     limits:
       cpu: 1.5
-      memory: 12Gi
+      memory: 20Gi
     requests:
       cpu: 200m
-      memory: 1Gi
+      memory: 5Gi


### PR DESCRIPTION
[Trello](https://trello.com/c/0R72UYbH)

Adjusting upper limit of memory for rstudio instances.  Increased
requests to hopefully reduce binpacking by the scheduler.  I'm hoping
this would reduce occurences of the scheduler having to reschedule pods,
should a user max-out their memory.