### PR TITLE
airflow-k8s 0.0.6: Fixed URLs in email notifications

### DIFF
--- a/charts/airflow-k8s/CHANGELOG.md
+++ b/charts/airflow-k8s/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [0.0.6] - 2018-09-13
+### Fixed
+Fixed URLs in email notifications.
+
+
 ## [0.0.5] - 2018-09-12
 ### Fixed
 SMTP secrets were not passed to the pods created by the `KubernetesPodOperator`.

--- a/charts/airflow-k8s/Chart.yaml
+++ b/charts/airflow-k8s/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 description: Airflow on kubernetes. Tasks are run as pods
 name: airflow-k8s
 icon: https://airflow.incubator.apache.org/_images/pin_large.png
-version: 0.0.5
+version: 0.0.6

--- a/charts/airflow-k8s/templates/configmap.yml
+++ b/charts/airflow-k8s/templates/configmap.yml
@@ -74,7 +74,7 @@ data:
     # The base url of your website as airflow cannot guess what domain or
     # cname you are using. This is used in automated emails that
     # airflow sends to point links to the right web server
-    base_url = http://localhost:8080
+    base_url = https://{{ printf "%s.%s" .Release.Name .Values.toolsDomain | lower }}
     # The ip specified when starting the web server
     web_server_host = 0.0.0.0
     # The port on which to run the web server


### PR DESCRIPTION
URLs in emails were previously `http://localhost:80` which is obviously nonsense.
This fixes it.