### PR TITLE
RStudio 1.5.7: Better probes

### DIFF
--- a/charts/rstudio/CHANGELOG.md
+++ b/charts/rstudio/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Don't hardcode target port in `Service`, use provided value
 - Renamed ports in `Deployment` to be more explicit and avoid any possible
   confusion (they're called `proxyPort` and `rstudioPort` respectively now)
+- Increaded probe frequency by reduced `periodSeconds` to `2` from `5`,
+  this could help with the user experience as k8s could respond to problems
+  more promptly.
+
+### Added
+- Added `livenessProbe` to containers. This will ensure that containers
+  are terminated (and restarted) when containers stop serving traffic
+  for whatever reason.
 
 
 ## [1.5.6] - 2018-10-05

--- a/charts/rstudio/CHANGELOG.md
+++ b/charts/rstudio/CHANGELOG.md
@@ -4,23 +4,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+## [1.5.7] - 2018-10-17
+
+### Changed
+- Don't hardcode target port in `Service`, use provided value
+- Renamed ports in `Deployment` to be more explicit and avoid any possible
+  confusion (they're called `proxyPort` and `rstudioPort` respectively now)
+
+
 ## [1.5.6] - 2018-10-05
 ### Added
 - Deployment has new label `idleable: "true"` to allow for future opt-in to new
   label-selector in the idler. This will allow idling of both rstudio (as
   currently avaiable) and jupyter or any other deployment we add this label to.
 
+
 ## [1.5.5] - 2018-08-15
 ### Changed
 - Added tls config to ingress.  This is required for tls termination with the nginx ingress controller. See [Trello](https://trello.com/c/M1snktNZ)
+
 
 ## [1.5.4] - 2018-07-09
 ### Changed
 - Modified RStudio image tag from v1.3.2 to 3.4.2-5 See: [PR](https://github.com/ministryofjustice/analytics-platform-rstudio/pull/34)
 
+
 ## [1.5.3] - 2018-06-05
 ### Changed
 - Adjusted memory resource limits and requests from `request: 1GB => 5GB` & `limit: 12GB => 20GB`
+
 
 ## [1.5.2] - 2018-05-10
 ### Changed

--- a/charts/rstudio/CHANGELOG.md
+++ b/charts/rstudio/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Don't hardcode target port in `Service`, use provided value
 - Renamed ports in `Deployment` to be more explicit and avoid any possible
-  confusion (they're called `proxyPort` and `rstudioPort` respectively now)
+  confusion (they're now called `proxy` and `rstudio` respectively)
 - Increaded probe frequency by reduced `periodSeconds` to `2` from `5`,
   this could help with the user experience as k8s could respond to problems
   more promptly.

--- a/charts/rstudio/CHANGELOG.md
+++ b/charts/rstudio/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Don't hardcode target port in `Service`, use provided value
 - Renamed ports in `Deployment` to be more explicit and avoid any possible
   confusion (they're now called `proxy` and `rstudio` respectively)
-- Increaded probe frequency by reduced `periodSeconds` to `2` from `5`,
+- Increaded probes' frequency by reduced `periodSeconds` to `2` from `5`,
   this could help with the user experience as k8s could respond to problems
   more promptly.
 

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: RStudio with Auth0 authentication proxy
 name: rstudio
-version: 1.5.6
+version: 1.5.7

--- a/charts/rstudio/templates/deployment.yml
+++ b/charts/rstudio/templates/deployment.yml
@@ -27,7 +27,7 @@ spec:
           image: "{{ .Values.authProxy.image.repository }}:{{ .Values.authProxy.image.tag }}"
           imagePullPolicy: {{ .Values.authProxy.image.pullPolicy }}
           ports:
-            - name: proxyPort
+            - name: proxy
               containerPort: {{ .Values.authProxy.express.port }}
           env:
             - name: USER
@@ -82,13 +82,13 @@ spec:
           readinessProbe:
             httpGet:
               path: /healthz
-              port: proxyPort
+              port: proxy
             initialDelaySeconds: 5
             periodSeconds: 2
           livenessProbe:
             httpGet:
               path: /healthz
-              port: proxyPort
+              port: proxy
             initialDelaySeconds: 5
             periodSeconds: 2
           resources:
@@ -98,7 +98,7 @@ spec:
           image: "{{ .Values.rstudio.image.repository }}:{{ .Values.rstudio.image.tag }}"
           imagePullPolicy: {{ .Values.rstudio.image.pullPolicy }}
           ports:
-            - name: rstudioPort
+            - name: rstudio
               containerPort: {{ .Values.rstudio.port }}
           env:
             - name: USER
@@ -118,13 +118,13 @@ spec:
           readinessProbe:
             httpGet:
               path: /
-              port: rstudioPort
+              port: rstudio
             initialDelaySeconds: 5
             periodSeconds: 2
           livenessProbe:
             httpGet:
               path: /
-              port: rstudioPort
+              port: rstudio
             initialDelaySeconds: 5
             periodSeconds: 2
           volumeMounts:

--- a/charts/rstudio/templates/deployment.yml
+++ b/charts/rstudio/templates/deployment.yml
@@ -89,7 +89,7 @@ spec:
             httpGet:
               path: /healthz
               port: proxy
-            initialDelaySeconds: 5
+            initialDelaySeconds: 10
             periodSeconds: 2
           resources:
 {{ toYaml .Values.authProxy.resources | indent 12 }}
@@ -125,7 +125,7 @@ spec:
             httpGet:
               path: /
               port: rstudio
-            initialDelaySeconds: 5
+            initialDelaySeconds: 10
             periodSeconds: 2
           volumeMounts:
             - name: home

--- a/charts/rstudio/templates/deployment.yml
+++ b/charts/rstudio/templates/deployment.yml
@@ -27,7 +27,7 @@ spec:
           image: "{{ .Values.authProxy.image.repository }}:{{ .Values.authProxy.image.tag }}"
           imagePullPolicy: {{ .Values.authProxy.image.pullPolicy }}
           ports:
-            - name: http
+            - name: proxyPort
               containerPort: {{ .Values.authProxy.express.port }}
           env:
             - name: USER
@@ -82,7 +82,7 @@ spec:
           readinessProbe:
             httpGet:
               path: /healthz
-              port: http
+              port: proxyPort
             initialDelaySeconds: 5
             periodSeconds: 5
           resources:
@@ -92,7 +92,7 @@ spec:
           image: "{{ .Values.rstudio.image.repository }}:{{ .Values.rstudio.image.tag }}"
           imagePullPolicy: {{ .Values.rstudio.image.pullPolicy }}
           ports:
-            - name: http
+            - name: rstudioPort
               containerPort: {{ .Values.rstudio.port }}
           env:
             - name: USER
@@ -112,7 +112,7 @@ spec:
           readinessProbe:
             httpGet:
               path: /
-              port: http
+              port: rstudioPort
             initialDelaySeconds: 5
             periodSeconds: 5
           volumeMounts:

--- a/charts/rstudio/templates/deployment.yml
+++ b/charts/rstudio/templates/deployment.yml
@@ -84,7 +84,13 @@ spec:
               path: /healthz
               port: proxyPort
             initialDelaySeconds: 5
-            periodSeconds: 5
+            periodSeconds: 2
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: proxyPort
+            initialDelaySeconds: 5
+            periodSeconds: 2
           resources:
 {{ toYaml .Values.authProxy.resources | indent 12 }}
 
@@ -114,7 +120,13 @@ spec:
               path: /
               port: rstudioPort
             initialDelaySeconds: 5
-            periodSeconds: 5
+            periodSeconds: 2
+          livenessProbe:
+            httpGet:
+              path: /
+              port: rstudioPort
+            initialDelaySeconds: 5
+            periodSeconds: 2
           volumeMounts:
             - name: home
               mountPath: "/home/{{ .Values.username }}"

--- a/charts/rstudio/templates/service.yml
+++ b/charts/rstudio/templates/service.yml
@@ -11,4 +11,4 @@ spec:
     app: "{{ .Chart.Name }}"
   ports:
   - port: 80
-    targetPort: 3000
+    targetPort: {{ .Values.authProxy.express.port }}


### PR DESCRIPTION
### What
Looks like sometimes auth proxy crashes but container is not terminated (see ticket)

Looking at the RStudio deployment I see that we defined a `readinessProbe` but not a `livenessProbe`, this is likely to be the cause of the problem.

Just a reminder:
- `readinessProbe` determine whether the container should receive traffic
- `livenessProbe` determine if the container is healthy and whether kubernetes will terminate it or not
- `initialDelaySeconds` on `livenessProbe` needs to be enough for the pod to start otherwise k8s will terminate the pod before it can be healthy and you’ll end-up in a loop

#### Changed
- Don't hardcode target port in `Service`, use provided value
- Renamed ports in `Deployment` to be more explicit and avoid any possible
  confusion (they're called `proxyPort` and `rstudioPort` respectively now)
- Increaded probe frequency by reduced `periodSeconds` to `2` from `5`,
  this could help with the user experience as k8s could respond to problems
  more promptly.

#### Added
- Added `livenessProbe` to containers. This will ensure that containers
  are terminated (and restarted) when containers stop serving traffic
  for whatever reason.

### See
- [Pod lifecycle / Container probes](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes)
- [Configure Liveness and Readiness Probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes)
- [Kubernetes Health Checks with Readiness and Liveness Probes (Kubernetes Best Practices) [VIDEO]](https://www.youtube.com/watch?v=mxEvAPQRwhw)
### Ticket
https://trello.com/c/92huREQl/1340-fix-liveness-probe-auth-proxy-crash-not-being-handled