### PR TITLE
Added tls block in ingress resources

### DIFF
--- a/charts/aws-login/CHANGELOG.md
+++ b/charts/aws-login/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+
+## [1.0.0] - 2018-09-26
+### Added
+Added (optional) TLS block in ingress resource.
+You can set the `ingress.addTlsBlock` value to `false` if your
+ingress-controller doesn't work when ingress resources have this block (e.g.
+[traefik](https://traefik.io) doesn't seem to work)
+
+### Changed
+`ingress.*` values structure changed so now you'll just pass a single
+host in `ingress.host` instead of an array in `ingress.hosts`.
+
+**NOTE**: You values files will need to change accordingly.

--- a/charts/aws-login/Chart.yaml
+++ b/charts/aws-login/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: aws-login
-version: 0.1.0
+version: 1.0.0

--- a/charts/aws-login/templates/ingress.yaml
+++ b/charts/aws-login/templates/ingress.yaml
@@ -16,24 +16,17 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
-{{- if .Values.ingress.tls }}
+{{- if .Values.ingress.addTlsBlock }}
   tls:
-  {{- range .Values.ingress.tls }}
     - hosts:
-      {{- range .hosts }}
-        - {{ . }}
-      {{- end }}
-      secretName: {{ .secretName }}
-  {{- end }}
+        - {{ .Values.ingress.host }}
 {{- end }}
   rules:
-  {{- range .Values.ingress.hosts }}
-    - host: {{ . }}
+    - host: {{ .Values.ingress.host }}
       http:
         paths:
           - path: {{ $ingressPath }}
             backend:
               serviceName: {{ $fullName }}
               servicePort: http
-  {{- end }}
 {{- end }}

--- a/charts/aws-login/values.yaml
+++ b/charts/aws-login/values.yaml
@@ -18,17 +18,13 @@ service:
   port: 80
 
 ingress:
+  addTlsBlock: true
   enabled: false
+  host: chart-example.local
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   path: /
-  hosts:
-    - chart-example.local
-  tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/cpanel/CHANGELOG.md
+++ b/charts/cpanel/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0] - 2018-09-26
+### Added
+Added (optional) TLS block in ingress resource.
+You can set the `ingress.addTlsBlock` value to `false` if your
+ingress-controller doesn't work when ingress resources have this block (e.g.
+[traefik](https://traefik.io) doesn't seem to work)
+
 ## [0.12.2] - 2018-05-30
 ### Added
 Added `ELASTICSEARCH_HOST`, `ELASTICSEARCH_PORT`, `ELASTICSEARCH_USERNAME` and

--- a/charts/cpanel/Chart.yaml
+++ b/charts/cpanel/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Analytics Platform Control Panel API webapp
 name: cpanel
-version: 0.12.2
+version: 1.0.0

--- a/charts/cpanel/README.md
+++ b/charts/cpanel/README.md
@@ -55,3 +55,4 @@ with `IAM_ARN_BASE:saml-provider/` to make an ARN | |
 | `postgresql.postgresUser` | The username to connect to the database with | |
 | `ServicesDomain` | DNS Domain where the app will be hosted | |
 | `tags.branch` | If true, a PostgreSQL instance will be deployed alongside the API, instead of using RDS | `false` |
+| `ingress.addTlsBlock` | Adds tls block to ingress resource. This needs to be `true` if you're using `nginx` as ingress-controller but it may need to be `false` for others (e.g. `traefik`) | `true` |

--- a/charts/cpanel/templates/_helpers.tpl
+++ b/charts/cpanel/templates/_helpers.tpl
@@ -14,3 +14,10 @@ We truncate at 24 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 24 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+CP API hostname
+*/}}
+{{- define "hostname" -}}
+"cpanelapi{{- if .Values.API.Branch -}}-{{ .Values.API.Branch }}{{- end -}}.{{ .Values.ServicesDomain }}"
+{{- end -}}

--- a/charts/cpanel/templates/ingress.yaml
+++ b/charts/cpanel/templates/ingress.yaml
@@ -9,10 +9,15 @@ metadata:
     kubernetes.io/ingress.class: "nginx"
 spec:
   rules:
