### PR TITLE
RStudio: 3.4.2-5

### DIFF
--- a/charts/rstudio/CHANGELOG.md
+++ b/charts/rstudio/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.5.4] - 2018-07-09
+### Changed
+- Modified RStudio image tag from v1.3.2 to 3.4.2-5 See: [PR](https://github.com/ministryofjustice/analytics-platform-rstudio/pull/34)
 
 ## [1.5.3] - 2018-06-05
 ### Changed

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: RStudio with Auth0 authentication proxy
 name: rstudio
-version: 1.5.3
+version: 1.5.4

--- a/charts/rstudio/values.yaml
+++ b/charts/rstudio/values.yaml
@@ -30,7 +30,7 @@ rstudio:
   port: "8787"
   image:
     repository: quay.io/mojanalytics/rstudio
-    tag: "v1.3.2"
+    tag: "3.4.2-5"
     pullPolicy: "Always"
   resources:
     limits:


### PR DESCRIPTION
Modified RStudio image tag from v1.3.2 to 3.4.2-5 See: [PR](https://github.com/ministryofjustice/analytics-platform-rstudio/pull/34)