### PR TITLE
Update logging

### DIFF
--- a/charts/webapp/CHANGELOG.md
+++ b/charts/webapp/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.3.12] - 2018-07-16
+### Changed
+- After upgrading Elasticsearch. The webapp logs stopped working after a few days.  
+  This was due to deprecations with mappings and Elasticsearch 6 not supporting multiple mapping per index. 
+  See: https://www.elastic.co/guide/en/elasticsearch/reference/6.0/breaking-changes-6.0.html
+  Setting `type_name` to resolve this as fluentd-elasticsearch-plugin sets two mappings.
+- Switched to using the more stable Kubernetes tested fluentd image. Made config changes to deployment accordingly.
+- Fixed "No Method" error on `time_nano` filter
+
 ## [1.3.11] - 2018-07-16
 ### Changed
 - Use [auth-proxy `v0.1.3`](https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v0.1.3) which upgrades login-passwordless page to use `lock` library instead of `lock-passwordless`

--- a/charts/webapp/Chart.yaml
+++ b/charts/webapp/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: webapp Helm chart for Kubernetes
 name: webapp
-version: 1.3.11
+version: 1.3.12

--- a/charts/webapp/templates/deployment.yaml
+++ b/charts/webapp/templates/deployment.yaml
@@ -129,13 +129,19 @@ spec:
                 configMapKeyRef:
                   name: {{ template "fullname" . }}-fluentd
                   key: logstash_prefix
+            - name: FLUENTD_ARGS
+              value: "-c /etc/fluent/fluent.conf --no-supervisor"
           volumeMounts:
             - name: fluentd-config
-              mountPath: /fluentd/etc
+              mountPath: /etc/fluent/fluent.conf
+              subPath: fluent.conf
             - name: varlognginx
               mountPath: /var/log/nginx
             - name: varlogshinyserver
               mountPath: /var/log/shiny-server
+            - name: libsystemddir
+              mountPath: /host/lib
+              readOnly: true
           resources:
 {{ toYaml .Values.resources | indent 12 }}
       volumes:
@@ -149,3 +155,6 @@ spec:
             items:
             - key: fluent.conf
               path: fluent.conf
+        - name: libsystemddir
+          hostPath:
+            path: /usr/lib64

--- a/charts/webapp/templates/fluentd-configmap.yml
+++ b/charts/webapp/templates/fluentd-configmap.yml
@@ -68,23 +68,25 @@ data:
         hostname "#{Socket.gethostname}"
       </record>
       <record>
-        time_nano ${t = Time.now; ((t.to_i * 1000000000) + t.nsec).t_s}
+        time_nano ${t = Time.now; ((t.to_i * 1000000000) + t.nsec).to_s}
       </record>
     </filter>
 
     <match **>
+       @id elasticsearch
        @type elasticsearch
-       log_level info
+       @log_level info
+       type_name time
        include_tag_key true
        scheme "#{ENV['FLUENT_ELASTICSEARCH_SCHEME']}"
        host "#{ENV['FLUENT_ELASTICSEARCH_HOST']}"
        port "#{ENV['FLUENT_ELASTICSEARCH_PORT']}"
-       user "#{ENV['FLUENT_ELASTICSEARCH_USERNAME']}"
+       user "#{ENV['FLUENT_ELASTICSEARCH_USER']}"
        password "#{ENV['FLUENT_ELASTICSEARCH_PASSWORD']}"
        logstash_prefix "#{ENV['FLUENT_ELASTICSEARCH_LOGSTASH_PREFIX'] || 'logstash'}"
        reload_connections false
        logstash_format true
-       buffer_chunk_limit 8M
+       buffer_chunk_limit 2M
        buffer_queue_limit 1024
        slow_flush_log_threshold 120s
        reload_on_failure true

--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -26,8 +26,8 @@ AWS:
   IAMRole: ""
 Fluentd:
   Image:
-    Repository: quay.io/mojanalytics/fluentd
-    Tag: tempFork
+    Repository: gcr.io/google-containers/fluentd-elasticsearch
+    Tag: v2.0.4
     PullPolicy: "IfNotPresent"
 Elasticsearch:
   Scheme: "http"


### PR DESCRIPTION
FluentD:
    
After upgrading Elasticsearch. The webapp logs stopped working after a few
days.  This was due to deprecations with mappings and Elasticsearch 6
not supporting multiple mapping per index. See: https://www.elastic.co/guide/en/elasticsearch/reference/6.0/breaking-changes-6.0.html
    
Setting `type_name` to resolve this as fluentd-elasticsearch-plugin sets two mappings.
    
Switched to using the more stable Kubernetes tested fluentd image. Made config changes to deployment accordingly.
    
Fixed "No Method" error on `time_nano` filter
