### PR TITLE
Ingress-Nginx: Upgrade

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -27,7 +27,7 @@ by running these commands from the root of the project (change `dev` to your env
 Necessary to access the services from outside the cluster.
 
 ```bash
-$ helm install charts/nginx-ingress -f ../analytics-platform-config/chart-env-config/dev/nginx-ingress.yml --namespace kube-system --name cluster-ingress
+$ helm upgrade cluster-ingress charts/nginx-ingress -f chart-env-config/<ENV>/nginx-ingress.yml --namespace kube-system --install
 ```
 
 

--- a/charts/nginx-ingress/Chart.yaml
+++ b/charts/nginx-ingress/Chart.yaml
@@ -1,18 +1,19 @@
-appVersion: 0.9.0-beta.15
+name: nginx-ingress
+version: 0.23.1
+appVersion: 0.15.0
+home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.
-engine: gotpl
 icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png
 keywords:
-- ingress
-- nginx
-maintainers:
-- email: jack.zampolin@gmail.com
-  name: jackzampolin
-- email: mgoodness@gmail.com
-  name: mgoodness
-- email: chance.zibolski@coreos.com
-  name: chancez
-name: nginx-ingress
+  - ingress
+  - nginx
 sources:
-- https://github.com/kubernetes/ingress-nginx
-version: 0.8.26
+  - https://github.com/kubernetes/ingress-nginx
+maintainers:
+  - name: jackzampolin
+    email: jack.zampolin@gmail.com
+  - name: mgoodness
+    email: mgoodness@gmail.com
+  - name: chancez
+    email: chance.zibolski@coreos.com
+engine: gotpl

--- a/charts/nginx-ingress/README.md
+++ b/charts/nginx-ingress/README.md
@@ -15,7 +15,7 @@ $ helm install stable/nginx-ingress
 This chart bootstraps an nginx-ingress deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 ## Prerequisites
-  - Kubernetes 1.4+ with Beta APIs enabled
+  - Kubernetes 1.6+
 
 ## Installing the Chart
 
@@ -41,52 +41,86 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Configuration
 
-The following tables lists the configurable parameters of the nginx-ingress chart and their default values.
+The following table lists the configurable parameters of the nginx-ingress chart and their default values.
 
 Parameter | Description | Default
 --- | --- | ---
 `controller.name` | name of the controller component | `controller`
-`controller.image.repository` | controller container image repository | `k8s.gcr.io/nginx-ingress-controller`
-`controller.image.tag` | controller container image tag | `0.9.0-beta.15`
+`controller.image.repository` | controller container image repository | `quay.io/kubernetes-ingress-controller/nginx-ingress-controller`
+`controller.image.tag` | controller container image tag | `0.15.0`
 `controller.image.pullPolicy` | controller container image pull policy | `IfNotPresent`
 `controller.config` | nginx ConfigMap entries | none
-`controller.hostNetwork` | If the nginx deployment / daemonset should run on the host's network namespace | false
+`controller.hostNetwork` | If the nginx deployment / daemonset should run on the host's network namespace. Do not set this when `controller.service.externalIPs` is set and `kube-proxy` is used as there will be a port-conflict for port `80` | false
 `controller.defaultBackendService` | default 404 backend service; required only if `defaultBackend.enabled = false` | `""`
 `controller.electionID` | election ID to use for the status update | `ingress-controller-leader`
 `controller.extraEnvs` | any additional environment variables to set in the pods | `{}`
+`controller.extraContainers` | Sidecar containers to add to the controller pod. See [LemonLDAP::NG controller](https://github.com/lemonldap-ng-controller/lemonldap-ng-controller) as example | `{}`
+`controller.extraVolumeMounts` | Additional volumeMounts to the controller main container | `{}`
+`controller.extraVolumes` | Additional volumes to the controller pod | `{}`
+`controller.extraInitContainers` | Containers, which are run before the app containers are started | `[]`
 `controller.ingressClass` | name of the ingress class to route through this controller | `nginx`
 `controller.scope.enabled` | limit the scope of the ingress controller | `false` (watch all namespaces)
 `controller.scope.namespace` | namespace to watch for ingress | `""` (use the release namespace)
 `controller.extraArgs` | Additional controller container arguments | `{}`
 `controller.kind` | install as Deployment or DaemonSet | `Deployment`
+`controller.daemonset.useHostPort` | If `controller.kind` is `DaemonSet`, this will enable `hostPort` for TCP/80 and TCP/443 | false
+`controller.daemonset.hostPorts.http` | If `controller.daemonset.useHostPort` is `true` and this is non-empty, it sets the hostPort | `"80"`
+`controller.daemonset.hostPorts.https` | If `controller.daemonset.useHostPort` is `true` and this is non-empty, it sets the hostPort | `"443"`
 `controller.tolerations` | node taints to tolerate (requires Kubernetes >=1.6) | `[]`
+`controller.affinity` | node/pod affinities (requires Kubernetes >=1.6) | `{}`
 `controller.minReadySeconds` | how many seconds a pod needs to be ready before killing the next, during update | `0`
 `controller.nodeSelector` | node labels for pod assignment | `{}`
 `controller.podAnnotations` | annotations to be added to pods | `{}`
 `controller.replicaCount` | desired number of controller pods | `1`
+`controller.minAvailable` | minimum number of available controller pods for PodDisruptionBudget | `1`
 `controller.resources` | controller pod resource requests & limits | `{}`
+`controller.priorityClassName` | controller priorityClassName | `nil`
 `controller.lifecycle` | controller pod lifecycle hooks | `{}`
 `controller.service.annotations` | annotations for controller service | `{}`
+`controller.service.labels` | labels for controller service | `{}`
 `controller.publishService.enabled` | if true, the controller will set the endpoint records on the ingress objects to reflect those on the service | `false`
 `controller.publishService.pathOverride` | override of the default publish-service name | `""`
 `controller.service.clusterIP` | internal controller cluster service IP | `""`
-`controller.service.externalIPs` | controller service external IP addresses | `[]`
+`controller.service.externalIPs` | controller service external IP addresses. Do not set this when `controller.hostNetwork` is set to `true` and `kube-proxy` is used as there will be a port-conflict for port `80` | `[]`
 `controller.service.externalTrafficPolicy` | If `controller.service.type` is `NodePort` or `LoadBalancer`, set this to `Local` to enable [source IP preservation](https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typenodeport) | `"Cluster"`
 `controller.service.healthCheckNodePort` | If `controller.service.type` is `NodePort` or `LoadBalancer` and `controller.service.externalTrafficPolicy` is set to `Local`, set this to [the managed health-check port the kube-proxy will expose](https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typenodeport). If blank, a random port in the `NodePort` range will be assigned | `""`
 `controller.service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`
 `controller.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`
+`controller.service.enableHttp` | if port 80 should be opened for service | `true`
+`controller.service.enableHttps` | if port 443 should be opened for service | `true`
 `controller.service.targetPorts.http` | Sets the targetPort that maps to the Ingress' port 80 | `80`
 `controller.service.targetPorts.https` | Sets the targetPort that maps to the Ingress' port 443 | `443`
 `controller.service.type` | type of controller service to create | `LoadBalancer`
 `controller.service.nodePorts.http` | If `controller.service.type` is `NodePort` and this is non-empty, it sets the nodePort that maps to the Ingress' port 80 | `""`
 `controller.service.nodePorts.https` | If `controller.service.type` is `NodePort` and this is non-empty, it sets the nodePort that maps to the Ingress' port 443 | `""`
-`controller.stats.enabled` | if true, enable "vts-status" page & Prometheus metrics | `false`
+`controller.livenessProbe.initialDelaySeconds` | Delay before liveness probe is initiated | 10
+`controller.livenessProbe.periodSeconds` | How often to perform the probe | 10
+`controller.livenessProbe.timeoutSeconds` | When the probe times out | 5
+`controller.livenessProbe.successThreshold` | Minimum consecutive successes for the probe to be considered successful after having failed. | 1
+`controller.livenessProbe.failureThreshold` | Minimum consecutive failures for the probe to be considered failed after having succeeded. | 3
+`controller.livenessProbe.port` | The port number that the liveness probe will listen on. | 10254
+`controller.readinessProbe.initialDelaySeconds` | Delay before readiness probe is initiated | 10
+`controller.readinessProbe.periodSeconds` | How often to perform the probe | 10
+`controller.readinessProbe.timeoutSeconds` | When the probe times out | 1
+`controller.readinessProbe.successThreshold` | Minimum consecutive successes for the probe to be considered successful after having failed. | 1
+`controller.readinessProbe.failureThreshold` | Minimum consecutive failures for the probe to be considered failed after having succeeded. | 3
+`controller.readinessProbe.port` | The port number that the readiness probe will listen on. | 10254
+`controller.stats.enabled` | if `true`, enable "vts-status" page | `false`
 `controller.stats.service.annotations` | annotations for controller stats service | `{}`
 `controller.stats.service.clusterIP` | internal controller stats cluster service IP | `""`
 `controller.stats.service.externalIPs` | controller service stats external IP addresses | `[]`
 `controller.stats.service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`
 `controller.stats.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`
 `controller.stats.service.type` | type of controller stats service to create | `ClusterIP`
+`controller.metrics.enabled` | if `true`, enable Prometheus metrics (`controller.stats.enabled` must be `true` as well) | `false`
+`controller.metrics.service.annotations` | annotations for Prometheus metrics service | `{}`
+`controller.metrics.service.clusterIP` | cluster IP address to assign to service | `""`
+`controller.metrics.service.externalIPs` | Prometheus metrics service external IP addresses | `[]`
+`controller.metrics.service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`
+`controller.metrics.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`
+`controller.metrics.service.servicePort` | Prometheus metrics service port | `9913`
+`controller.metrics.service.targetPort` | Prometheus metrics target port | `10254`
+`controller.metrics.service.type` | type of Prometheus metrics service to create | `ClusterIP`
 `controller.customTemplate.configMapName` | configMap containing a custom nginx template | `""`
 `controller.customTemplate.configMapKey` | configMap key containing the nginx template | `""`
 `controller.headers` | configMap key:value pairs containing the [custom headers](https://github.com/kubernetes/ingress-nginx/tree/master/docs/examples/customization/custom-headers) for Nginx | `{}`
@@ -97,36 +131,24 @@ Parameter | Description | Default
 `defaultBackend.image.pullPolicy` | default backend container image pull policy | `IfNotPresent`
 `defaultBackend.extraArgs` | Additional default backend container arguments | `{}`
 `defaultBackend.tolerations` | node taints to tolerate (requires Kubernetes >=1.6) | `[]`
+`defaultBackend.affinity` | node/pod affinities (requires Kubernetes >=1.6) | `{}`
 `defaultBackend.nodeSelector` | node labels for pod assignment | `{}`
 `defaultBackend.podAnnotations` | annotations to be added to pods | `{}`
 `defaultBackend.replicaCount` | desired number of default backend pods | `1`
+`defaultBackend.minAvailable` | minimum number of available default backend pods for PodDisruptionBudget | `1`
 `defaultBackend.resources` | default backend pod resource requests & limits | `{}`
+`defaultBackend.priorityClassName` | default backend  priorityClassName | `nil`
 `defaultBackend.service.annotations` | annotations for default backend service | `{}`
 `defaultBackend.service.clusterIP` | internal default backend cluster service IP | `""`
 `defaultBackend.service.externalIPs` | default backend service external IP addresses | `[]`
 `defaultBackend.service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`
 `defaultBackend.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`
 `defaultBackend.service.type` | type of default backend service to create | `ClusterIP`
-`rbac.create` | If true, create & use RBAC resources | `false`
-`rbac.serviceAccountName` | ServiceAccount to be used (ignored if rbac.create=true) | `default`
+`imagePullSecrets` | name of Secret resource containing private registry credentials | `nil`
+`rbac.create` | if `true`, create & use RBAC resources | `true`
+`serviceAccount.create` | if `true`, create a service account | ``
+`serviceAccount.name` | The name of the service account to use. If not set and `create` is `true`, a name is generated using the fullname template. | ``
 `revisionHistoryLimit` | The number of old history to retain to allow rollback. | `10`
-`statsExporter.name` | name of the Prometheus metrics exporter component | `stats-exporter`
-`statsExporter.image.repository` | Prometheus metrics exporter container image repository | `sophos/nginx-vts-exporter`
-`statsExporter.image.tag` | Prometheus metrics exporter image tag | `v0.6`
-`statsExporter.image.pullPolicy` | Prometheus metrics exporter image pull policy | `IfNotPresent`
-`statsExporter.endpoint` | path at which Prometheus metrics are exposed | `/metrics`
-`statsExporter.extraArgs` | Additional Prometheus metrics exporter container arguments | `{}`
-`statsExporter.metricsNamespace` | namespace used for metrics labeling | `nginx`
-`statsExporter.statusPage` | URL of "vts-stats" page exposed by controller | `http://localhost:18080/nginx_status/format/json`
-`statsExporter.resources` | Prometheus metrics exporter resource requests & limits | `{}`
-`statsExporter.service.annotations` | annotations for Prometheus metrics exporter service | `{}`
-`statsExporter.service.clusterIP` | cluster IP address to assign to service | `""`
-`statsExporter.service.externalIPs` | Prometheus metrics exporter service external IP addresses | `[]`
-`statsExporter.service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`
-`statsExporter.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`
-`statsExporter.service.servicePort` | Prometheus metrics exporter service port | `9913`
-`statsExporter.service.targetPort` | Prometheus metrics exporter target port | `9913`
-`statsExporter.service.type` | type of Prometheus metrics exporter service to create | `ClusterIP`
 `tcp` | TCP service key:value pairs | `{}`
 `udp` | UDP service key:value pairs | `{}`
 
@@ -141,4 +163,80 @@ Alternatively, a YAML file that specifies the values for the parameters can be p
 $ helm install stable/nginx-ingress --name my-release -f values.yaml
 ```
 
+A useful trick to debug issues with ingress is to increase the logLevel
+as described [here](https://github.com/kubernetes/ingress-nginx/blob/master/docs/troubleshooting.md#debug)
+
+```console
+$ helm install stable/nginx-ingress --set controller.extraArgs.v=2
+```
+
+## Prometheus Metrics
+
+The Nginx ingress controller can export Prometheus metrics. In order for this to work, the VTS dashboard must be enabled as well.
+
+```console
+$ helm install stable/nginx-ingress --name my-release \
+    --set controller.stats.enabled=true \
+    --set controller.metrics.enabled=true
+```
+
+You can add Prometheus annotations to the metrics service using `controller.metrics.service.annotations`. Alternatively, if you use the Prometheus Operator, you need to create a ServiceMonitor as follows:
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: nginx-ingress-service-monitor
+spec:
+  jobLabel: nginx-ingress
+  selector:
+    matchLabels:
+      app: nginx-ingress
+      release: <RELEASE>
+  namespaceSelector:
+    matchNames:
+      - <RELEASE_NAMESPACE>
+  endpoints:
+    - port: metrics
+      interval: 30s
+```
 > **Tip**: You can use the default [values.yaml](values.yaml)
+
+## ExternalDNS Service configuration
+
+Add an [ExternalDNS](https://github.com/kubernetes-incubator/external-dns) annotation to the LoadBalancer service:
+
+```yaml
+annotations:
+  external-dns.alpha.kubernetes.io/hostname: kubernetes-example.com.
+```
+
+## AWS L7 ELB with SSL Termination
+
+Annotate the controller as shown in the [nginx-ingress l7 patch](https://github.com/kubernetes/ingress-nginx/blob/master/deploy/provider/aws/service-l7.yaml):
+
+```yaml
+controller:
+  service:
+    targetPorts:
+      http: http
+      https: http
+    annotations:
+      service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:XX-XXXX-X:XXXXXXXXX:certificate/XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXX
+      service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "http"
+      service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "https"
+      service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: '3600'
+```
+
+## AWS route53-mapper
+
+To configure the LoadBalancer service with the [route53-mapper addon](https://github.com/kubernetes/kops/tree/master/addons/route53-mapper), add the `domainName` annotation and `dns` label:
+
+```yaml
+controller:
+  service:
+    labels:
+      dns: "route53"
+    annotations:
+      domainName: "kubernetes-example.com"
+```

--- a/charts/nginx-ingress/templates/_helpers.tpl
+++ b/charts/nginx-ingress/templates/_helpers.tpl
@@ -59,3 +59,14 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- printf "%s-%s-%s" .Release.Name $name .Values.defaultBackend.name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "nginx-ingress.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "nginx-ingress.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/charts/nginx-ingress/templates/clusterrole.yaml
+++ b/charts/nginx-ingress/templates/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create -}}
+{{- if and .Values.rbac.create (not .Values.controller.scope.enabled) -}}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:

--- a/charts/nginx-ingress/templates/clusterrolebinding.yaml
+++ b/charts/nginx-ingress/templates/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create -}}
+{{- if and .Values.rbac.create (not .Values.controller.scope.enabled) -}}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
@@ -14,6 +14,6 @@ roleRef:
   name: {{ template "nginx-ingress.fullname" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ template "nginx-ingress.fullname" . }}
+    name: {{ template "nginx-ingress.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/charts/nginx-ingress/templates/controller-daemonset.yaml
+++ b/charts/nginx-ingress/templates/controller-daemonset.yaml
@@ -29,6 +29,14 @@ spec:
 {{ toYaml .Values.controller.podLabels | indent 8}}
         {{- end }}
     spec:
+      dnsPolicy: {{ .Values.controller.dnsPolicy }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
+      {{- end }}
+{{- if .Values.controller.priorityClassName }}
+      priorityClassName: "{{ .Values.controller.priorityClassName }}"
+{{- end }}
       containers:
         - name: {{ template "nginx-ingress.name" . }}-{{ .Values.controller.name }}
           image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
@@ -40,16 +48,16 @@ spec:
           args:
             - /nginx-ingress-controller
             - --default-backend-service={{ if .Values.defaultBackend.enabled }}{{ .Release.Namespace }}/{{ template "nginx-ingress.defaultBackend.fullname" . }}{{ else }}{{ .Values.controller.defaultBackendService }}{{ end }}
-          {{- if and (contains "0.9" .Values.controller.image.tag) .Values.controller.publishService.enabled }}
+          {{- if and (semverCompare ">=0.9.0-beta.1" .Values.controller.image.tag) .Values.controller.publishService.enabled }}
             - --publish-service={{ template "nginx-ingress.controller.publishServicePath" . }}
           {{- end }}
-          {{- if (contains "0.9" .Values.controller.image.tag) }}
+          {{- if (semverCompare ">=0.9.0-beta.1" .Values.controller.image.tag) }}
             - --election-id={{ .Values.controller.electionID }}
           {{- end }}
-          {{- if (contains "0.9" .Values.controller.image.tag) }}
+          {{- if (semverCompare ">=0.9.0-beta.1" .Values.controller.image.tag) }}
             - --ingress-class={{ .Values.controller.ingressClass }}
           {{- end }}
-          {{- if (contains "0.9" .Values.controller.image.tag) }}
+          {{- if (semverCompare ">=0.9.0-beta.1" .Values.controller.image.tag) }}
             - --configmap={{ .Release.Namespace }}/{{ template "nginx-ingress.controller.fullname" . }}
           {{- else }}
             - --nginx-configmap={{ .Release.Namespace }}/{{ template "nginx-ingress.controller.fullname" . }}
@@ -79,34 +87,41 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          {{- range $key, $value := .Values.controller.extraEnvs }}
-            - name: {{ $key | upper | replace "." "_" }}
-              value: {{ $value }}
+          {{- if .Values.controller.extraEnvs }}
+{{ toYaml .Values.controller.extraEnvs | indent 12 }}
           {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz
-              port: 10254
+              port: {{ .Values.controller.livenessProbe.port }}
               scheme: HTTP
-            initialDelaySeconds: 10
-            timeoutSeconds: 1
+            initialDelaySeconds: {{ .Values.controller.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.controller.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.controller.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.controller.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.controller.livenessProbe.failureThreshold }}
           ports:
             - name: http
               containerPort: 80
               protocol: TCP
-              {{- if .Values.controller.daemonset.useHostPorts }}
-              hostPort: 80
+              {{- if .Values.controller.daemonset.useHostPort }}
+              hostPort: {{ .Values.controller.daemonset.hostPorts.http }}
               {{- end }}
             - name: https
               containerPort: 443
               protocol: TCP
-              {{- if .Values.controller.daemonset.useHostPorts }}
-              hostPort: 443
+              {{- if .Values.controller.daemonset.useHostPort }}
+              hostPort: {{ .Values.controller.daemonset.hostPorts.https }}
               {{- end }}
           {{- if .Values.controller.stats.enabled }}
             - name: stats
               containerPort: 18080
               protocol: TCP
+            {{- if .Values.controller.metrics.enabled }}
+            - name: metrics
+              containerPort: 10254
+              protocol: TCP
+            {{- end }}
           {{- end }}
           {{- range $key, $value := .Values.tcp }}
             - name: "{{ $key }}-tcp"
@@ -121,36 +136,33 @@ spec:
           readinessProbe:
             httpGet:
               path: /healthz
-              port: 10254
+              port: {{ .Values.controller.readinessProbe.port }}
               scheme: HTTP
-{{- if .Values.controller.customTemplate.configMapName }}
+            initialDelaySeconds: {{ .Values.controller.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.controller.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.controller.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.controller.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.controller.readinessProbe.failureThreshold }}
+{{- if (or .Values.controller.customTemplate.configMapName .Values.controller.extraVolumeMounts) }}
           volumeMounts:
+{{- end }}
+{{- if .Values.controller.customTemplate.configMapName }}
             - mountPath: /etc/nginx/template
               name: nginx-template-volume
               readOnly: true
 {{- end }}
+{{- if .Values.controller.extraVolumeMounts }}
+{{ toYaml .Values.controller.extraVolumeMounts | indent 10}}
+{{- end }}
           resources:
 {{ toYaml .Values.controller.resources | indent 12 }}
-      {{- if .Values.controller.stats.enabled }}
-        - name: {{ template "nginx-ingress.name" . }}-{{ .Values.statsExporter.name }}
-          image: "{{ .Values.statsExporter.image.repository }}:{{ .Values.statsExporter.image.tag }}"
-          imagePullPolicy: "{{ .Values.statsExporter.image.pullPolicy }}"
-          env:
-            - name: METRICS_ADDR
-              value: ":9913"
-            - name: METRICS_ENDPOINT
-              value: "{{ .Values.statsExporter.endpoint }}"
-            - name: METRICS_NS
-              value: "{{ .Values.statsExporter.metricsNamespace }}"
-            - name: NGINX_STATUS
-              value: "{{ .Values.statsExporter.statusPage }}"
-          ports:
-            - name: metrics
-              containerPort: 9913
-              protocol: TCP
-          resources:
-{{ toYaml .Values.statsExporter.resources | indent 12 }}
-      {{- end }}
+{{- if .Values.controller.extraContainers }}
+{{ toYaml .Values.controller.extraContainers | indent 8}}
+{{- end }}
+{{- if .Values.controller.extraInitContainers }}
+      initContainers:
+{{ toYaml .Values.controller.extraInitContainers | indent 8}}
+{{- end }}
       hostNetwork: {{ .Values.controller.hostNetwork }}
     {{- if .Values.controller.nodeSelector }}
       nodeSelector:
@@ -160,10 +172,16 @@ spec:
       tolerations:
 {{ toYaml .Values.controller.tolerations | indent 8 }}
     {{- end }}
-      serviceAccountName: {{ if .Values.rbac.create }}{{ template "nginx-ingress.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
+    {{- if .Values.controller.affinity }}
+      affinity:
+{{ toYaml .Values.controller.affinity | indent 8 }}
+    {{- end }}
+      serviceAccountName: {{ template "nginx-ingress.serviceAccountName" . }}
       terminationGracePeriodSeconds: 60
-{{- if .Values.controller.customTemplate.configMapName }}
+{{- if (or .Values.controller.customTemplate.configMapName .Values.controller.extraVolumes) }}
       volumes:
+{{- end }}
+{{- if .Values.controller.customTemplate.configMapName }}
         - name: nginx-template-volume
           configMap:
             name: {{ .Values.controller.customTemplate.configMapName }}
@@ -171,6 +189,7 @@ spec:
             - key: {{ .Values.controller.customTemplate.configMapKey }}
               path: nginx.tmpl
 {{- end }}
-  updateStrategy:
-{{ toYaml .Values.controller.updateStrategy | indent 4 }}
+{{- if .Values.controller.extraVolumes }}
+{{ toYaml .Values.controller.extraVolumes | indent 6}}
+{{- end }}
 {{- end }}

--- a/charts/nginx-ingress/templates/controller-deployment.yaml
+++ b/charts/nginx-ingress/templates/controller-deployment.yaml
@@ -47,6 +47,7 @@ spec:
           {{- end }}
           args:
             - /nginx-ingress-controller
+            - --enable-dynamic-configuration
             - --default-backend-service={{ if .Values.defaultBackend.enabled }}{{ .Release.Namespace }}/{{ template "nginx-ingress.defaultBackend.fullname" . }}{{ else }}{{ .Values.controller.defaultBackendService }}{{ end }}
           {{- if and (semverCompare ">=0.9.0-beta.1" .Values.controller.image.tag) .Values.controller.publishService.enabled }}
             - --publish-service={{ template "nginx-ingress.controller.publishServicePath" . }}

--- a/charts/nginx-ingress/templates/controller-deployment.yaml
+++ b/charts/nginx-ingress/templates/controller-deployment.yaml
@@ -17,9 +17,8 @@ spec:
   minReadySeconds: {{ .Values.controller.minReadySeconds }}
   template:
     metadata:
-      annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/controller-configmap.yaml") . | sha256sum }}
       {{- if .Values.controller.podAnnotations }}
+      annotations:
 {{ toYaml .Values.controller.podAnnotations | indent 8}}
       {{- end }}
       labels:
@@ -30,6 +29,14 @@ spec:
 {{ toYaml .Values.controller.podLabels | indent 8 }}
         {{- end }}
     spec:
+      dnsPolicy: {{ .Values.controller.dnsPolicy }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
+      {{- end }}
+{{- if .Values.controller.priorityClassName }}
+      priorityClassName: "{{ .Values.controller.priorityClassName }}"
+{{- end }}
       containers:
         - name: {{ template "nginx-ingress.name" . }}-{{ .Values.controller.name }}
           image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
@@ -41,16 +48,16 @@ spec:
           args:
             - /nginx-ingress-controller
             - --default-backend-service={{ if .Values.defaultBackend.enabled }}{{ .Release.Namespace }}/{{ template "nginx-ingress.defaultBackend.fullname" . }}{{ else }}{{ .Values.controller.defaultBackendService }}{{ end }}
-          {{- if and (contains "0.9" .Values.controller.image.tag) .Values.controller.publishService.enabled }}
+          {{- if and (semverCompare ">=0.9.0-beta.1" .Values.controller.image.tag) .Values.controller.publishService.enabled }}
             - --publish-service={{ template "nginx-ingress.controller.publishServicePath" . }}
           {{- end }}
-          {{- if (contains "0.9" .Values.controller.image.tag) }}
+          {{- if (semverCompare ">=0.9.0-beta.1" .Values.controller.image.tag) }}
             - --election-id={{ .Values.controller.electionID }}
           {{- end }}
-          {{- if (contains "0.9" .Values.controller.image.tag) }}
+          {{- if (semverCompare ">=0.9.0-beta.1" .Values.controller.image.tag) }}
             - --ingress-class={{ .Values.controller.ingressClass }}
           {{- end }}
-          {{- if (contains "0.9" .Values.controller.image.tag) }}
+          {{- if (semverCompare ">=0.9.0-beta.1" .Values.controller.image.tag) }}
             - --configmap={{ .Release.Namespace }}/{{ template "nginx-ingress.controller.fullname" . }}
           {{- else }}
             - --nginx-configmap={{ .Release.Namespace }}/{{ template "nginx-ingress.controller.fullname" . }}
@@ -80,17 +87,19 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          {{- range $key, $value := .Values.controller.extraEnvs }}
-            - name: {{ $key | upper | replace "." "_" }}
-              value: {{ $value }}
+          {{- if .Values.controller.extraEnvs }}
+{{ toYaml .Values.controller.extraEnvs | indent 12 }}
           {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz
-              port: 10254
+              port: {{ .Values.controller.livenessProbe.port }}
               scheme: HTTP
-            initialDelaySeconds: 10
-            timeoutSeconds: 1
+            initialDelaySeconds: {{ .Values.controller.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.controller.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.controller.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.controller.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.controller.livenessProbe.failureThreshold }}
           ports:
             - name: http
               containerPort: 80
@@ -98,13 +107,15 @@ spec:
             - name: https
               containerPort: 443
               protocol: TCP
-            - name: httpredirect
-              containerPort: 8000
-              protocol: TCP
           {{- if .Values.controller.stats.enabled }}
             - name: stats
               containerPort: 18080
               protocol: TCP
+            {{- if .Values.controller.metrics.enabled }}
+            - name: metrics
+              containerPort: 10254
+              protocol: TCP
+            {{- end }}
           {{- end }}
           {{- range $key, $value := .Values.tcp }}
             - name: "{{ $key }}-tcp"
@@ -119,36 +130,33 @@ spec:
           readinessProbe:
             httpGet:
               path: /healthz
-              port: 10254
+              port: {{ .Values.controller.readinessProbe.port }}
               scheme: HTTP
-{{- if .Values.controller.customTemplate.configMapName }}
+            initialDelaySeconds: {{ .Values.controller.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.controller.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.controller.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.controller.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.controller.readinessProbe.failureThreshold }}
+{{- if (or .Values.controller.customTemplate.configMapName .Values.controller.extraVolumeMounts) }}
           volumeMounts:
+{{- end }}
+{{- if .Values.controller.customTemplate.configMapName }}
             - mountPath: /etc/nginx/template
               name: nginx-template-volume
               readOnly: true
 {{- end }}
+{{- if .Values.controller.extraVolumeMounts }}
+{{ toYaml .Values.controller.extraVolumeMounts | indent 12}}
+{{- end }}
           resources:
 {{ toYaml .Values.controller.resources | indent 12 }}
-      {{- if .Values.controller.stats.enabled }}
-        - name: {{ template "nginx-ingress.name" . }}-{{ .Values.statsExporter.name }}
-          image: "{{ .Values.statsExporter.image.repository }}:{{ .Values.statsExporter.image.tag }}"
-          imagePullPolicy: "{{ .Values.statsExporter.image.pullPolicy }}"
-          env:
-            - name: METRICS_ADDR
-              value: ":9913"
-            - name: METRICS_ENDPOINT
-              value: "{{ .Values.statsExporter.endpoint }}"
-            - name: METRICS_NS
-              value: "{{ .Values.statsExporter.metricsNamespace }}"
-            - name: NGINX_STATUS
-              value: "{{ .Values.statsExporter.statusPage }}"
-          ports:
-            - name: metrics
-              containerPort: 9913
-              protocol: TCP
-          resources:
-{{ toYaml .Values.statsExporter.resources | indent 12 }}
-      {{- end }}
+{{- if .Values.controller.extraContainers }}
+{{ toYaml .Values.controller.extraContainers | indent 8}}
+{{- end }}
+{{- if .Values.controller.extraInitContainers }}
+      initContainers:
+{{ toYaml .Values.controller.extraInitContainers | indent 8}}
+{{- end }}
       hostNetwork: {{ .Values.controller.hostNetwork }}
     {{- if .Values.controller.nodeSelector }}
       nodeSelector:
@@ -158,15 +166,24 @@ spec:
       tolerations:
 {{ toYaml .Values.controller.tolerations | indent 8 }}
     {{- end }}
-      serviceAccountName: {{ if .Values.rbac.create }}{{ template "nginx-ingress.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
+    {{- if .Values.controller.affinity }}
+      affinity:
+{{ toYaml .Values.controller.affinity | indent 8 }}
+    {{- end }}
+      serviceAccountName: {{ template "nginx-ingress.serviceAccountName" . }}
       terminationGracePeriodSeconds: 60
-{{- if .Values.controller.customTemplate.configMapName }}
+{{- if (or .Values.controller.customTemplate.configMapName .Values.controller.extraVolumes) }}
       volumes:
+{{- end }}
+{{- if .Values.controller.customTemplate.configMapName }}
         - name: nginx-template-volume
           configMap:
             name: {{ .Values.controller.customTemplate.configMapName }}
             items:
             - key: {{ .Values.controller.customTemplate.configMapKey }}
               path: nginx.tmpl
+{{- end }}
+{{- if .Values.controller.extraVolumes }}
+{{ toYaml .Values.controller.extraVolumes | indent 8}}
 {{- end }}
 {{- end }}

--- a/charts/nginx-ingress/templates/controller-hpa.yaml
+++ b/charts/nginx-ingress/templates/controller-hpa.yaml
@@ -18,9 +18,13 @@ spec:
   minReplicas: {{ .Values.controller.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.controller.autoscaling.maxReplicas }}
   metrics:
-  - type: Resource
-    resource:
-      name: cpu
-      targetAverageUtilization: {{ .Values.controller.autoscaling.targetAverageUtilization }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.controller.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.controller.autoscaling.targetMemoryUtilizationPercentage }}
 {{- end }}
 {{- end }}

--- a/charts/nginx-ingress/templates/controller-metrics-service.yaml
+++ b/charts/nginx-ingress/templates/controller-metrics-service.yaml
@@ -1,10 +1,10 @@
-{{- if .Values.controller.stats.enabled }}
+{{- if and .Values.controller.stats.enabled .Values.controller.metrics.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
-{{- if .Values.statsExporter.service.annotations }}
+{{- if .Values.controller.metrics.service.annotations }}
   annotations:
-{{ toYaml .Values.statsExporter.service.annotations | indent 4 }}
+{{ toYaml .Values.controller.metrics.service.annotations | indent 4 }}
 {{- end }}
   labels:
     app: {{ template "nginx-ingress.name" . }}
@@ -14,25 +14,25 @@ metadata:
     release: {{ .Release.Name }}
   name: {{ template "nginx-ingress.controller.fullname" . }}-metrics
 spec:
-  clusterIP: "{{ .Values.statsExporter.service.clusterIP }}"
-{{- if .Values.statsExporter.service.externalIPs }}
+  clusterIP: "{{ .Values.controller.metrics.service.clusterIP }}"
+{{- if .Values.controller.metrics.service.externalIPs }}
   externalIPs:
-{{ toYaml .Values.statsExporter.service.externalIPs | indent 4 }}
+{{ toYaml .Values.controller.metrics.service.externalIPs | indent 4 }}
 {{- end }}
-{{- if .Values.statsExporter.service.loadBalancerIP }}
-  loadBalancerIP: "{{ .Values.statsExporter.service.loadBalancerIP }}"
+{{- if .Values.controller.metrics.service.loadBalancerIP }}
+  loadBalancerIP: "{{ .Values.controller.metrics.service.loadBalancerIP }}"
 {{- end }}
-{{- if .Values.statsExporter.service.loadBalancerSourceRanges }}
+{{- if .Values.controller.metrics.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
-{{ toYaml .Values.statsExporter.service.loadBalancerSourceRanges | indent 4 }}
+{{ toYaml .Values.controller.metrics.service.loadBalancerSourceRanges | indent 4 }}
 {{- end }}
   ports:
     - name: metrics
-      port: {{ .Values.statsExporter.service.servicePort }}
-      targetPort: {{ .Values.statsExporter.service.targetPort }}
+      port: {{ .Values.controller.metrics.service.servicePort }}
+      targetPort: metrics
   selector:
     app: {{ template "nginx-ingress.name" . }}
     component: "{{ .Values.controller.name }}"
     release: {{ .Release.Name }}
-  type: "{{ .Values.statsExporter.service.type }}"
+  type: "{{ .Values.controller.metrics.service.type }}"
 {{- end }}

--- a/charts/nginx-ingress/templates/controller-nlb-service.yaml
+++ b/charts/nginx-ingress/templates/controller-nlb-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "nginx-ingress.controller.fullname" . }}-nlb
+  namespace: {{ .Release.Namespace }}
+  annotations:
+  # https://github.com/kubernetes/kubernetes/blob/10688257e63e4d778c499ba30cddbc8c6219abe9/pkg/cloudprovider/providers/aws/aws.go#L98
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+spec:
+  loadBalancerSourceRanges:
+    - "0.0.0.0/0"
+  externalTrafficPolicy: Local
+  selector:
+    app: {{ template "nginx-ingress.name" . }}
+  ports:
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: 443
+  # https://github.com/kubernetes/kubernetes/issues/56703
+  type: LoadBalancer

--- a/charts/nginx-ingress/templates/controller-poddisruptionbudget.yaml
+++ b/charts/nginx-ingress/templates/controller-poddisruptionbudget.yaml
@@ -1,0 +1,17 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app: {{ template "nginx-ingress.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: "{{ .Values.controller.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "nginx-ingress.controller.fullname" . }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "nginx-ingress.name" . }}
+      release: {{ .Release.Name }}
+      component: "{{ .Values.controller.name }}"
+  minAvailable: {{ .Values.controller.minAvailable }}

--- a/charts/nginx-ingress/templates/controller-service.yaml
+++ b/charts/nginx-ingress/templates/controller-service.yaml
@@ -6,6 +6,9 @@ metadata:
 {{ toYaml .Values.controller.service.annotations | indent 4 }}
 {{- end }}
   labels:
+{{- if .Values.controller.service.labels }}
+{{ toYaml .Values.controller.service.labels | indent 4 }}
+{{- end }}
     app: {{ template "nginx-ingress.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     component: "{{ .Values.controller.name }}"
@@ -25,13 +28,14 @@ spec:
   loadBalancerSourceRanges:
 {{ toYaml .Values.controller.service.loadBalancerSourceRanges | indent 4 }}
 {{- end }}
-{{- if and (ge .Capabilities.KubeVersion.Minor "7") (.Values.controller.service.externalTrafficPolicy) }}
+{{- if and (semverCompare ">=1.7-0" .Capabilities.KubeVersion.GitVersion) (.Values.controller.service.externalTrafficPolicy) }}
   externalTrafficPolicy: "{{ .Values.controller.service.externalTrafficPolicy }}"
 {{- end }}
-{{- if and (ge .Capabilities.KubeVersion.Minor "7") (.Values.controller.service.healthCheckNodePort) }}
+{{- if and (semverCompare ">=1.7-0" .Capabilities.KubeVersion.GitVersion) (.Values.controller.service.healthCheckNodePort) }}
   healthCheckNodePort: {{ .Values.controller.service.healthCheckNodePort }}
 {{- end }}
   ports:
+    {{- if .Values.controller.service.enableHttp }}
     - name: http
       port: 80
       protocol: TCP
@@ -39,6 +43,8 @@ spec:
       {{- if (and (eq .Values.controller.service.type "NodePort") (not (empty .Values.controller.service.nodePorts.http))) }}
       nodePort: {{ .Values.controller.service.nodePorts.http }}
       {{- end }}
+    {{- end }}
+    {{- if .Values.controller.service.enableHttps }}
     - name: https
       port: 443
       protocol: TCP
@@ -46,17 +52,18 @@ spec:
       {{- if (and (eq .Values.controller.service.type "NodePort") (not (empty .Values.controller.service.nodePorts.https))) }}
       nodePort: {{ .Values.controller.service.nodePorts.https }}
       {{- end }}
+    {{- end }}
   {{- range $key, $value := .Values.tcp }}
     - name: "{{ $key }}-tcp"
       port: {{ $key }}
       protocol: TCP
-      targetPort: {{ $key }}
+      targetPort: "{{ $key }}-tcp"
   {{- end }}
   {{- range $key, $value := .Values.udp }}
     - name: "{{ $key }}-udp"
       port: {{ $key }}
       protocol: UDP
-      targetPort: {{ $key }}
+      targetPort: "{{ $key }}-udp"
   {{- end }}
   selector:
     app: {{ template "nginx-ingress.name" . }}

--- a/charts/nginx-ingress/templates/controller-stats-service.yaml
+++ b/charts/nginx-ingress/templates/controller-stats-service.yaml
@@ -29,7 +29,7 @@ spec:
   ports:
     - name: stats
       port: {{ .Values.controller.stats.service.servicePort }}
-      targetPort: 18080
+      targetPort: stats
   selector:
     app: {{ template "nginx-ingress.name" . }}
     component: "{{ .Values.controller.name }}"

--- a/charts/nginx-ingress/templates/default-backend-deployment.yaml
+++ b/charts/nginx-ingress/templates/default-backend-deployment.yaml
@@ -26,6 +26,13 @@ spec:
 {{ toYaml .Values.defaultBackend.podLabels | indent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
+      {{- end }}
+{{- if .Values.defaultBackend.priorityClassName }}
+      priorityClassName: "{{ .Values.defaultBackend.priorityClassName }}"
+{{- end }}
       containers:
         - name: {{ template "nginx-ingress.name" . }}-{{ .Values.defaultBackend.name }}
           image: "{{ .Values.defaultBackend.image.repository }}:{{ .Values.defaultBackend.image.tag }}"
@@ -46,7 +53,8 @@ spec:
             initialDelaySeconds: 30
             timeoutSeconds: 5
           ports:
-            - containerPort: 8080
+            - name: http
+              containerPort: 8080
               protocol: TCP
           resources:
 {{ toYaml .Values.defaultBackend.resources | indent 12 }}
@@ -57,6 +65,10 @@ spec:
     {{- if .Values.defaultBackend.tolerations }}
       tolerations:
 {{ toYaml .Values.defaultBackend.tolerations | indent 8 }}
+    {{- end }}
+    {{- if .Values.defaultBackend.affinity }}
+      affinity:
+{{ toYaml .Values.defaultBackend.affinity | indent 8 }}
     {{- end }}
       terminationGracePeriodSeconds: 60
 {{- end }}

--- a/charts/nginx-ingress/templates/default-backend-poddisruptionbudget.yaml
+++ b/charts/nginx-ingress/templates/default-backend-poddisruptionbudget.yaml
@@ -1,0 +1,17 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app: {{ template "nginx-ingress.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: "{{ .Values.defaultBackend.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "nginx-ingress.defaultBackend.fullname" . }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "nginx-ingress.name" . }}
+      release: {{ .Release.Name }}
+      component: "{{ .Values.defaultBackend.name }}"
+  minAvailable: {{ .Values.defaultBackend.minAvailable }}

--- a/charts/nginx-ingress/templates/default-backend-service.yaml
+++ b/charts/nginx-ingress/templates/default-backend-service.yaml
@@ -27,8 +27,10 @@ spec:
 {{ toYaml .Values.defaultBackend.service.loadBalancerSourceRanges | indent 4 }}
 {{- end }}
   ports:
-    - port: {{ .Values.defaultBackend.service.servicePort }}
-      targetPort: 8080
+    - name: http
+      port: {{ .Values.defaultBackend.service.servicePort }}
+      protocol: TCP
+      targetPort: http
   selector:
     app: {{ template "nginx-ingress.name" . }}
     component: "{{ .Values.defaultBackend.name }}"

--- a/charts/nginx-ingress/templates/role.yaml
+++ b/charts/nginx-ingress/templates/role.yaml
@@ -12,12 +12,43 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - configmaps
       - namespaces
-      - pods
-      - secrets
     verbs:
       - get
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - pods
+      - secrets
+      - endpoints
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses/status
+    verbs:
+      - update
   - apiGroups:
       - ""
     resources:
@@ -41,4 +72,11 @@ rules:
       - create
       - get
       - update
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
 {{- end -}}

--- a/charts/nginx-ingress/templates/rolebinding.yaml
+++ b/charts/nginx-ingress/templates/rolebinding.yaml
@@ -14,6 +14,6 @@ roleRef:
   name: {{ template "nginx-ingress.fullname" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ template "nginx-ingress.fullname" . }}
+    name: {{ template "nginx-ingress.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/charts/nginx-ingress/templates/serviceaccount.yaml
+++ b/charts/nginx-ingress/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create -}}
+{{- if or .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -7,5 +7,5 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "nginx-ingress.fullname" . }}
+  name: {{ template "nginx-ingress.serviceAccountName" . }}
 {{- end -}}

--- a/charts/nginx-ingress/values.yaml
+++ b/charts/nginx-ingress/values.yaml
@@ -4,11 +4,14 @@
 controller:
   name: controller
   image:
-    repository: k8s.gcr.io/nginx-ingress-controller
-    tag: "0.9.0-beta.15"
+    repository: quay.io/kubernetes-ingress-controller/nginx-ingress-controller
+    tag: "0.15.0"
     pullPolicy: IfNotPresent
 
+  # Add a snippet to each nginx server{} block, forcing HTTP->HTTPS
+  # redirection regardless of Ingress rule config
   config: {}
+
   # Will add custom header to Nginx https://github.com/kubernetes/ingress-nginx/tree/master/docs/examples/customization/custom-headers
   headers: {}
 
@@ -17,9 +20,18 @@ controller:
   # is merged
   hostNetwork: false
 
+  # Optionally change this to ClusterFirstWithHostNet in case you have 'hostNetwork: true'.
+  # By default, while using host network, name resolution uses the host's DNS. If you wish nginx-controller
+  # to keep resolving names inside the k8s network, use ClusterFirstWithHostNet.
+  dnsPolicy: ClusterFirst
+
   ## Use host ports 80 and 443
   daemonset:
     useHostPort: false
+
+    hostPorts:
+      http: 80
+      https: 443
 
   ## Required only if defaultBackend.enabled = false
   ## Must be <namespace>/<service_name>
@@ -60,8 +72,13 @@ controller:
   extraArgs: {}
 
   ## Additional environment variables to set
-  ##
-  extraEnvs: {}
+  extraEnvs: []
+  # extraEnvs:
+  #   - name: FOO
+  #     valueFrom:
+  #       secretKeyRef:
+  #         key: FOO
+  #         name: secret-resource
 
   ## DaemonSet or Deployment
   ##
@@ -69,10 +86,11 @@ controller:
 
   # The update strategy to apply to the Deployment or DaemonSet
   ##
-  updateStrategy: {}
-  #  rollingUpdate:
-  #    maxUnavailable: 1
-  #  type: RollingUpdate
+  updateStrategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
 
   # minReadySeconds to avoid killing pods before we are ready
   ##
@@ -88,16 +106,38 @@ controller:
   #    value: "value"
   #    effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
 
+  affinity: {}
+
   ## Node labels for controller pod assignment
   ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
   ##
   nodeSelector: {}
 
+  ## Liveness and readiness probe values
+  ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+  ##
+  livenessProbe:
+    failureThreshold: 3
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 1
+    port: 10254
+  readinessProbe:
+    failureThreshold: 3
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 1
+    port: 10254
+
   ## Annotations to be added to controller pods
   ##
   podAnnotations: {}
 
-  replicaCount: 1
+  replicaCount: 3
+
+  minAvailable: 1
 
   resources: {}
   #  limits:
@@ -111,915 +151,17 @@ controller:
     enabled: false
   #  minReplicas: 1
   #  maxReplicas: 11
-  #  targetAverageUtilization: 50
+  #  targetCPUUtilizationPercentage: 50
+  #  targetMemoryUtilizationPercentage: 50
 
   ## Override NGINX template
   customTemplate:
-    configMapName: "nginx-ingress-customconfig"
-    configMapKey: "template"
-    template: |-
-      {{ $all := . }}
-      {{ $servers := .Servers }}
-      {{ $cfg := .Cfg }}
-      {{ $IsIPV6Enabled := .IsIPV6Enabled }}
-      {{ $healthzURI := .HealthzURI }}
-      {{ $backends := .Backends }}
-      {{ $proxyHeaders := .ProxySetHeaders }}
-      {{ $addHeaders := .AddHeaders }}
-
-      {{ if $cfg.EnableModsecurity }}
-      load_module /etc/nginx/modules/ngx_http_modsecurity_module.so;
-      {{ end }}
-
-      {{ if $cfg.EnableOpentracing }}
-      load_module /etc/nginx/modules/ngx_http_opentracing_module.so;
-      {{ end }}
-
-      {{ if (and $cfg.EnableOpentracing (ne $cfg.ZipkinCollectorHost "")) }}
-      load_module /etc/nginx/modules/ngx_http_zipkin_module.so;
-      {{ end }}
-
-      daemon off;
-
-      worker_processes {{ $cfg.WorkerProcesses }};
-      pid /run/nginx.pid;
-      {{ if ne .MaxOpenFiles 0 }}
-      worker_rlimit_nofile {{ .MaxOpenFiles }};
-      {{ end}}
-
-      {{/* http://nginx.org/en/docs/ngx_core_module.html#worker_shutdown_timeout */}}
-      {{/* avoid waiting too long during a reload */}}
-      worker_shutdown_timeout {{ $cfg.WorkerShutdownTimeout }} ;
-
-      events {
-          multi_accept        on;
-          worker_connections  {{ $cfg.MaxWorkerConnections }};
-          use                 epoll;
-      }
-
-      http {
-          {{/* we use the value of the header X-Forwarded-For to be able to use the geo_ip module */}}
-          {{ if $cfg.UseProxyProtocol }}
-          real_ip_header      proxy_protocol;
-          {{ else }}
-          real_ip_header      {{ $cfg.ForwardedForHeader }};
-          {{ end }}
-
-          real_ip_recursive   on;
-          {{ range $trusted_ip := $cfg.ProxyRealIPCIDR }}
-          set_real_ip_from    {{ $trusted_ip }};
-          {{ end }}
-
-          {{/* databases used to determine the country depending on the client IP address */}}
-          {{/* http://nginx.org/en/docs/http/ngx_http_geoip_module.html */}}
-          {{/* this is require to calculate traffic for individual country using GeoIP in the status page */}}
-          geoip_country       /etc/nginx/GeoIP.dat;
-          geoip_city          /etc/nginx/GeoLiteCity.dat;
-          geoip_proxy_recursive on;
-
-          {{ if $cfg.EnableVtsStatus }}
-          vhost_traffic_status_zone shared:vhost_traffic_status:{{ $cfg.VtsStatusZoneSize }};
-          vhost_traffic_status_filter_by_set_key {{ $cfg.VtsDefaultFilterKey }};
-          {{ end }}
-
-          sendfile            on;
-
-          aio                 threads;
-          aio_write           on;
-
-          tcp_nopush          on;
-          tcp_nodelay         on;
-
-          log_subrequest      on;
-
-          reset_timedout_connection on;
-
-          keepalive_timeout  {{ $cfg.KeepAlive }}s;
-          keepalive_requests {{ $cfg.KeepAliveRequests }};
-
-          client_header_buffer_size       {{ $cfg.ClientHeaderBufferSize }};
-          client_header_timeout           {{ $cfg.ClientHeaderTimeout }}s;
-          large_client_header_buffers     {{ $cfg.LargeClientHeaderBuffers }};
-          client_body_buffer_size         {{ $cfg.ClientBodyBufferSize }};
-          client_body_timeout             {{ $cfg.ClientBodyTimeout }}s;
-
-          http2_max_field_size            {{ $cfg.HTTP2MaxFieldSize }};
-          http2_max_header_size           {{ $cfg.HTTP2MaxHeaderSize }};
-
-          types_hash_max_size             2048;
-          server_names_hash_max_size      {{ $cfg.ServerNameHashMaxSize }};
-          server_names_hash_bucket_size   {{ $cfg.ServerNameHashBucketSize }};
-          map_hash_bucket_size            {{ $cfg.MapHashBucketSize }};
-
-          proxy_headers_hash_max_size     {{ $cfg.ProxyHeadersHashMaxSize }};
-          proxy_headers_hash_bucket_size  {{ $cfg.ProxyHeadersHashBucketSize }};
-
-          variables_hash_bucket_size      {{ $cfg.VariablesHashBucketSize }};
-          variables_hash_max_size         {{ $cfg.VariablesHashMaxSize }};
-
-          underscores_in_headers          {{ if $cfg.EnableUnderscoresInHeaders }}on{{ else }}off{{ end }};
-          ignore_invalid_headers          {{ if $cfg.IgnoreInvalidHeaders }}on{{ else }}off{{ end }};
-
-          {{ if $cfg.EnableOpentracing }}
-          opentracing on;
-          {{ end }}
-
-          {{ if (and $cfg.EnableOpentracing (ne $cfg.ZipkinCollectorHost "")) }}
-          zipkin_collector_host           {{ $cfg.ZipkinCollectorHost }};
-          zipkin_collector_port           {{ $cfg.ZipkinCollectorPort }};
-          zipkin_service_name             {{ $cfg.ZipkinServiceName }};
-          {{ end }}
-
-          include /etc/nginx/mime.types;
-          default_type text/html;
-
-          {{ if $cfg.EnableBrotli }}
-          brotli on;
-          brotli_comp_level {{ $cfg.BrotliLevel }};
-          brotli_types {{ $cfg.BrotliTypes }};
-          {{ end }}
-
-          {{ if $cfg.UseGzip }}
-          gzip on;
-          gzip_comp_level 5;
-          gzip_http_version 1.1;
-          gzip_min_length 256;
-          gzip_types {{ $cfg.GzipTypes }};
-          gzip_proxied any;
-          gzip_vary on;
-          {{ end }}
-
-          # Custom headers for response
-          {{ range $k, $v := $addHeaders }}
-          add_header {{ $k }}            "{{ $v }}";
-          {{ end }}
-
-          server_tokens {{ if $cfg.ShowServerTokens }}on{{ else }}off{{ end }};
-
-          # disable warnings
-          uninitialized_variable_warn off;
-
-          # Additional available variables:
-          # $namespace
-          # $ingress_name
-          # $service_name
-          log_format upstreaminfo {{ if $cfg.LogFormatEscapeJSON }}escape=json {{ end }}'{{ buildLogFormatUpstream $cfg }}';
-
-          {{/* map urls that should not appear in access.log */}}
-          {{/* http://nginx.org/en/docs/http/ngx_http_log_module.html#access_log */}}
-          map $request_uri $loggable {
-              {{ range $reqUri := $cfg.SkipAccessLogURLs }}
-              {{ $reqUri }} 0;{{ end }}
-              default 1;
-          }
-
-          {{ if $cfg.DisableAccessLog }}
-          access_log off;
-          {{ else }}
-          access_log {{ $cfg.AccessLogPath }} upstreaminfo if=$loggable;
-          {{ end }}
-          error_log  {{ $cfg.ErrorLogPath }} {{ $cfg.ErrorLogLevel }};
-
-          {{ buildResolvers $cfg.Resolver }}
-
-          {{/* Whenever nginx proxies a request without a "Connection" header, the "Connection" header is set to "close" */}}
-          {{/* when making the target request.  This means that you cannot simply use */}}
-          {{/* "proxy_set_header Connection $http_connection" for WebSocket support because in this case, the */}}
-          {{/* "Connection" header would be set to "" whenever the original request did not have a "Connection" header, */}}
-          {{/* which would mean no "Connection" header would be in the target request.  Since this would deviate from */}}
-          {{/* normal nginx behavior we have to use this approach. */}}
-          # Retain the default nginx handling of requests without a "Connection" header
-          map $http_upgrade $connection_upgrade {
-              default          upgrade;
-              ''               close;
-          }
-
-          map {{ buildForwardedFor $cfg.ForwardedForHeader }} $the_real_ip {
-          {{ if $cfg.UseProxyProtocol }}
-              # Get IP address from Proxy Protocol
-              default          $proxy_protocol_addr;
-          {{ else }}
-              default          $remote_addr;
-          {{ end }}
-          }
-
-          # trust http_x_forwarded_proto headers correctly indicate ssl offloading
-          map $http_x_forwarded_proto $pass_access_scheme {
-              default          $http_x_forwarded_proto;
-              ''               $scheme;
-          }
-
-          map $http_x_forwarded_port $pass_server_port {
-              default           $http_x_forwarded_port;
-              ''                $server_port;
-          }
-
-          map $http_x_forwarded_host $best_http_host {
-              default          $http_x_forwarded_host;
-              ''               $this_host;
-          }
-
-          {{ if $all.IsSSLPassthroughEnabled }}
-          # map port {{ $all.ListenPorts.SSLProxy }} to 443 for header X-Forwarded-Port
-          map $pass_server_port $pass_port {
-              {{ $all.ListenPorts.SSLProxy }}              443;
-              default          $pass_server_port;
-          }
-          {{ else }}
-          map $pass_server_port $pass_port {
-              443              443;
-              default          $pass_server_port;
-          }
-          {{ end }}
-
-          # Obtain best http host
-          map $http_host $this_host {
-              default          $http_host;
-              ''               $host;
-          }
-
-          {{ if $cfg.ComputeFullForwardedFor }}
-          # We can't use $proxy_add_x_forwarded_for because the realip module
-          # replaces the remote_addr too soon
-          map $http_x_forwarded_for $full_x_forwarded_for {
-              {{ if $all.Cfg.UseProxyProtocol }}
-              default          "$http_x_forwarded_for, $proxy_protocol_addr";
-              ''               "$proxy_protocol_addr";
-              {{ else }}
-              default          "$http_x_forwarded_for, $realip_remote_addr";
-              ''               "$realip_remote_addr";
-              {{ end}}
-          }
-          {{ end }}
-
-          server_name_in_redirect off;
-          port_in_redirect        off;
-
-          ssl_protocols {{ $cfg.SSLProtocols }};
-
-          # turn on session caching to drastically improve performance
-          {{ if $cfg.SSLSessionCache }}
-          ssl_session_cache builtin:1000 shared:SSL:{{ $cfg.SSLSessionCacheSize }};
-          ssl_session_timeout {{ $cfg.SSLSessionTimeout }};
-          {{ end }}
-
-          # allow configuring ssl session tickets
-          ssl_session_tickets {{ if $cfg.SSLSessionTickets }}on{{ else }}off{{ end }};
-
-          {{ if not (empty $cfg.SSLSessionTicketKey ) }}
-          ssl_session_ticket_key /etc/nginx/tickets.key;
-          {{ end }}
-
-          # slightly reduce the time-to-first-byte
-          ssl_buffer_size {{ $cfg.SSLBufferSize }};
-
-          {{ if not (empty $cfg.SSLCiphers) }}
-          # allow configuring custom ssl ciphers
-          ssl_ciphers '{{ $cfg.SSLCiphers }}';
-          ssl_prefer_server_ciphers on;
-          {{ end }}
-
-          {{ if not (empty $cfg.SSLDHParam) }}
-          # allow custom DH file http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_dhparam
-          ssl_dhparam {{ $cfg.SSLDHParam }};
-          {{ end }}
-
-          {{ if not $cfg.EnableDynamicTLSRecords }}
-          ssl_dyn_rec_size_lo 0;
-          {{ end }}
-
-          ssl_ecdh_curve {{ $cfg.SSLECDHCurve }};
-
-          {{ if .CustomErrors }}
-          # Custom error pages
-          proxy_intercept_errors on;
-          {{ end }}
-
-          {{ range $errCode := $cfg.CustomHTTPErrors }}
-          error_page {{ $errCode }} = @custom_{{ $errCode }};{{ end }}
-
-          proxy_ssl_session_reuse on;
-
-          {{ if $cfg.AllowBackendServerHeader }}
-          proxy_pass_header Server;
-          {{ end }}
-
-          {{ if not (empty $cfg.HTTPSnippet) }}
-          # Custom code snippet configured in the configuration configmap
-          {{ $cfg.HTTPSnippet }}
-          {{ end }}
-
-          {{ range $name, $upstream := $backends }}
-          {{ if eq $upstream.SessionAffinity.AffinityType "cookie" }}
-          upstream sticky-{{ $upstream.Name }} {
-              sticky hash={{ $upstream.SessionAffinity.CookieSessionAffinity.Hash }} name={{ $upstream.SessionAffinity.CookieSessionAffinity.Name }}  httponly;
-
-              {{ if (gt $cfg.UpstreamKeepaliveConnections 0) }}
-              keepalive {{ $cfg.UpstreamKeepaliveConnections }};
-              {{ end }}
-
-              {{ range $server := $upstream.Endpoints }}server {{ $server.Address | formatIP }}:{{ $server.Port }} max_fails={{ $server.MaxFails }} fail_timeout={{ $server.FailTimeout }};
-              {{ end }}
-
-          }
-
-          {{ end }}
-
-
-          upstream {{ $upstream.Name }} {
-              # Load balance algorithm; empty for round robin, which is the default
-              {{ if ne $cfg.LoadBalanceAlgorithm "round_robin" }}
-              {{ $cfg.LoadBalanceAlgorithm }};
-              {{ end }}
-
-              {{ if $upstream.UpstreamHashBy }}
-              hash {{ $upstream.UpstreamHashBy }} consistent;
-              {{ end }}
-
-              {{ if (gt $cfg.UpstreamKeepaliveConnections 0) }}
-              keepalive {{ $cfg.UpstreamKeepaliveConnections }};
-              {{ end }}
-
-              {{ range $server := $upstream.Endpoints }}server {{ $server.Address | formatIP }}:{{ $server.Port }} max_fails={{ $server.MaxFails }} fail_timeout={{ $server.FailTimeout }};
-              {{ end }}
-          }
-
-          {{ end }}
-
-          {{/* build the maps that will be use to validate the Whitelist */}}
-          {{ range $index, $server := $servers }}
-          {{ range $location := $server.Locations }}
-          {{ $path := buildLocation $location }}
-
-          {{ if isLocationAllowed $location }}
-          {{ if gt (len $location.Whitelist.CIDR) 0 }}
-
-          # Deny for {{ print $server.Hostname  $path }}
-          geo $the_real_ip {{ buildDenyVariable (print $server.Hostname "_"  $path) }} {
-              default 1;
-
-              {{ range $ip := $location.Whitelist.CIDR }}
-              {{ $ip }} 0;{{ end }}
-          }
-          {{ end }}
-          {{ end }}
-          {{ end }}
-          {{ end }}
-
-          {{ range $rl := (filterRateLimits $servers ) }}
-          # Ratelimit {{ $rl.Name }}
-          geo $the_real_ip $whitelist_{{ $rl.ID }} {
-              default 0;
-              {{ range $ip := $rl.Whitelist }}
-              {{ $ip }} 1;{{ end }}
-          }
-
-          # Ratelimit {{ $rl.Name }}
-          map $whitelist_{{ $rl.ID }} $limit_{{ $rl.ID }} {
-              0 {{ $cfg.LimitConnZoneVariable }};
-              1 "";
-          }
-          {{ end }}
-
-          {{/* build all the required rate limit zones. Each annotation requires a dedicated zone */}}
-          {{/* 1MB -> 16 thousand 64-byte states or about 8 thousand 128-byte states */}}
-          {{ range $zone := (buildRateLimitZones $servers) }}
-          {{ $zone }}
-          {{ end }}
-
-          {{/* Build server redirects (from/to www) */}}
-          {{ range $hostname, $to := .RedirectServers }}
-          server {
-              {{ range $address := $all.Cfg.BindAddressIpv4 }}
-              listen {{ $address }}:{{ $all.ListenPorts.HTTP }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }};
-              listen {{ $address }}:{{ if $all.IsSSLPassthroughEnabled }}{{ $all.ListenPorts.SSLProxy }} proxy_protocol{{ else }}{{ $all.ListenPorts.HTTPS }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }}{{ end }} ssl;
-              {{ else }}
-              listen {{ $all.ListenPorts.HTTP }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }};
-              listen {{ if $all.IsSSLPassthroughEnabled }}{{ $all.ListenPorts.SSLProxy }} proxy_protocol{{ else }}{{ $all.ListenPorts.HTTPS }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }}{{ end }} ssl;
-              {{ end }}
-              {{ if $IsIPV6Enabled }}
-              {{ range $address := $all.Cfg.BindAddressIpv6 }}
-              listen {{ $address }}:{{ $all.ListenPorts.HTTP }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }};
-              listen {{ $address }}:{{ if $all.IsSSLPassthroughEnabled }}{{ $all.ListenPorts.SSLProxy }} proxy_protocol{{ else }}{{ $all.ListenPorts.HTTPS }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }}{{ end }};
-              {{ else }}
-              listen [::]:{{ $all.ListenPorts.HTTP }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }};
-              listen [::]:{{ if $all.IsSSLPassthroughEnabled }}{{ $all.ListenPorts.SSLProxy }} proxy_protocol{{ else }}{{ $all.ListenPorts.HTTPS }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }}{{ end }};
-              {{ end }}
-              {{ end }}
-              server_name {{ $hostname }};
-
-              {{ if ne $all.ListenPorts.HTTPS 443 }}
-              {{ $redirect_port := (printf ":%v" $all.ListenPorts.HTTPS) }}
-              return {{ $all.Cfg.HTTPRedirectCode }} $scheme://{{ $to }}{{ $redirect_port }}$request_uri;
-              {{ else }}
-              return {{ $all.Cfg.HTTPRedirectCode }} $scheme://{{ $to }}$request_uri;
-              {{ end }}
-          }
-          {{ end }}
-
-          {{/* Handles HTTP traffic from ELB and redirects to HTTPS */}}
-          server {
-             listen 8000 proxy_protocol;
-             server_tokens off;
-             return 301 https://$host$request_uri;
-          }
-
-          {{ range $index, $server := $servers }}
-
-          ## start server {{ $server.Hostname }}
-          server {
-              server_name {{ $server.Hostname }} {{ $server.Alias }};
-              {{ template "SERVER" serverConfig $all $server }}
-
-              {{ if not (empty $cfg.ServerSnippet) }}
-              # Custom code snippet configured in the configuration configmap
-              {{ $cfg.ServerSnippet }}
-              {{ end }}
-
-              {{ template "CUSTOM_ERRORS" $all }}
-          }
-          ## end server {{ $server.Hostname }}
-
-          {{ end }}
-
-          # default server, used for NGINX healthcheck and access to nginx stats
-          server {
-              # Use the port {{ $all.ListenPorts.Status }} (random value just to avoid known ports) as default port for nginx.
-              # Changing this value requires a change in:
-              # https://github.com/kubernetes/ingress-nginx/blob/master/controllers/nginx/pkg/cmd/controller/nginx.go
-              listen {{ $all.ListenPorts.Status }} default_server reuseport backlog={{ $all.BacklogSize }};
-              {{ if $IsIPV6Enabled }}listen [::]:{{ $all.ListenPorts.Status }} default_server reuseport backlog={{ $all.BacklogSize }};{{ end }}
-              set $proxy_upstream_name "-";
-
-              location {{ $healthzURI }} {
-                  access_log off;
-                  return 200;
-              }
-
-              location /nginx_status {
-                  set $proxy_upstream_name "internal";
-
-                  {{ if $cfg.EnableVtsStatus }}
-                  vhost_traffic_status_display;
-                  vhost_traffic_status_display_format html;
-                  {{ else }}
-                  access_log off;
-                  stub_status on;
-                  {{ end }}
-              }
-
-              location / {
-                  {{ if .CustomErrors }}
-                  proxy_set_header    X-Code 404;
-                  {{ end }}
-                  set $proxy_upstream_name "upstream-default-backend";
-                  proxy_pass          http://upstream-default-backend;
-              }
-
-              {{ template "CUSTOM_ERRORS" $all }}
-          }
-      }
-
-      stream {
-          log_format log_stream {{ $cfg.LogFormatStream }};
-
-          {{ if $cfg.DisableAccessLog }}
-          access_log off;
-          {{ else }}
-          access_log {{ $cfg.AccessLogPath }} log_stream;
-          {{ end }}
-
-          error_log  {{ $cfg.ErrorLogPath }};
-
-          # TCP services
-          {{ range $i, $tcpServer := .TCPBackends }}
-          upstream tcp-{{ $tcpServer.Port }}-{{ $tcpServer.Backend.Namespace }}-{{ $tcpServer.Backend.Name }}-{{ $tcpServer.Backend.Port }} {
-          {{ range $j, $endpoint := $tcpServer.Endpoints }}
-              server                  {{ $endpoint.Address }}:{{ $endpoint.Port }};
-          {{ end }}
-          }
-          server {
-              {{ range $address := $all.Cfg.BindAddressIpv4 }}
-              listen                  {{ $address }}:{{ $tcpServer.Port }}{{ if $tcpServer.Backend.ProxyProtocol.Decode }} proxy_protocol{{ end }};
-              {{ else }}
-              listen                  {{ $tcpServer.Port }}{{ if $tcpServer.Backend.ProxyProtocol.Decode }} proxy_protocol{{ end }};
-              {{ end }}
-              {{ if $IsIPV6Enabled }}
-              {{ range $address := $all.Cfg.BindAddressIpv6 }}
-              listen                  {{ $address }}:{{ $tcpServer.Port }}{{ if $tcpServer.Backend.ProxyProtocol.Decode }} proxy_protocol{{ end }};
-              {{ else }}
-              listen                  [::]:{{ $tcpServer.Port }}{{ if $tcpServer.Backend.ProxyProtocol.Decode }} proxy_protocol{{ end }};
-              {{ end }}
-              {{ end }}
-              proxy_timeout           {{ $cfg.ProxyStreamTimeout }};
-              proxy_pass              tcp-{{ $tcpServer.Port }}-{{ $tcpServer.Backend.Namespace }}-{{ $tcpServer.Backend.Name }}-{{ $tcpServer.Backend.Port }};
-              {{ if $tcpServer.Backend.ProxyProtocol.Encode }}
-              proxy_protocol          on;
-              {{ end }}
-          }
-
-          {{ end }}
-
-          # UDP services
-          {{ range $i, $udpServer := .UDPBackends }}
-          upstream udp-{{ $udpServer.Port }}-{{ $udpServer.Backend.Namespace }}-{{ $udpServer.Backend.Name }}-{{ $udpServer.Backend.Port }} {
-          {{ range $j, $endpoint := $udpServer.Endpoints }}
-              server                  {{ $endpoint.Address }}:{{ $endpoint.Port }};
-          {{ end }}
-          }
-
-          server {
-              {{ range $address := $all.Cfg.BindAddressIpv4 }}
-              listen                  {{ $address }}:{{ $udpServer.Port }} udp;
-              {{ else }}
-              listen                  {{ $udpServer.Port }} udp;
-              {{ end }}
-              {{ if $IsIPV6Enabled }}
-              {{ range $address := $all.Cfg.BindAddressIpv6 }}
-              listen                  {{ $address }}:{{ $udpServer.Port }} udp;
-              {{ else }}
-              listen                  [::]:{{ $udpServer.Port }} udp;
-              {{ end }}
-              {{ end }}
-              proxy_responses         {{ $cfg.ProxyStreamResponses }};
-              proxy_timeout           {{ $cfg.ProxyStreamTimeout }};
-              proxy_pass              udp-{{ $udpServer.Port }}-{{ $udpServer.Backend.Namespace }}-{{ $udpServer.Backend.Name }}-{{ $udpServer.Backend.Port }};
-          }
-
-          {{ end }}
-      }
-
-      {{/* definition of templates to avoid repetitions */}}
-      {{ define "CUSTOM_ERRORS" }}
-              {{ $proxySetHeaders := .ProxySetHeaders }}
-              {{ range $errCode := .Cfg.CustomHTTPErrors }}
-              location @custom_{{ $errCode }} {
-                  internal;
-
-                  proxy_intercept_errors off;
-
-                  proxy_set_header       X-Code             {{ $errCode }};
-                  proxy_set_header       X-Format           $http_accept;
-                  proxy_set_header       X-Original-URI     $request_uri;
-                  proxy_set_header       X-Namespace        $namespace;
-                  proxy_set_header       X-Ingress-Name     $ingress_name;
-                  proxy_set_header       X-Service-Name     $service_name;
-
-                  rewrite                (.*) / break;
-                  proxy_pass             http://upstream-default-backend;
-              }
-              {{ end }}
-      {{ end }}
-
-      {{/* CORS support from https://michielkalkman.com/snippets/nginx-cors-open-configuration.html */}}
-      {{ define "CORS" }}
-           {{ $cors := .CorsConfig }}
-           # Cors Preflight methods needs additional options and different Return Code
-           if ($request_method = 'OPTIONS') {
-              add_header 'Access-Control-Allow-Origin' '{{ $cors.CorsAllowOrigin }}' always;
-              {{ if $cors.CorsAllowCredentials }} add_header 'Access-Control-Allow-Credentials' '{{ $cors.CorsAllowCredentials }}' always; {{ end }}
-              add_header 'Access-Control-Allow-Methods' '{{ $cors.CorsAllowMethods }}' always;
-              add_header 'Access-Control-Allow-Headers' '{{ $cors.CorsAllowHeaders }}' always;
-              add_header 'Access-Control-Max-Age' 1728000;
-              add_header 'Content-Type' 'text/plain charset=UTF-8';
-              add_header 'Content-Length' 0;
-              return 204;
-           }
-
-              add_header 'Access-Control-Allow-Origin' '{{ $cors.CorsAllowOrigin }}' always;
-              {{ if $cors.CorsAllowCredentials }} add_header 'Access-Control-Allow-Credentials' '{{ $cors.CorsAllowCredentials }}' always; {{ end }}
-              add_header 'Access-Control-Allow-Methods' '{{ $cors.CorsAllowMethods }}' always;
-              add_header 'Access-Control-Allow-Headers' '{{ $cors.CorsAllowHeaders }}' always;
-
-      {{ end }}
-
-      {{/* definition of server-template to avoid repetitions with server-alias */}}
-      {{ define "SERVER" }}
-              {{ $all := .First }}
-              {{ $server := .Second }}
-              {{ range $address := $all.Cfg.BindAddressIpv4 }}
-              listen {{ $address }}:{{ $all.ListenPorts.HTTP }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }}{{ if eq $server.Hostname "_"}} default_server reuseport backlog={{ $all.BacklogSize }}{{end}};
-              {{ else }}
-              listen {{ $all.ListenPorts.HTTP }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }}{{ if eq $server.Hostname "_"}} default_server reuseport backlog={{ $all.BacklogSize }}{{end}};
-              {{ end }}
-              {{ if $all.IsIPV6Enabled }}
-              {{ range $address := $all.Cfg.BindAddressIpv6 }}
-              listen {{ $address }}:{{ $all.ListenPorts.HTTP }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }}{{ if eq $server.Hostname "_"}} default_server reuseport backlog={{ $all.BacklogSize }}{{ end }};
-              {{ else }}
-              listen [::]:{{ $all.ListenPorts.HTTP }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }}{{ if eq $server.Hostname "_"}} default_server reuseport backlog={{ $all.BacklogSize }}{{ end }};
-              {{ end }}
-              {{ end }}
-              set $proxy_upstream_name "-";
-
-              {{/* Listen on {{ $all.ListenPorts.SSLProxy }} because port {{ $all.ListenPorts.HTTPS }} is used in the TLS sni server */}}
-              {{/* This listener must always have proxy_protocol enabled, because the SNI listener forwards on source IP info in it. */}}
-              {{ if not (empty $server.SSLCertificate) }}
-              {{ range $address := $all.Cfg.BindAddressIpv4 }}
-              listen {{ $address }}:{{ if $all.IsSSLPassthroughEnabled }}{{ $all.ListenPorts.SSLProxy }} proxy_protocol {{ else }}{{ $all.ListenPorts.HTTPS }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }}{{ end }} {{ if eq $server.Hostname "_"}} default_server reuseport backlog={{ $all.BacklogSize }}{{end}} ssl {{ if $all.Cfg.UseHTTP2 }}http2{{ end }};
-              {{ else }}
-              listen {{ if $all.IsSSLPassthroughEnabled }}{{ $all.ListenPorts.SSLProxy }} proxy_protocol {{ else }}{{ $all.ListenPorts.HTTPS }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }}{{ end }} {{ if eq $server.Hostname "_"}} default_server reuseport backlog={{ $all.BacklogSize }}{{end}} ssl {{ if $all.Cfg.UseHTTP2 }}http2{{ end }};
-              {{ end }}
-              {{ if $all.IsIPV6Enabled }}
-              {{ range $address := $all.Cfg.BindAddressIpv6 }}
-              {{ if not (empty $server.SSLCertificate) }}listen {{ $address }}:{{ if $all.IsSSLPassthroughEnabled }}{{ $all.ListenPorts.SSLProxy }} proxy_protocol{{ else }}{{ $all.ListenPorts.HTTPS }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }}{{ end }}{{ end }} {{ if eq $server.Hostname "_"}} default_server reuseport backlog={{ $all.BacklogSize }}{{end}} ssl {{ if $all.Cfg.UseHTTP2 }}http2{{ end }};
-              {{ else }}
-              {{ if not (empty $server.SSLCertificate) }}listen [::]:{{ if $all.IsSSLPassthroughEnabled }}{{ $all.ListenPorts.SSLProxy }} proxy_protocol{{ else }}{{ $all.ListenPorts.HTTPS }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }}{{ end }}{{ end }} {{ if eq $server.Hostname "_"}} default_server reuseport backlog={{ $all.BacklogSize }}{{end}} ssl {{ if $all.Cfg.UseHTTP2 }}http2{{ end }};
-              {{ end }}
-              {{ end }}
-              {{/* comment PEM sha is required to detect changes in the generated configuration and force a reload */}}
-              # PEM sha: {{ $server.SSLPemChecksum }}
-              ssl_certificate                         {{ $server.SSLCertificate }};
-              ssl_certificate_key                     {{ $server.SSLCertificate }};
-              {{ if not (empty $server.SSLFullChainCertificate)}}
-              ssl_trusted_certificate                 {{ $server.SSLFullChainCertificate }};
-              ssl_stapling                            on;
-              ssl_stapling_verify                     on;
-              {{ end }}
-              {{ end }}
-
-              {{ if (and (not (empty $server.SSLCertificate)) $all.Cfg.HSTS) }}
-              more_set_headers                        "Strict-Transport-Security: max-age={{ $all.Cfg.HSTSMaxAge }}{{ if $all.Cfg.HSTSIncludeSubdomains }}; includeSubDomains{{ end }};{{ if $all.Cfg.HSTSPreload }} preload{{ end }}";
-              {{ end }}
-
-
-              {{ if not (empty $server.CertificateAuth.CAFileName) }}
-              # PEM sha: {{ $server.CertificateAuth.PemSHA }}
-              ssl_client_certificate                  {{ $server.CertificateAuth.CAFileName }};
-              ssl_verify_client                       {{ $server.CertificateAuth.VerifyClient }};
-              ssl_verify_depth                        {{ $server.CertificateAuth.ValidationDepth }};
-              {{ if not (empty $server.CertificateAuth.ErrorPage)}}
-              error_page 495 496 = {{ $server.CertificateAuth.ErrorPage }};
-              {{ end }}
-              {{ end }}
-
-              {{ if not (empty $server.ServerSnippet) }}
-              {{ $server.ServerSnippet }}
-              {{ end }}
-
-              {{ range $location := $server.Locations }}
-              {{ $path := buildLocation $location }}
-              {{ $authPath := buildAuthLocation $location }}
-
-              {{ if not (empty $location.Rewrite.AppRoot)}}
-              if ($uri = /) {
-                  return 302 {{ $location.Rewrite.AppRoot }};
-              }
-              {{ end }}
-
-              {{ if not (empty $authPath) }}
-              location = {{ $authPath }} {
-                  internal;
-                  set $proxy_upstream_name "external-authentication";
-
-                  proxy_pass_request_body     off;
-                  proxy_set_header            Content-Length "";
-
-                  {{ if not (empty $location.ExternalAuth.Method) }}
-                  proxy_method                {{ $location.ExternalAuth.Method }};
-                  proxy_set_header            X-Original-URI          $request_uri;
-                  proxy_set_header            X-Scheme                $pass_access_scheme;
-                  {{ end }}
-
-                  proxy_set_header            Host                    {{ $location.ExternalAuth.Host }};
-                  proxy_set_header            X-Original-URL          $scheme://$http_host$request_uri;
-                  proxy_set_header            X-Original-Method       $request_method;
-                  proxy_set_header            X-Auth-Request-Redirect $request_uri;
-                  proxy_set_header            X-Sent-From             "nginx-ingress-controller";
-
-                  proxy_http_version          1.1;
-                  proxy_ssl_server_name       on;
-                  proxy_pass_request_headers  on;
-                  client_max_body_size        "{{ $location.Proxy.BodySize }}";
-                  {{ if isValidClientBodyBufferSize $location.ClientBodyBufferSize }}
-                  client_body_buffer_size     {{ $location.ClientBodyBufferSize }};
-                  {{ end }}
-
-                  set $target {{ $location.ExternalAuth.URL }};
-                  proxy_pass $target;
-              }
-              {{ end }}
-
-              location {{ $path }} {
-                  {{ if $all.Cfg.EnableVtsStatus }}{{ if $location.VtsFilterKey }} vhost_traffic_status_filter_by_set_key {{ $location.VtsFilterKey }};{{ end }}{{ end }}
-
-                  set $proxy_upstream_name "{{ buildUpstreamName $server.Hostname $all.Backends $location }}";
-
-                  {{ $ing := (getIngressInformation $location.Ingress $path) }}
-                  {{/* $ing.Metadata contains the Ingress metadata */}}
-                  set $namespace      "{{ $ing.Namespace }}";
-                  set $ingress_name   "{{ $ing.Rule }}";
-                  set $service_name   "{{ $ing.Service }}";
-
-                  {{ if (or $location.Rewrite.ForceSSLRedirect (and (not (empty $server.SSLCertificate)) $location.Rewrite.SSLRedirect)) }}
-                  # enforce ssl on server side
-                  if ($pass_access_scheme = http) {
-                      {{ if ne $all.ListenPorts.HTTPS 443 }}
-                      {{ $redirect_port := (printf ":%v" $all.ListenPorts.HTTPS) }}
-                      return {{ $all.Cfg.HTTPRedirectCode }} https://$best_http_host{{ $redirect_port }}$request_uri;
-                      {{ else }}
-                      return {{ $all.Cfg.HTTPRedirectCode }} https://$best_http_host$request_uri;
-                      {{ end }}
-                  }
-                  {{ end }}
-
-                  {{ if $all.Cfg.EnableModsecurity }}
-                  modsecurity on;
-
-                  modsecurity_rules_file /etc/nginx/modsecurity/modsecurity.conf;
-                  {{ if $all.Cfg.EnableOWASPCoreRules }}
-                  modsecurity_rules_file /etc/nginx/owasp-modsecurity-crs/nginx-modsecurity.conf;
-                  {{ end }}
-                  {{ end }}
-
-                  {{ if isLocationAllowed $location }}
-                  {{ if gt (len $location.Whitelist.CIDR) 0 }}
-                  if ({{ buildDenyVariable (print $server.Hostname "_"  $path) }}) {
-                      return 403;
-                  }
-                  {{ end }}
-
-                  port_in_redirect {{ if $location.UsePortInRedirects }}on{{ else }}off{{ end }};
-
-                  {{ if not (empty $authPath) }}
-                  # this location requires authentication
-                  auth_request        {{ $authPath }};
-                  auth_request_set    $auth_cookie $upstream_http_set_cookie;
-                  add_header          Set-Cookie $auth_cookie;
-                  {{- range $idx, $line := buildAuthResponseHeaders $location }}
-                  {{ $line }}
-                  {{- end }}
-                  {{ end }}
-
-                  {{ if not (empty $location.ExternalAuth.SigninURL) }}
-                  error_page 401 = {{ buildAuthSignURL $location.ExternalAuth.SigninURL }};
-                  {{ end }}
-
-                  {{/* if the location contains a rate limit annotation, create one */}}
-                  {{ $limits := buildRateLimit $location }}
-                  {{ range $limit := $limits }}
-                  {{ $limit }}{{ end }}
-
-                  {{ if $location.BasicDigestAuth.Secured }}
-                  {{ if eq $location.BasicDigestAuth.Type "basic" }}
-                  auth_basic "{{ $location.BasicDigestAuth.Realm }}";
-                  auth_basic_user_file {{ $location.BasicDigestAuth.File }};
-                  {{ else }}
-                  auth_digest "{{ $location.BasicDigestAuth.Realm }}";
-                  auth_digest_user_file {{ $location.BasicDigestAuth.File }};
-                  {{ end }}
-                  proxy_set_header Authorization "";
-                  {{ end }}
-
-                  {{ if $location.CorsConfig.CorsEnabled }}
-                  {{ template "CORS" $location }}
-                  {{ end }}
-
-                  {{ if not (empty $location.Redirect.URL) }}
-                  if ($uri ~* {{ $path }}) {
-                      return {{ $location.Redirect.Code }} {{ $location.Redirect.URL }};
-                  }
-                  {{ end }}
-
-                  client_max_body_size                    "{{ $location.Proxy.BodySize }}";
-                  {{ if isValidClientBodyBufferSize $location.ClientBodyBufferSize }}
-                  client_body_buffer_size                 {{ $location.ClientBodyBufferSize }};
-                  {{ end }}
-
-                  {{/* By default use vhost as Host to upstream, but allow overrides */}}
-                  {{ if not (empty $location.UpstreamVhost) }}
-                  proxy_set_header Host                   "{{ $location.UpstreamVhost }}";
-                  {{ else }}
-                  proxy_set_header Host                   $best_http_host;
-                  {{ end }}
-
-
-                  # Pass the extracted client certificate to the backend
-                  {{ if not (empty $server.CertificateAuth.CAFileName) }}
-                  {{ if $server.CertificateAuth.PassCertToUpstream }}
-                  proxy_set_header ssl-client-cert        $ssl_client_escaped_cert;
-                  {{ else }}
-                  proxy_set_header ssl-client-cert        "";
-                  {{ end }}
-                  proxy_set_header ssl-client-verify      $ssl_client_verify;
-                  proxy_set_header ssl-client-dn          $ssl_client_s_dn;
-                  {{ else }}
-                  proxy_set_header ssl-client-cert        "";
-                  proxy_set_header ssl-client-verify      "";
-                  proxy_set_header ssl-client-dn          "";
-                  {{ end }}
-
-                  # Allow websocket connections
-                  proxy_set_header                        Upgrade           $http_upgrade;
-                  proxy_set_header                        Connection        $connection_upgrade;
-
-                  proxy_set_header X-Real-IP              $the_real_ip;
-                  {{ if $all.Cfg.ComputeFullForwardedFor }}
-                  proxy_set_header X-Forwarded-For        $full_x_forwarded_for;
-                  {{ else }}
-                  proxy_set_header X-Forwarded-For        $the_real_ip;
-                  {{ end }}
-                  proxy_set_header X-Forwarded-Host       $best_http_host;
-                  proxy_set_header X-Forwarded-Port       $pass_port;
-                  proxy_set_header X-Forwarded-Proto      $pass_access_scheme;
-                  proxy_set_header X-Original-URI         $request_uri;
-                  proxy_set_header X-Scheme               $pass_access_scheme;
-
-                  # Pass the original X-Forwarded-For
-                  proxy_set_header X-Original-Forwarded-For {{ buildForwardedFor $all.Cfg.ForwardedForHeader }};
-
-                  # mitigate HTTPoxy Vulnerability
-                  # https://www.nginx.com/blog/mitigating-the-httpoxy-vulnerability-with-nginx/
-                  proxy_set_header Proxy                  "";
-
-                  # Custom headers to proxied server
-                  {{ range $k, $v := $all.ProxySetHeaders }}
-                  proxy_set_header {{ $k }}                    "{{ $v }}";
-                  {{ end }}
-
-                  proxy_connect_timeout                   {{ $location.Proxy.ConnectTimeout }}s;
-                  proxy_send_timeout                      {{ $location.Proxy.SendTimeout }}s;
-                  proxy_read_timeout                      {{ $location.Proxy.ReadTimeout }}s;
-
-                  {{ if (or (eq $location.Proxy.ProxyRedirectFrom "default") (eq $location.Proxy.ProxyRedirectFrom "off")) }}
-                  proxy_redirect                          {{ $location.Proxy.ProxyRedirectFrom }};
-                  {{ else }}
-                  proxy_redirect                          {{ $location.Proxy.ProxyRedirectFrom }} {{ $location.Proxy.ProxyRedirectTo }};
-                  {{ end }}
-                  proxy_buffering                         off;
-                  proxy_buffer_size                       "{{ $location.Proxy.BufferSize }}";
-                  proxy_buffers                           4 "{{ $location.Proxy.BufferSize }}";
-                  proxy_request_buffering                 "{{ $location.Proxy.RequestBuffering }}";
-
-                  proxy_http_version                      1.1;
-
-                  proxy_cookie_domain                     {{ $location.Proxy.CookieDomain }};
-                  proxy_cookie_path                       {{ $location.Proxy.CookiePath }};
-
-                  # In case of errors try the next upstream server before returning an error
-                  proxy_next_upstream                     {{ buildNextUpstream $location.Proxy.NextUpstream $all.Cfg.RetryNonIdempotent }};
-
-                  {{/* rewrite only works if the content is not compressed */}}
-                  {{ if $location.Rewrite.AddBaseURL }}
-                  proxy_set_header                        Accept-Encoding     "";
-                  {{ end }}
-
-                  {{/* Add any additional configuration defined */}}
-                  {{ $location.ConfigurationSnippet }}
-
-                  {{ if not (empty $all.Cfg.LocationSnippet) }}
-                  # Custom code snippet configured in the configuration configmap
-                  {{ $all.Cfg.LocationSnippet }}
-                  {{ end }}
-
-                  {{/* if we are sending the request to a custom default backend, we add the required headers */}}
-                  {{ if (hasPrefix $location.Backend "custom-default-backend-") }}
-                  proxy_set_header       X-Code             503;
-                  proxy_set_header       X-Format           $http_accept;
-                  proxy_set_header       X-Namespace        $namespace;
-                  proxy_set_header       X-Ingress-Name     $ingress_name;
-                  proxy_set_header       X-Service-Name     $service_name;
-                  {{ end }}
-
-
-                  {{ if not (empty $location.Backend) }}
-                  {{ buildProxyPass $server.Hostname $all.Backends $location }}
-                  {{ else }}
-                  # No endpoints available for the request
-                  return 503;
-                  {{ end }}
-                  {{ else }}
-                  # Location denied. Reason: {{ $location.Denied }}
-                  return 503;
-                  {{ end }}
-              }
-
-              {{ end }}
-
-              {{ if eq $server.Hostname "_" }}
-              # health checks in cloud providers require the use of port {{ $all.ListenPorts.HTTP }}
-              location {{ $all.HealthzURI }} {
-                  access_log off;
-                  return 200;
-              }
-
-              # this is required to avoid error if nginx is being monitored
-              # with an external software (like sysdig)
-              location /nginx_status {
-                  allow 127.0.0.1;
-                  {{ if $all.IsIPV6Enabled }}allow ::1;{{ end }}
-                  deny all;
-
-                  access_log off;
-                  stub_status on;
-              }
-
-              {{ end }}
-
-      {{ end }}
-
+    configMapName: ""
+    configMapKey: ""
 
   service:
     annotations: {}
+    labels: {}
     clusterIP: ""
 
     ## List of IP addresses at which the controller services are available
@@ -1030,16 +172,19 @@ controller:
     loadBalancerIP: ""
     loadBalancerSourceRanges: []
 
+    enableHttp: true
+    enableHttps: true
+
     ## Set external traffic policy to: "Local" to preserve source IP on
     ## providers supporting it
     ## Ref: https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typeloadbalancer
-    externalTrafficPolicy: ""
+    externalTrafficPolicy: "Local"
 
     healthCheckNodePort: 0
 
     targetPorts:
       http: 80
-      https: 443
+      https: 80
 
     type: LoadBalancer
 
@@ -1050,6 +195,47 @@ controller:
     nodePorts:
       http: ""
       https: ""
+
+  extraContainers: {}
+  ## Additional containers to be added to the controller pod.
+  ## See https://github.com/lemonldap-ng-controller/lemonldap-ng-controller as example.
+  #  - name: my-sidecar
+  #    image: nginx:latest
+  #  - name: lemonldap-ng-controller
+  #    image: lemonldapng/lemonldap-ng-controller:0.2.0
+  #    args:
+  #      - /lemonldap-ng-controller
+  #      - --alsologtostderr
+  #      - --configmap=$(POD_NAMESPACE)/lemonldap-ng-configuration
+  #    env:
+  #      - name: POD_NAME
+  #        valueFrom:
+  #          fieldRef:
+  #            fieldPath: metadata.name
+  #      - name: POD_NAMESPACE
+  #        valueFrom:
+  #          fieldRef:
+  #            fieldPath: metadata.namespace
+  #    volumeMounts:
+  #    - name: copy-portal-skins
+  #      mountPath: /srv/var/lib/lemonldap-ng/portal/skins
+
+  extraVolumeMounts: {}
+  ## Additional volumeMounts to the controller main container.
+  #  - name: copy-portal-skins
+  #   mountPath: /var/lib/lemonldap-ng/portal/skins
+
+  extraVolumes: {}
+  ## Additional volumes to the controller pod.
+  #  - name: copy-portal-skins
+  #    emptyDir: {}
+
+  extraInitContainers: []
+  ## Containers, which are run before the app containers are started.
+  # - name: init-myservice
+  #   image: busybox
+  #   command: ['sh', '-c', 'until nslookup myservice; do echo waiting for myservice; sleep 2; done;']
+
 
   stats:
     enabled: false
@@ -1068,7 +254,31 @@ controller:
       servicePort: 18080
       type: ClusterIP
 
+  ## If controller.stats.enabled = true and controller.metrics.enabled = true, Prometheus metrics will be exported
+  ##
+  metrics:
+    enabled: false
+
+    service:
+      annotations: {}
+      # prometheus.io/scrape: "true"
+      # prometheus.io/port: "10254"
+
+      clusterIP: ""
+
+      ## List of IP addresses at which the stats-exporter service is available
+      ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
+      ##
+      externalIPs: []
+
+      loadBalancerIP: ""
+      loadBalancerSourceRanges: []
+      servicePort: 9913
+      type: ClusterIP
+
   lifecycle: {}
+
+  priorityClassName: ""
 
 ## Rollback limit
 ##
@@ -1099,6 +309,8 @@ defaultBackend:
   #    value: "value"
   #    effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
 
+  affinity: {}
+
   # labels to add to the pod container metadata
   podLabels: {}
   #  key: value
@@ -1113,6 +325,8 @@ defaultBackend:
   podAnnotations: {}
 
   replicaCount: 1
+
+  minAvailable: 1
 
   resources: {}
   # limits:
@@ -1136,48 +350,20 @@ defaultBackend:
     servicePort: 80
     type: ClusterIP
 
+  priorityClassName: ""
+
 ## Enable RBAC as per https://github.com/kubernetes/ingress/tree/master/examples/rbac/nginx and https://github.com/kubernetes/ingress/issues/266
 rbac:
-  create: false
-  serviceAccountName: default
+  create: true
 
-## If controller.stats.enabled = true, Prometheus metrics will be exported
-## Ref: https://github.com/hnlq715/nginx-vts-exporter
-##
-statsExporter:
-  name: stats-exporter
-  image:
-    repository: sophos/nginx-vts-exporter
-    tag: v0.6
-    pullPolicy: IfNotPresent
+serviceAccount:
+  create: true
+  name:
 
-  endpoint: /metrics
-  extraArgs: {}
-  metricsNamespace: nginx
-  statusPage: http://localhost:18080/nginx_status/format/json
-
-  resources: {}
-  # limits:
-  #   cpu: 10m
-  #   memory: 20Mi
-  # requests:
-  #   cpu: 10m
-  #   memory: 20Mi
-
-  service:
-    annotations: {}
-    clusterIP: ""
-
-    ## List of IP addresses at which the stats-exporter service is available
-    ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
-    ##
-    externalIPs: []
-
-    loadBalancerIP: ""
-    loadBalancerSourceRanges: []
-    servicePort: 9913
-    targetPort: 9913
-    type: ClusterIP
+## Optional array of imagePullSecrets containing private registry credentials
+## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+imagePullSecrets: []
+# - name: secretName
 
 # TCP service key:value pairs
 # Ref: https://github.com/kubernetes/contrib/tree/master/ingress/controllers/nginx/examples/tcp


### PR DESCRIPTION
### This is just a fork of [upstream](https://github.com/helm/charts/tree/master/stable/nginx-ingress)

[Trello](https://trello.com/c/M1snktNZ)

[Config PR](https://github.com/ministryofjustice/analytics-platform-config/pull/72)

As part of the above ticket, I thought it would be a good time to upgrade
the ingress stack.

Apart from minor version increments, the main difference is the way
custom __nginx__ configuration is handled/applied.

The recent version of [Ingress-Nginx](https://github.com/kubernetes/ingress-nginx) now supports [configmaps](https://github.com/kubernetes/ingress-nginx/blob/0f7ef88a80b9011024194f287b720755a7986099/docs/user-guide/nginx-configuration/configmap.md) which allows applying custom configuration without having to override/fork the entire __nginx__ configuration file.

Such as adding snippets to location or [server](https://github.com/kubernetes/ingress-nginx/blob/0f7ef88a80b9011024194f287b720755a7986099/docs/user-guide/nginx-configuration/configmap.md#server-snippet) blocks.


Enabled dynamic configuration

There is a bug in our current version of K8s where we can only provision 
an NLB with one listener.  See [bug](https://github.com/kubernetes/kubernetes/issues/56703)

Our custom configuration among other things returns a permanent redirect `308` code and
redirects the client to `https` if it has requested a valid host.