### PR TITLE
Jupyter & Rstudio Ingress

### DIFF
--- a/charts/jupyter-lab/CHANGELOG.md
+++ b/charts/jupyter-lab/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.1.7] - 2018-08-15
+### Changed
+- Added tls config to ingress.  This is required for tls termination with the nginx ingress controller. See [Trello](https://trello.com/c/M1snktNZ)
+- Auth-proxy image tag from 0.1.4 to 0.1.3 while investigating ssl redirect issues 
+
 ## [0.1.6] - 2018-08-10
 ## jupyter-tag-3
 - Update datascience-notebook image tag from 0.3.3 to 0.4.0. Relates to [PR](https://github.com/ministryofjustice/analytics-platform-jupyter-notebook/pull/8)

--- a/charts/jupyter-lab/Chart.yaml
+++ b/charts/jupyter-lab/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Jupyter Lab with Auth0 authentication proxy
 name: jupyter-lab
-version: 0.1.6
+version: 0.1.7

--- a/charts/jupyter-lab/templates/ingress.yaml
+++ b/charts/jupyter-lab/templates/ingress.yaml
@@ -17,3 +17,6 @@ spec:
             backend:
               serviceName: {{ template "fullname" . }}
               servicePort: {{ .Values.service.port }}
+  tls:
+    - hosts:
+        - {{ .Values.Username | lower }}-jupyter-lab.{{ .Values.toolsDomain }}

--- a/charts/jupyter-lab/values.yaml
+++ b/charts/jupyter-lab/values.yaml
@@ -9,7 +9,7 @@ service:
 
 authProxy:
   image: quay.io/mojanalytics/auth-proxy
-  tag: v0.1.4
+  tag: v0.1.3
   imagePullPolicy: IfNotPresent
   containerPort: 3000
   resources:

--- a/charts/rstudio/CHANGELOG.md
+++ b/charts/rstudio/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.5.5] - 2018-08-15
+### Changed
+- Added tls config to ingress.  This is required for tls termination with the nginx ingress controller. See [Trello](https://trello.com/c/M1snktNZ)
+
 ## [1.5.4] - 2018-07-09
 ### Changed
 - Modified RStudio image tag from v1.3.2 to 3.4.2-5 See: [PR](https://github.com/ministryofjustice/analytics-platform-rstudio/pull/34)

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: RStudio with Auth0 authentication proxy
 name: rstudio
-version: 1.5.4
+version: 1.5.5

--- a/charts/rstudio/templates/ingress.yml
+++ b/charts/rstudio/templates/ingress.yml
@@ -16,3 +16,6 @@ spec:
           serviceName: {{ template "fullname" . }}
           servicePort: 80
         path: /
+  tls:
+    - hosts:
+        - {{ .Values.username | lower }}-rstudio.{{ .Values.toolsDomain }}


### PR DESCRIPTION
[Trello](https://trello.com/c/M1snktNZ)

- Added tls config to ingress objects for Rstudio and Jupyter.  This is required for tls termination with the nginx ingress controller.
- Auth-proxy image tag from 0.1.4 to 0.1.3 while investigating ssl redirect issues