### PR TITLE
Idler v0.4.0: Support for idling Jupyter-lab

### DIFF
--- a/charts/idler/CHANGELOG.md
+++ b/charts/idler/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2018-10-10
+### Changed
+- Add support for idling Jupyter-lab
+
 ## [1.0.1] - 2018-10-09
 ### Changed
 - Using a new version of idler (`v0.3.1`) with more support for cpu metrics in

--- a/charts/idler/Chart.yaml
+++ b/charts/idler/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: idler cronjob
 name: idler
-version: 1.0.1
-appVersion: v0.3.1
+version: 1.1.0
+appVersion: v0.4.0

--- a/charts/idler/values.yaml
+++ b/charts/idler/values.yaml
@@ -1,5 +1,5 @@
 # Docker image version
-image: quay.io/mojanalytics/idler:v0.3.1
+image: quay.io/mojanalytics/idler:v0.4.0
 
 # Schedule when to run
 #   min    hour   day    month (Sun-Sat)


### PR DESCRIPTION
Generic support for idling any tool by using app label instead of assuming the
tool `ingress` name is the same as the tool `deployment` name.