### PR TITLE
Create initial /users/homes dir on the NFS disk

### DIFF
--- a/charts/init-platform/templates/create-nfs-dir-job.yml
+++ b/charts/init-platform/templates/create-nfs-dir-job.yml
@@ -1,0 +1,33 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: create-nfs-dir
+  namespace: default
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+spec:
+  template:
+    metadata:
+      name: create-nfs-dir
+    spec:
+      containers:
+      - name: "create-nfs-dirs"
+        restart: Never
+        image: bash
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+          - name: user-homes-root
+            mountPath: "/tmp/homes"
+        command:
+          - "bash"
+        args:
+          - "-cx"
+          - >
+              cd /tmp/homes &&
+              mkdir -p users/homes
+      restartPolicy: Never
+      volumes:
+      - name: user-homes-root
+        nfs:
+          server: {{ .Values.NFSHostname }}
+          path: /


### PR DESCRIPTION
This job mounts the NFS disk at `/` and creates the `/users/homes` dir. If you don't do this then the `efs-homes` PersistentVolume cannot be mounted because it mounts at that dir.

@kerin and I figured this must have been done manually for alpha & dev's softnas disks. This Job automates it.

Tested on accelerator environment.