-  - host: "cpanelapi{{- if .Values.API.Branch -}}-{{ .Values.API.Branch }}{{- end -}}.{{ .Values.ServicesDomain }}"
+  - host: {{ template "hostname" . }}
     http:
       paths:
       - backend:
           serviceName: {{ template "fullname" . }}
           servicePort: 80
         path: /
+{{ if .Values.ingress.addTlsBlock }}
+  tls:
+  - hosts:
+    - {{ template "hostname" . }}
+{{ end }}

--- a/charts/cpanel/values.yaml
+++ b/charts/cpanel/values.yaml
@@ -35,6 +35,9 @@ AWS:
 tags:
   branch: false
 
+ingress:
+  addTlsBlock: true
+
 postgresql:
     postgresHost: ""
     postgresUser: ""

--- a/charts/cpfrontend/CHANGELOG.md
+++ b/charts/cpfrontend/CHANGELOG.md
@@ -5,6 +5,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [2.0.0] - 2018-09-26
+### Changed
+Added (optional) TLS block in ingress resource.
+You can set the `ingress.addTlsBlock` value to `false` if your
+ingress-controller doesn't work when ingress resources have this block (e.g.
+[traefik](https://traefik.io) doesn't seem to work)
+
+
 ## [1.3.5] - 2018-02-14
 ### Changed
 Using newly added `/healthz` endpoint instead of the `/login`.

--- a/charts/cpfrontend/Chart.yaml
+++ b/charts/cpfrontend/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Analytics Platform Control Panel webapp
 name: cpfrontend
-version: 1.3.5
+version: 2.0.0

--- a/charts/cpfrontend/README.md
+++ b/charts/cpfrontend/README.md
@@ -37,3 +37,4 @@ The instance will be available at https://cpfrontend-$BRANCH_NAME.$SERVICES_DOMA
 | `Frontend.Environment.SENTRY_DSN` | Credentials needed to report errors to Sentry | `""` |
 | `Frontend.Environment.TOOLS_DOMAIN` | Domain under which tools are deployed, e.g. `tools.example.com` | `""` |
 | `ServicesDomain` | domain under which the UI will be available, e.g. `services.example.com` | `""` |
+| `ingress.addTlsBlock` | Adds tls block to ingress resource. This needs to be `true` if you're using `nginx` as ingress-controller but it may need to be `false` for others (e.g. `traefik`) | `true` |

--- a/charts/cpfrontend/templates/_helpers.tpl
+++ b/charts/cpfrontend/templates/_helpers.tpl
@@ -14,3 +14,10 @@ We truncate at 24 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 24 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+CP Frontend hostname
+*/}}
+{{- define "hostname" -}}
+"cpanel{{- if .Values.Frontend.Branch -}}-{{ .Values.Frontend.Branch }}{{- end -}}.{{ .Values.ServicesDomain }}"
+{{- end -}}

--- a/charts/cpfrontend/templates/ingress.yaml
+++ b/charts/cpfrontend/templates/ingress.yaml
@@ -9,10 +9,15 @@ metadata:
     kubernetes.io/ingress.class: "nginx"
 spec:
   rules:
-  - host: "cpanel{{- if .Values.Frontend.Branch -}}-{{ .Values.Frontend.Branch }}{{- end -}}.{{ .Values.ServicesDomain }}"
+  - host: {{ template "hostname" . }}
     http:
       paths:
       - backend:
           serviceName: {{ template "fullname" . }}
           servicePort: 80
         path: /
+{{ if .Values.ingress.addTlsBlock }}
+  tls:
+  - hosts:
+    - {{ template "hostname" . }}
+{{ end }}

--- a/charts/cpfrontend/values.yaml
+++ b/charts/cpfrontend/values.yaml
@@ -16,6 +16,9 @@ Frontend:
   ServicePort: 80
   Protocol: "https"
 
+ingress:
+  addTlsBlock: true
+
 redis:
   persistence:
     enabled: false

