### PR TITLE
airflow-k8s 0.0.5: Fixed missing SMTP credentials in k8s operator pod

### DIFF
--- a/charts/airflow-k8s/CHANGELOG.md
+++ b/charts/airflow-k8s/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [0.0.5] - 2018-09-12
+### Fixed
+SMTP secrets were not passed to the pods created by the `KubernetesPodOperator`.
+This is the pod which sends the email on retry/fail so emails were not sent.
+
+
 ## [0.0.4] - 2018-09-07
 ### Added
 Support for SMTP configuration. This allows sending of emails, e.g. on retries

--- a/charts/airflow-k8s/Chart.yaml
+++ b/charts/airflow-k8s/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 description: Airflow on kubernetes. Tasks are run as pods
 name: airflow-k8s
 icon: https://airflow.incubator.apache.org/_images/pin_large.png
-version: 0.0.4
+version: 0.0.5

--- a/charts/airflow-k8s/templates/configmap.yml
+++ b/charts/airflow-k8s/templates/configmap.yml
@@ -170,6 +170,8 @@ data:
     [kubernetes_secrets]
     SQL_ALCHEMY_CONN = {{ .Release.Name }}=sql-alchemy-conn
     FERNET_KEY = {{ .Release.Name }}=fernet-key
+    SMTP_USER = {{ .Release.Name }}=smtp-user
+    SMTP_PASSWORD = {{ .Release.Name }}=smtp-password
     [hive]
     # Default mapreduce queue for HiveOperator tasks
     default_hive_mapred_queue =


### PR DESCRIPTION
This was causing emails to not be sent.