### PR TITLE
unidler v3.0.0: Use `go-unidler`

### DIFF
--- a/charts/unidler/CHANGELOG.md
+++ b/charts/unidler/CHANGELOG.md
@@ -5,6 +5,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [v3.0.0] - 2018-10-10
+### Changed
+- Changed Docker image to use [`go-unidler`](https://github.com/ministryofjustice/analytics-platform-go-unidler) instead of ["old" `unidler` (Python)](https://github.com/ministryofjustice/analytics-platform-unidler)
+- Use `/healthz` endpoint provided by `go-unidler` to check readiness/liveness.
+- Increased `replicaCount` from `1` to `3` as `go-unidler` is stateless and unidling is idempotent
+- `ingress.className` defaults to `"nginx"` again (not `"istio"`)
+- removed unused values (`logLevel`)
+- added `appVersion` to `Chart.yaml`
+
+
 ## [v2.0.0] - 2018-09-26
 ### Changed
 Added (optional) TLS block in ingress resource.

--- a/charts/unidler/Chart.yaml
+++ b/charts/unidler/Chart.yaml
@@ -1,4 +1,5 @@
 apiVersion: v1
 description: unidler proxy
 name: unidler
-version: "v2.0.0"
+version: "v3.0.0"
+appVersion: "v0.0.4"

--- a/charts/unidler/templates/clusterrole.yaml
+++ b/charts/unidler/templates/clusterrole.yaml
@@ -11,8 +11,10 @@ rules:
       - "deployments"
     verbs:
       - "get"
+      - "list"
       - "patch"
       - "update"
+      - "watch"
   - apiGroups:
       - "extensions"
     resources:
@@ -21,3 +23,4 @@ rules:
       - "get"
       - "list"
       - "patch"
+      - "update"

--- a/charts/unidler/templates/deployment.yaml
+++ b/charts/unidler/templates/deployment.yaml
@@ -21,7 +21,17 @@ spec:
         - name: http
           containerPort: {{ .Values.service.internalPort }}
         env:
-          - name: LOG_LEVEL
-            value: "{{ .Values.logLevel }}"
           - name: INGRESS_CLASS_NAME
             value: "{{ .Values.ingress.className }}"
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: http
+          initialDelaySeconds: 1
+          periodSeconds: 5
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: http
+          initialDelaySeconds: 1
+          periodSeconds: 10

--- a/charts/unidler/values.yaml
+++ b/charts/unidler/values.yaml
@@ -1,16 +1,14 @@
 # Docker image
 image:
-  name: quay.io/mojanalytics/unidler
-  tag: v1.0.0
+  name: quay.io/mojanalytics/go-unidler
+  tag: v0.0.4
   pullPolicy: IfNotPresent
 
-logLevel: INFO
-
-replicaCount: 1
+replicaCount: 3
 
 ingress:
   addTlsBlock: true
-  className: "istio"
+  className: "nginx"
 
 service:
   externalPort: 80


### PR DESCRIPTION
- Changed Docker image to use [`go-unidler`](https://github.com/ministryofjustice/analytics-platform-go-unidler) instead of ["old" `unidler` (Python)](https://github.com/ministryofjustice/analytics-platform-unidler)
- Use `/healthz` endpoint provided by `go-unidler` to check readiness/liveness.
- Increased `replicaCount` from `1` to `3` as `go-unidler` is stateless and unidling is idempotent
- `ingress.className` defaults to `"nginx"` again (not `"istio"`)
- removed unused values (`logLevel`)