--- a/charts/kibana-auth-proxy/CHANGELOG.md
+++ b/charts/kibana-auth-proxy/CHANGELOG.md
@@ -5,6 +5,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [2.0.0] - 2018-09-27
+### Changed
+Added (optional) TLS block in ingress resource.
+You can set the `ingress.addTlsBlock` value to `false` if your
+ingress-controller doesn't work when ingress resources have this block (e.g.
+[traefik](https://traefik.io) doesn't seem to work)
+
+
 ## [1.1.3] - 2018-05-09
 ### Changed
 Use [`kibana-auth-proxy` v1.1.2](https://github.com/ministryofjustice/analytics-platform-kibana-auth-proxy/releases/tag/v1.1.2).

--- a/charts/kibana-auth-proxy/Chart.yaml
+++ b/charts/kibana-auth-proxy/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: kibana-auth-proxy
-version: 1.1.3
+version: 2.0.0

--- a/charts/kibana-auth-proxy/README.md
+++ b/charts/kibana-auth-proxy/README.md
@@ -10,26 +10,9 @@ Authentication layer in front of kibana.
 To install the chart:
 
 ```bash
-helm install --dry-run mojanalytics/kibana-auth-proxy \
-  --name cluster-logviewer \
-  --namespace kube-system \
-  --set auth.domain=$AUTH_DOMAIN \
-  --set auth.clientID=$AUTH_CLIENT_ID \
-  --set auth.clientSecret=$AUTH_CLIENT_SECRET \
-  --set kibana.url=$KIBANA_URL \
-  --set kibana.admin.username=$KIBANA_ADMIN_USERNAME \
-  --set kibana.admin.password=$KIBANA_ADMIN_PASSWORD \
-  --set kibana.user.username=$KIBANA_USER_USERNAME \
-  --set kibana.user.password=$KIBANA_USER_PASSWORD \
-  --set ingress.host=$INGRESS_HOST \
-```
-
-To upgrade the existing chart:
-
-```bash
 helm upgrade --dry-run --install cluster-logviewer mojanalytics/kibana-auth-proxy \
   --namespace kube-system \
-  -f chart-env-config/ENV/kibana.yml
+  -f chart-env-config/ENV/kibana-auth-proxy.yml
 ```
 
 The proxy will be available at the host specified via `ingress.host` value.
@@ -48,3 +31,4 @@ The proxy will be available at the host specified via `ingress.host` value.
 | `kibana.user.username` | Kibana non-admin username | `""` |
 | `kibana.user.password` | Kibana non-admin password | `""` |
 | `ingress.host` | Host where the proxy will be available | `"example.com"` |
+| `ingress.addTlsBlock` | Whether to add the tls block to the ingress resource | `true` |

--- a/charts/kibana-auth-proxy/templates/ingress.yaml
+++ b/charts/kibana-auth-proxy/templates/ingress.yaml
@@ -16,3 +16,8 @@ spec:
           serviceName: {{ template "fullname" . }}
           servicePort: 80
         path: /
+{{ if .Values.ingress.addTlsBlock }}
+  tls:
+  - hosts:
+    - "{{ .Values.ingress.host }}"
+{{ end }}

--- a/charts/kibana-auth-proxy/values.yaml
+++ b/charts/kibana-auth-proxy/values.yaml
@@ -22,4 +22,5 @@ kibana:
     username: ""
     password: ""
 ingress:
+  addTlsBlock: true
   host: "example.com"

--- a/charts/kubernetes-dashboard/CHANGELOG.md
+++ b/charts/kubernetes-dashboard/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+## [1.0.0] - 2018-09-27
+### Changed
+- Added (optional) TLS block in ingress resource.
+You can set the `ingress.addTlsBlock` value to `false` if your
+ingress-controller doesn't work when ingress resources have this block (e.g.
+[traefik](https://traefik.io) doesn't seem to work)
+- Changed from passing the `servicesDomain` value to have an `ingress.host`
+  value
+
+
 ## [0.1.0] - 2018-03-21
 ### Initial Commit
 - Initial chart development

--- a/charts/kubernetes-dashboard/Chart.yaml
+++ b/charts/kubernetes-dashboard/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Kubernetes Dashboard with OIDC auth
 name: kubernetes-dashboard
-version: 0.1.0
+version: 1.0.0

--- a/charts/kubernetes-dashboard/templates/_helpers.tpl
+++ b/charts/kubernetes-dashboard/templates/_helpers.tpl
@@ -1,0 +1,6 @@
+{{/*
+hostname
+*/}}
+{{- define "hostname" -}}
+"{{ .Values.ingress.host }}"
+{{- end -}}

--- a/charts/kubernetes-dashboard/templates/ingress.yaml
+++ b/charts/kubernetes-dashboard/templates/ingress.yaml
@@ -10,10 +10,15 @@ metadata:
     nginx.ingress.kubernetes.io/secure-backends: "true"  # ----- Proxy back to https ----- #
 spec:
   rules:
-    - host: dashboard.{{ .Values.servicesDomain }}
+    - host: {{ template "hostname" . }}
       http:
         paths:
           - path: /
             backend:
               serviceName: {{ .Chart.Name }}
               servicePort: 443
+{{- if .Values.ingress.addTlsBlock }}
+  tls:
+    - hosts:
+        - {{ template "hostname" . }}
+{{- end }}

--- a/charts/kubernetes-dashboard/values.yaml
+++ b/charts/kubernetes-dashboard/values.yaml
@@ -1,4 +1,6 @@
 image: k8s.gcr.io/kubernetes-dashboard-amd64
 tag: v1.8.3
 port: 8443
-servicesDomain: ""
+ingress:
+    addTlsBlock: true
+    host: ""

--- a/charts/logstash/CHANGELOG.md
+++ b/charts/logstash/CHANGELOG.md
@@ -4,9 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+## [1.0.0] - 2018-09-27
+## Changed
+Added (optional) TLS block in ingress resource.
+You can set the `ingress.addTlsBlock` value to `false` if your
+ingress-controller doesn't work when ingress resources have this block (e.g. [traefik](https://traefik.io) doesn't seem to work)
+
+
 ## [0.1.1] - 2018-07-09
 ## Upgrade Logstash
 - Bumping image tag to 6.3.1 (from 5.6.10) to match elasticsearch version
+
 
 ## [0.1.0] - 2018-06-26
 ### Initial Commit

--- a/charts/logstash/Chart.yaml
+++ b/charts/logstash/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: logstash
-version: 0.1.1
+version: 1.0.0

--- a/charts/logstash/README.md
+++ b/charts/logstash/README.md
@@ -6,5 +6,5 @@ Deploys [logstash](https://www.elastic.co/products/logstash)
 ### Installing and Upgrading a release
 
 ``` bash
-$ helm upgrade logstash-something charts/logstash -f chart-env-config/ENV/logstash.yaml --namespace=default --install
+$ helm upgrade logstash-auth0 charts/logstash -f chart-env-config/ENV/logstash.yaml --namespace=default --install
 ```

--- a/charts/logstash/templates/_helpers.tpl
+++ b/charts/logstash/templates/_helpers.tpl
@@ -12,3 +12,10 @@ Create chart name and version as used by the chart label.
 {{- define "logstash.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Hostname
+*/}}
+{{- define "hostname" -}}
+{{ .Release.Name }}.{{ .Values.servicesdomain }}
+{{- end -}}

--- a/charts/logstash/templates/ingress.yaml
+++ b/charts/logstash/templates/ingress.yaml
@@ -12,11 +12,16 @@ metadata:
     kubernetes.io/ingress.class: "nginx"
 spec:
   rules:
-    - host: {{ .Release.Name }}.{{ .Values.servicesdomain }}
+    - host: {{ template "hostname" . }}
       http:
         paths:
           - path: /
             backend:
               serviceName: {{ .Release.Name }}
               servicePort: {{ .Values.service.port }}
+{{- if .Values.ingress.addTlsBlock }}
+  tls:
+    - hosts:
+        - {{ template "hostname" . }}
+{{- end }}
 {{- end }}

--- a/charts/logstash/values.yaml
+++ b/charts/logstash/values.yaml
@@ -20,6 +20,7 @@ service:
 
 ingress:
   enabled: true
+  addTlsBlock: true
 
 config:
 

--- a/charts/unidler/CHANGELOG.md
+++ b/charts/unidler/CHANGELOG.md
@@ -5,6 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [v2.0.0] - 2018-09-26
+### Changed
+Added (optional) TLS block in ingress resource.
+You can set the `ingress.addTlsBlock` value to `false` if your
+ingress-controller doesn't work when ingress resources have this block (e.g.
+[traefik](https://traefik.io) doesn't seem to work)
+
+
 ## [v1.0.0] - 2018-09-25
 ### Changed
 Use Host header instead of X-Forwarded-Host to determine pod to unidle.

--- a/charts/unidler/Chart.yaml
+++ b/charts/unidler/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: unidler proxy
 name: unidler
-version: "v1.0.0"
+version: "v2.0.0"

--- a/charts/unidler/README.md
+++ b/charts/unidler/README.md
@@ -1,0 +1,11 @@
+# Unidler Helm Chart
+
+The unidler is responsible for unidling the RStudio instances (currently).
+
+## Installing the chart
+
+```bash
+$ helm upgrade --install --dry-run unidler charts/unidler --namespace default -f chart-env-config/ENV/unidler.yml
+```
+
+**NOTE**: Remove `--dry-run` and adjust the values file path.

--- a/charts/unidler/templates/_helpers.tpl
+++ b/charts/unidler/templates/_helpers.tpl
@@ -1,0 +1,6 @@
+{{/*
+Hostname
+*/}}
+{{- define "hostname" -}}
+{{ .Release.Name }}.{{ .Values.servicesDomain }}
+{{- end -}}

--- a/charts/unidler/templates/ingress.yaml
+++ b/charts/unidler/templates/ingress.yaml
@@ -9,10 +9,15 @@ metadata:
     kubernetes.io/ingress.class: "{{ .Values.ingress.className }}"
 spec:
   rules:
-  - host: {{ .Release.Name }}.{{ .Values.servicesDomain }}
+  - host: {{ template "hostname" . }}
     http:
       paths:
       - backend:
           serviceName: {{ .Release.Name }}
           servicePort: 80
         path: /
+{{ if .Values.ingress.addTlsBlock }}
+  tls:
+  - hosts:
+    - {{ template "hostname" . }}
+{{ end }}

--- a/charts/unidler/values.yaml
+++ b/charts/unidler/values.yaml
@@ -9,6 +9,7 @@ logLevel: INFO
 replicaCount: 1
 
 ingress:
+  addTlsBlock: true
   className: "istio"
 
 service:


### PR DESCRIPTION
This is needed by nginx-ingress. This is added by default but
you can set the `ingress.addTlsBlock` value to `false`.

- [x] kibana-auth-proxy
  - release: `cluster-logviewer`
  - ns: `kube-system`
- [x] kubernetes-dashboard ? 
  - ns: `kube-system`
  - NOTE: This is in our repo. We do **NOT** use the [stable/kube-dashboard](https://github.com/helm/charts/tree/master/stable/kubernetes-dashboard) chart. We **should** move to it at some point
- [x] release: `kube-prometheus`
  - ns: `monitoring`
  - **NOTE**: I *think* this is the helm chart that was installed: [coreos/kube-prometheus](https://github.com/coreos/prometheus-operator/tree/master/helm/kube-prometheus)
  - **NOTE**: Stick with the same version (`0.0.32`) for now as newer version changed values structures and even when I tried to fix them I got some other errors which I think may be related to CRDs, `helm upgrade --dry-run --debug kube-prometheus coreos/kube-prometheus --version 0.0.32` seemed promising.
- [ ] Grafana
  - release: `cluster-monitoring`
  - Release in `alpha` is using `grafana-0.8.0` but user-supplied-value for `server.image` is a forked image [`quay.io/mojanalytics/grafana:tempFork`](https://quay.io/repository/mojanalytics/grafana?tab=tags) (can't see where the repo for this is)
  - **NOTE**: We'll have to just patch the ingress object manually until we have more clarity on the forked docker image
- [x] Logstash
  - release: `logstash-auth0`
  - ns: `default`
  - chart: `logstash-0.1.1`
  - the chart installed is maintained by us: https://github.com/ministryofjustice/analytics-platform-helm-charts/tree/master/charts/logstash
  - **NOTE**: This helm chart is not installed in `dev`. Is this a problem?
- [X] Concourse
- [X] CP API
- [X] CP Frontend
- [X] AWS Login 🙉 
- [X] Unidler