### PR TITLE
Webapp: Upgrade to v0.1.3 docker image of auth-proxy

### DIFF
--- a/charts/webapp/CHANGELOG.md
+++ b/charts/webapp/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.3.11] - 2018-07-16
+### Changed
+- Use [auth-proxy `v0.1.3`](https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v0.1.3) which upgrades login-passwordless page to use `lock` library instead of `lock-passwordless`
+
 ## [1.3.10] - 2018-07-03
 ### Changed
 - Add webapp service account for auditing purposes

--- a/charts/webapp/Chart.yaml
+++ b/charts/webapp/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: webapp Helm chart for Kubernetes
 name: webapp
-version: 1.3.10
+version: 1.3.11

--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -20,7 +20,7 @@ AuthProxy:
     Domain: "AUTH0_USER.eu.auth0.com"
   Image:
     Repository: quay.io/mojanalytics/auth-proxy
-    Tag: "v0.1.2"
+    Tag: "v0.1.3"
     PullPolicy: "IfNotPresent"
 AWS:
   IAMRole: ""


### PR DESCRIPTION
This new version of auth proxy uses `lock` instead of `lock-passwordless` which
is now deprecated by auth0