### PR TITLE
JupyterLab & RStudio: Add idleable label

### DIFF
--- a/charts/jupyter-lab/CHANGELOG.md
+++ b/charts/jupyter-lab/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.1.8] - 2018-10-05
+### Added
+- Add `idleable=true` annoation to the deployment. This is to allow opt-in to
+  the idler.
+
 ## [0.1.7] - 2018-08-15
 ### Changed
 - Added tls config to ingress.  This is required for tls termination with the nginx ingress controller. See [Trello](https://trello.com/c/M1snktNZ)

--- a/charts/jupyter-lab/Chart.yaml
+++ b/charts/jupyter-lab/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Jupyter Lab with Auth0 authentication proxy
 name: jupyter-lab
-version: 0.1.7
+version: 0.1.8

--- a/charts/jupyter-lab/templates/deployment.yaml
+++ b/charts/jupyter-lab/templates/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app: {{ .Chart.Name }}
+    "mojanalytics.xyz/idleable": "true"
 spec:
   selector:
     matchLabels:

--- a/charts/rstudio/CHANGELOG.md
+++ b/charts/rstudio/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.5.6] - 2018-10-05
+### Added
+- Deployment has new label `idleable: "true"` to allow for future opt-in to new
+  label-selector in the idler. This will allow idling of both rstudio (as
+  currently avaiable) and jupyter or any other deployment we add this label to.
+
 ## [1.5.5] - 2018-08-15
 ### Changed
 - Added tls config to ingress.  This is required for tls termination with the nginx ingress controller. See [Trello](https://trello.com/c/M1snktNZ)

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: RStudio with Auth0 authentication proxy
 name: rstudio
-version: 1.5.5
+version: 1.5.6

--- a/charts/rstudio/templates/deployment.yml
+++ b/charts/rstudio/templates/deployment.yml
@@ -5,6 +5,7 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: "{{ .Chart.Name }}"
+    "mojanalytics.xyz/idleable": "true"
 spec:
   replicas: 1
   strategy:


### PR DESCRIPTION
Add `idleable: "true"` so that Jupyter and Rstudio can opt-in to being idled with a single label selector