### PR TITLE
Concourse: Target correct pipeline

### DIFF
--- a/charts/concourse-org-pipeline/Chart.yaml
+++ b/charts/concourse-org-pipeline/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Concourse pipeline for creating deployment pipelines for Github org repos
 name: concourse-org-pipeline
-version: 0.1.6
+version: 0.1.7

--- a/charts/concourse-org-pipeline/files/pipeline.yaml
+++ b/charts/concourse-org-pipeline/files/pipeline.yaml
@@ -16,8 +16,8 @@ resources:
     concourse_url: ((concourse_url))
     username: ((fly.username))
     password: ((fly.password))
-    access_token: ((github-access-token))
-  webhook_token: ((github-webhook-token))
+    access_token: ((secrets.github-access-token))
+  webhook_token: ((secrets.github-webhook-token))
 
 resource_types:
 - name: github-org

--- a/charts/concourse-org-pipeline/files/set-pipeline.sh
+++ b/charts/concourse-org-pipeline/files/set-pipeline.sh
@@ -11,13 +11,11 @@ fly -t default login \
     -n $CONCOURSE_TEAM
 
 fly -t default set-pipeline \
-    -n $CONCOURSE_TEAM \
-    -p $1 \
+    -n \
+    -p $PIPELINE_NAME \
     -c /scripts/pipeline.yaml \
-    -v team_name=$CONCOURSE_TEAM \
+    -v team_name=$CONCOURSE_TARGET_TEAM \
     -v concourse_url=$CONCOURSE_URL \
-    -v github-access-token=$GITHUB_ACCESS_TOKEN \
     -v github-org=$1 \
     -v github-org-resource-image=$GITHUB_ORG_RESOURCE_IMAGE \
-    -v github-org-resource-tag=$GITHUB_ORG_RESOURCE_TAG \
-    -v github-webhook-token=$GITHUB_WEBHOOK_TOKEN
+    -v github-org-resource-tag=$GITHUB_ORG_RESOURCE_TAG

--- a/charts/concourse-org-pipeline/templates/job.yaml
+++ b/charts/concourse-org-pipeline/templates/job.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: concourse-{{ .Values.concourse.team }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded
 spec:
   template:
     metadata:
@@ -15,19 +19,23 @@ spec:
         image: appropriate/curl:3.1
         imagePullPolicy: IfNotPresent
         env:
+          - name: PIPELINE_NAME
+            value: {{ .Values.concourse.pipeline_name }}
           - name: CONCOURSE_TEAM
             value: {{ .Values.concourse.team }}
+          - name: CONCOURSE_TARGET_TEAM
+            value: {{ .Values.concourse.target_team }}
           - name: CONCOURSE_URL
             value: {{ .Values.concourse.externalURL }}
           - name: FLY_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: fly
+                name: fly-admin
                 key: password
           - name: FLY_USERNAME
             valueFrom:
               secretKeyRef:
-                name: fly
+                name: fly-admin
                 key: username
           - name: GITHUB_ACCESS_TOKEN
             valueFrom:

--- a/charts/concourse-org-pipeline/templates/secrets.yaml
+++ b/charts/concourse-org-pipeline/templates/secrets.yaml
@@ -1,8 +1,9 @@
+{{- define "concourse-secrets" -}}
 apiVersion: v1
 kind: Secret
 metadata:
   name: secrets
-  namespace: concourse-{{ .Values.concourse.team }}
+  namespace: concourse-{{ .team }}
   labels:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
 type: Opaque
@@ -30,12 +31,35 @@ data:
   kubernetes-api-url: {{ .Values.kubernetes.apiUrl | b64enc | quote }}
   kubernetes-ca-cert: {{ .Values.kubernetes.caCert | b64enc | quote }}
   kubernetes-token: {{ .Values.kubernetes.token | b64enc | quote }}
-
+  gitcrypt-symmetric-key: {{ .Values.gitCrypt.symmetricKey | b64enc | quote }}
+  role-putter-access-key-id: {{ .Values.aws.rolePutterAccessKeyId | b64enc | quote }}
+  role-putter-secret-access-key: {{ .Values.aws.rolePutterSecretAccessKey | b64enc | quote }}
+  nodes-role-arn: {{ .Values.aws.nodesRoleArn | b64enc | quote }}
+{{- end }}
+---
+{{ $_ := set . "team" .Values.concourse.target_team }}
+{{ template "concourse-secrets" . }}
+---
+{{ $_ := set . "team" .Values.concourse.team }}
+{{ template "concourse-secrets" . }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: fly
+  namespace: concourse-{{ .Values.concourse.team }}
+  labels:
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+type: Opaque
+data:
+  password: {{ .Values.concourse.target_password | b64enc | quote }}
+  username: {{ .Values.concourse.target_username | b64enc | quote }}
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: fly-admin
   namespace: concourse-{{ .Values.concourse.team }}
   labels:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}

--- a/charts/concourse-org-pipeline/values.yaml
+++ b/charts/concourse-org-pipeline/values.yaml
@@ -12,6 +12,11 @@ aws:
   ecrAccessKeyId: ""
   ecrSecretAccessKey: ""
   region: "eu-west-1"
+  nodesRoleArn: ""
+  iamListRolesAccessKeyId: ""
+  iamListRolesSecretAccessKey: ""
+  rolePutterAccessKeyId: ""
+  rolePutterSecretAccessKey: ""
 
 concourse:
   # externalURL is the same value as for the concourse helm chart
@@ -19,6 +24,10 @@ concourse:
   password: ""
   team: main
   username: ""
+  pipeline_name: "create-webapp-pipelines"
+  target_team: ""
+  target_username: ""
+  target_password: ""
 
 cookieSecret: ""
 


### PR DESCRIPTION
The old chart used to target a pipeline called `moj-analytical-services` because
the pipeline name was based on the org name. At some point we manually deployed
this to a pipeline called `create-webapp-pipelines` in the admin team.

These changes update the chart to reflect the current state of the world.

I've also updated the pipeline to read the github tokens from k8s secrets
instead of having them passed in with fly