### PR TITLE
Kube2iam: Update to use MoJ Kube2iam regexp ns restrictions

### DIFF
--- a/charts/airflow-k8s/Chart.yaml
+++ b/charts/airflow-k8s/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 description: Airflow on kubernetes. Tasks are run as pods
 name: airflow-k8s
 icon: https://airflow.incubator.apache.org/_images/pin_large.png
-version: 0.0.2
+version: 0.0.3

--- a/charts/airflow-k8s/templates/hooks/init-airflow-ns-hook.yml
+++ b/charts/airflow-k8s/templates/hooks/init-airflow-ns-hook.yml
@@ -1,0 +1,60 @@
+# This hook depends on helm creating the target namespace if it doesn't exist
+# before the hook is called. This is the case on Helm >v2.9.1
+{{ if eq .Chart.Version "0.0.3"}}
+## apply this only on one upgrade - like a database migration
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: upgrade-airflow-ns
+  namespace: kube-system
+  labels:
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: hook-succeeded
+spec:
+  template:
+    spec:
+      containers:
+      - name: annotator
+        image: gcr.io/google_containers/hyperkube:v1.11.2
+        command:
+        - kubectl
+        - annotate
+        - --overwrite
+        - ns
+        - {{ .Release.Namespace }}
+        - |
+            iam.amazonaws.com/allowed-roles=[{{ .Values.kube2iam.allowedRoles | quote }}]
+      restartPolicy: Never
+      serviceAccountName: helm
+{{ else }}
+# Apply this on a new install
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: init-airflow-ns
+  namespace: kube-system
+  labels:
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    helm.sh/hook: pre-install
+    helm.sh/hook-delete-policy: hook-succeeded
+spec:
+  template:
+    spec:
+      containers:
+      - name: annotator
+        image: gcr.io/google_containers/hyperkube:v1.11.2
+        command:
+        - kubectl
+        - annotate
+        - ns
+        - {{ .Release.Namespace }}
+        - |
+            iam.amazonaws.com/allowed-roles=[{{ .Values.kube2iam.allowedRoles | quote }}]
+      restartPolicy: Never
+      serviceAccountName: {{ .Values.kube2iam.serviceAccountName }}
+{{ end }}

--- a/charts/airflow-k8s/templates/ingress.yml
+++ b/charts/airflow-k8s/templates/ingress.yml
@@ -17,3 +17,5 @@ spec:
           serviceName: {{ .Release.Name }}
           servicePort: 80
         path: /
+  tls:
+    - hosts:

--- a/charts/airflow-k8s/templates/ingress.yml
+++ b/charts/airflow-k8s/templates/ingress.yml
@@ -19,3 +19,4 @@ spec:
         path: /
   tls:
     - hosts:
+      - {{ printf "%s.%s" .Release.Name .Values.toolsDomain | lower }}

--- a/charts/airflow-k8s/values.yaml
+++ b/charts/airflow-k8s/values.yaml
@@ -49,3 +49,6 @@ redis:
     enabled: false
   persistence:
     enabled: false
+kube2iam:
+  allowedRoles: ".*"
+  serviceAccountName: ""

--- a/charts/init-user/Chart.yaml
+++ b/charts/init-user/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: init-user
-version: 0.1.2
+version: 0.1.3

--- a/charts/init-user/templates/namespace.yml
+++ b/charts/init-user/templates/namespace.yml
@@ -2,3 +2,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: user-{{ .Values.Username }}
+  annotations:
+    iam.amazonaws.com/allowed-roles: |
+      ["(dev|alpha)_.*"]

--- a/charts/kube2iam/Chart.yaml
+++ b/charts/kube2iam/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Allows k8s pods to be started with AWS IAM roles attached
 name: kube2iam
-version: 1.0.0
+version: 1.1.0

--- a/charts/kube2iam/templates/daemonset.yml
+++ b/charts/kube2iam/templates/daemonset.yml
@@ -23,6 +23,8 @@ spec:
             - "--host-interface={{ .Values.host_interface }}"
             - "--host-ip=$(HOST_IP)"
             - "--default-role={{ .Values.default_role }}"
+            - "--namespace-restrictions=true"
+            - "--namespace-restriction-format=regexp"
           env:
             - name: HOST_IP
               valueFrom:


### PR DESCRIPTION
This enables `regexp` namespace restrictions for kube2iam and has some fallout.

By default un-annotated namespaces can no longer assume _any role at all_.

* new file:   airflow-k8s/templates/hooks/init-airflow-ns-hook.yml
    This is a helm hook, kind of like a database migration that on installing
    this updated version of the chart will annotate the existing `airflow`
    namespace with the required annotation
* modified:   init-user/templates/namespace.yml
    New user namespaces need will have new annotation to allow them to assume
    roles starting with dev or alpha