### PR TITLE
Concourse: add aws secrets to list IAM roles

### DIFF
--- a/charts/concourse-org-pipeline/CHANGELOG.md
+++ b/charts/concourse-org-pipeline/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [0.1.6] - 2018-07-30
+### Added
+Added `secrets.iam-list-roles-key-id` and `secrets.iam-list-roles-secret-access-key` secrets, intended to be overridden in config repo.
+This is to allow concourse to list aws iam roles.
+
 ## [0.1.5] - 2018-05-17
 ### Added
 Added `secrets.cpanel-api-user` and `secrets.cpanel-api-password` secrets, intended to be overridden in config repo.

--- a/charts/concourse-org-pipeline/Chart.yaml
+++ b/charts/concourse-org-pipeline/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Concourse pipeline for creating deployment pipelines for Github org repos
 name: concourse-org-pipeline
-version: 0.1.5
+version: 0.1.6

--- a/charts/concourse-org-pipeline/README.md
+++ b/charts/concourse-org-pipeline/README.md
@@ -27,6 +27,8 @@ helm install mojanalytics/concourse-org-pipeline \
 | auth0.domain | Auth0 tenant domain | "" |
 | aws.ecrAccessKeyId | AWS Access Key ID for read/write to ECR | "" |
 | aws.ecrSecretAccessKey | AWS Secret Access Key for read/write to ECR | "" |
+| aws.iamListRolesAccessKeyId | AWS Access Key ID to list AWS IAM roles | "" |
+| aws.iamListRolesSecretAccessKey | AWS Secret Access Key to list AWS IAM roles | "" |
 | aws.region | Default AWS region | "eu-west-1" |
 | concourse.externalURL | The same value as for the Concourse Helm chart | "" |
 | concourse.password | Basic authentication password for Concourse | "" |

--- a/charts/concourse-org-pipeline/templates/secrets.yaml
+++ b/charts/concourse-org-pipeline/templates/secrets.yaml
@@ -20,6 +20,8 @@ data:
   cpanel-api-user: {{ .Values.cpanelApi.user | b64enc | quote }}
   ecr-access-key-id: {{ .Values.aws.ecrAccessKeyId | b64enc | quote }}
   ecr-secret-access-key: {{ .Values.aws.ecrSecretAccessKey | b64enc | quote }}
+  iam-list-roles-key-id: {{ .Values.aws.iamListRolesAccessKeyId | b64enc | quote }}
+  iam-list-roles-secret-access-key: {{ .Values.aws.iamListRolesSecretAccessKey | b64enc | quote }}
   github-access-token: {{ .Values.github.accessToken | b64enc | quote }}
   github-webhook-token: {{ .Values.github.webhookToken | b64enc | quote }}
   ip-102pf: {{ .Values.ipRanges.wifi102pf | b64enc | quote }}


### PR DESCRIPTION
This commit adds placeholder for AWS key and secret that are then available to
concourse pipelines which intend to list AWS IAM roles