### PR TITLE
Reload on Failure

### DIFF
--- a/charts/webapp/CHANGELOG.md
+++ b/charts/webapp/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.3.13] - 2018-07-17
+### Changed
+- Mismatched `FLUENT_ELASTICSEARCH_USERNAME` env var in configmap
+- Set reload on failure to __false__.  See: https://github.com/uken/fluent-plugin-elasticsearch/issues/257#issuecomment-348946393
+
 ## [1.3.12] - 2018-07-16
 ### Changed
 - After upgrading Elasticsearch. The webapp logs stopped working after a few days.  

--- a/charts/webapp/Chart.yaml
+++ b/charts/webapp/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: webapp Helm chart for Kubernetes
 name: webapp
-version: 1.3.12
+version: 1.3.13

--- a/charts/webapp/templates/fluentd-configmap.yml
+++ b/charts/webapp/templates/fluentd-configmap.yml
@@ -81,7 +81,7 @@ data:
        scheme "#{ENV['FLUENT_ELASTICSEARCH_SCHEME']}"
        host "#{ENV['FLUENT_ELASTICSEARCH_HOST']}"
        port "#{ENV['FLUENT_ELASTICSEARCH_PORT']}"
-       user "#{ENV['FLUENT_ELASTICSEARCH_USER']}"
+       user "#{ENV['FLUENT_ELASTICSEARCH_USERNAME']}"
        password "#{ENV['FLUENT_ELASTICSEARCH_PASSWORD']}"
        logstash_prefix "#{ENV['FLUENT_ELASTICSEARCH_LOGSTASH_PREFIX'] || 'logstash'}"
        reload_connections false
@@ -89,7 +89,7 @@ data:
        buffer_chunk_limit 2M
        buffer_queue_limit 1024
        slow_flush_log_threshold 120s
-       reload_on_failure true
+       reload_on_failure false
        request_timeout 60
        max_retry_wait 30
        disable_retry_limit


### PR DESCRIPTION
Mismatched `FLUENT_ELASTICSEARCH_USERNAME` env var in configmap
Set reload on failure to __false__.  See: https://github.com/uken/fluent-plugin-elasticsearch/issues/257#issuecomment-348946393