### PR TITLE
Idler 1.0.0 (appVersion: v0.3.0): Support Nanocores

### DIFF
--- a/charts/idler/CHANGELOG.md
+++ b/charts/idler/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.0] - 2018-10-03
+### Changed
+- Using a new version of idler (`v0.3.0`) with more support for cpu metrics in
+  nanocores:
+  https://github.com/ministryofjustice/analytics-platform-idler/pull/16
+
 
 ## [0.2.4] - 2018-04-27
 ### Changed

--- a/charts/idler/Chart.yaml
+++ b/charts/idler/Chart.yaml
@@ -1,4 +1,5 @@
 apiVersion: v1
 description: idler cronjob
 name: idler
-version: 0.2.4
+version: 1.0.0
+appVersion: v0.3.0

--- a/charts/idler/values.yaml
+++ b/charts/idler/values.yaml
@@ -1,5 +1,5 @@
 # Docker image version
-image: quay.io/mojanalytics/idler:v0.2.4
+image: quay.io/mojanalytics/idler:v0.3.0
 
 # Schedule when to run
 #   min    hour   day    month (Sun-Sat)


### PR DESCRIPTION
This bumps the image version of the idler to a version that supports nanocores
as a unit/format for cpu usage.