### PR TITLE
Webapp: Add TLS block to ingress

### DIFF
--- a/charts/webapp/CHANGELOG.md
+++ b/charts/webapp/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.3.15] - 2018-10-01
+### Changed
+- Update ingress object created by this chart to have a tls block (required by
+  nginx + nlb ingress)
+- Remove `path` from ingress object as it's not required (`/` is already the default)
+
 ## [1.3.14] - 2018-08-02
 ### Changed
 - Update auth-proxy to v0.1.4, which fixes the login loop problem which happens

--- a/charts/webapp/Chart.yaml
+++ b/charts/webapp/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: webapp Helm chart for Kubernetes
 name: webapp
-version: 1.3.14
+version: 1.3.15

--- a/charts/webapp/templates/_helpers.tpl
+++ b/charts/webapp/templates/_helpers.tpl
@@ -14,3 +14,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "hostname" -}}
+{{ .Values.WebApp.Name }}.{{ .Values.WebApp.BaseHost }}
+{{- end -}}

--- a/charts/webapp/templates/ingress.yaml
+++ b/charts/webapp/templates/ingress.yaml
@@ -11,10 +11,12 @@ metadata:
     nginx.ingress.kubernetes.io/affinity: "cookie"
 spec:
   rules:
-  - host: {{ .Values.WebApp.Name }}.{{ .Values.WebApp.BaseHost }}
+  - host: {{ template "hostname" . }}
     http:
       paths:
       - backend:
           serviceName: {{ template "fullname" . }}
           servicePort: {{ .Values.WebApp.Port }}
-        path: /
+  tls:
+    - hosts:
+      - {{ template "hostname" . }}


### PR DESCRIPTION
Update ingress object created by this chart to have a tls block (required by
nginx + nlb ingress) and remove `path` from ingress object as it's not
required (`/` is already the default).