### PR TITLE
Update jupyter images to latest tag

### DIFF
--- a/charts/jupyter-lab/CHANGELOG.md
+++ b/charts/jupyter-lab/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.1.9] - 2018-10-16
+### Changed
+- Updated image tag to v0.6.0, which adds geospatial functionality, support for s3 access in spark, and the latest version of jupyter lab.
+
+
 ## [0.1.8] - 2018-10-05
 ### Added
 - Add `idleable=true` annoation to the deployment. This is to allow opt-in to
@@ -12,7 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [0.1.7] - 2018-08-15
 ### Changed
 - Added tls config to ingress.  This is required for tls termination with the nginx ingress controller. See [Trello](https://trello.com/c/M1snktNZ)
-- Auth-proxy image tag from 0.1.4 to 0.1.3 while investigating ssl redirect issues 
+- Auth-proxy image tag from 0.1.4 to 0.1.3 while investigating ssl redirect issues
 
 ## [0.1.6] - 2018-08-10
 ## jupyter-tag-3
@@ -31,14 +36,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [0.1.3] - 2018-5-18
 ## Package Home
 - Profile failed to auto load alias. Amended `pip-user-home.sh` to create `.bash_aliases` file which `.bashrc` checks exists
-- [Trello](https://trello.com/c/NKz0zS0m) 
+- [Trello](https://trello.com/c/NKz0zS0m)
 
 ## [0.1.2] - 2018-04-10
 ## Jupyter Auth0 CallBack URL
 -  Fixing auth proxy callback envvar to point to the correct endpoint
 
 ## [0.1.1] - 2018-02-15
-## Image Tag 
+## Image Tag
 - Modifying Image tag to point to latest image
 
 ## [0.1.0] - 2018-02-08

--- a/charts/jupyter-lab/Chart.yaml
+++ b/charts/jupyter-lab/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Jupyter Lab with Auth0 authentication proxy
 name: jupyter-lab
-version: 0.1.8
+version: 0.1.9

--- a/charts/jupyter-lab/values.yaml
+++ b/charts/jupyter-lab/values.yaml
@@ -25,7 +25,7 @@ authProxy:
 
 jupyter:
   image: quay.io/mojanalytics/datascience-notebook
-  tag: v0.4.0
+  tag: v0.6.0
   imagePullPolicy: IfNotPresent
   containerPort: 8888
   resources:


### PR DESCRIPTION
This updates the Jupyter image tag to v0.6.0, which adds geospatial functionality, support for s3 access in spark, and the latest version of jupyter lab.

Might want to pay a little more attention to this PR than usual since it's my first into the helm charts repo!