### PR TITLE
Jupyter: auth-proxy

### DIFF
--- a/charts/jupyter-lab/templates/deployment.yaml
+++ b/charts/jupyter-lab/templates/deployment.yaml
@@ -61,6 +61,8 @@ spec:
                   key: cookie_secret
             - name: NICKNAME_RE
               value: {{ .Values.Username }}
+            - name: COOKIE_MAXAGE
+              value: {{ .Values.authProxy.cookie_maxage | quote }}
           readinessProbe:
             httpGet:
               path: /healthz

--- a/charts/jupyter-lab/templates/deployment.yaml
+++ b/charts/jupyter-lab/templates/deployment.yaml
@@ -63,7 +63,7 @@ spec:
               value: {{ .Values.Username }}
           readinessProbe:
             httpGet:
-              path: /login?healthz
+              path: /healthz
               port: http
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/charts/jupyter-lab/values.yaml
+++ b/charts/jupyter-lab/values.yaml
@@ -21,6 +21,7 @@ authProxy:
       memory: 64Mi
   auth0_domain: ""
   auth0_client_id: ""
+  cookie_maxage: 36000 #10 hours
 
 jupyter:
   image: quay.io/mojanalytics/datascience-notebook


### PR DESCRIPTION
Fixing Readiness probe's path

See [here](https://github.com/ministryofjustice/analytics-platform-auth-proxy/blob/2cfd41ed0d215a495ab596540276b2267ba88c4e/app/base/routes.js#L8)

#### Jupyter: Set Session Expiration
    
Setting the session cookie maxage to 10 hours
    
This will result in the auth-proxy not having to go through the login process when/if the connection drops over a 10 hour period.
