### PR TITLE
jupyter-lab 0.1.10: Better probes

### DIFF
--- a/charts/jupyter-lab/CHANGELOG.md
+++ b/charts/jupyter-lab/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+## [0.1.10] - 2018-10-19
+### Changed
+- Added `livenessProbe` to be sure pods are terminated when unhealthy
+- Reduced probes' `periodSeconds` from `5` to `2`
+- Renamed ports in `Deployment` to `proxy`/`jupyter` instead of using `http`
+  for everything which could lead to confusion
+- Fixed indentation in `Deployment` YAML file
+
+
 ## [0.1.9] - 2018-10-16
 ### Changed
 - Updated image tag to v0.6.0, which adds geospatial functionality, support for s3 access in spark, and the latest version of jupyter lab.
@@ -14,14 +24,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add `idleable=true` annoation to the deployment. This is to allow opt-in to
   the idler.
 
+
 ## [0.1.7] - 2018-08-15
 ### Changed
 - Added tls config to ingress.  This is required for tls termination with the nginx ingress controller. See [Trello](https://trello.com/c/M1snktNZ)
 - Auth-proxy image tag from 0.1.4 to 0.1.3 while investigating ssl redirect issues
 
+
 ## [0.1.6] - 2018-08-10
 ## jupyter-tag-3
 - Update datascience-notebook image tag from 0.3.3 to 0.4.0. Relates to [PR](https://github.com/ministryofjustice/analytics-platform-jupyter-notebook/pull/8)
+
 
 ## [0.1.5] - 2018-08-02
 ## Changed
@@ -29,22 +42,27 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   when a user fails to login but is redirected back to the login page without an
   error message.
 
+
 ## [0.1.4] - 2018-07-17
 ## Jupyter Tag
 -Updating the image tag from 0.3.2 to 0.3.3
+
 
 ## [0.1.3] - 2018-5-18
 ## Package Home
 - Profile failed to auto load alias. Amended `pip-user-home.sh` to create `.bash_aliases` file which `.bashrc` checks exists
 - [Trello](https://trello.com/c/NKz0zS0m)
 
+
 ## [0.1.2] - 2018-04-10
 ## Jupyter Auth0 CallBack URL
 -  Fixing auth proxy callback envvar to point to the correct endpoint
 
+
 ## [0.1.1] - 2018-02-15
 ## Image Tag
 - Modifying Image tag to point to latest image
+
 
 ## [0.1.0] - 2018-02-08
 ### Initial Commit

--- a/charts/jupyter-lab/Chart.yaml
+++ b/charts/jupyter-lab/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Jupyter Lab with Auth0 authentication proxy
 name: jupyter-lab
-version: 0.1.9
+version: 0.1.10

--- a/charts/jupyter-lab/templates/deployment.yaml
+++ b/charts/jupyter-lab/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           image: {{ .Values.authProxy.image }}:{{ .Values.authProxy.tag }}
           imagePullPolicy: {{ .Values.authProxy.imagePullPolicy }}
           ports:
-            - name: http
+            - name: proxy
               containerPort: {{ .Values.authProxy.containerPort }}
           env:
             - name: TARGET_URL
@@ -67,16 +67,22 @@ spec:
           readinessProbe:
             httpGet:
               path: /healthz
-              port: http
-          initialDelaySeconds: 5
-          periodSeconds: 5
+              port: proxy
+            initialDelaySeconds: 5
+            periodSeconds: 2
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: proxy
+            initialDelaySeconds: 10
+            periodSeconds: 2
           resources:
 {{ toYaml .Values.authProxy.resources | indent 12 }}
         - name: {{ .Chart.Name }}
           image: {{ .Values.jupyter.image }}:{{ .Values.jupyter.tag }}
           imagePullPolicy: {{ .Values.jupyter.imagePullPolicy }}
           ports:
-            - name: http
+            - name: jupyter
               containerPort: {{ .Values.jupyter.containerPort }}
           command:
             - "start.sh"
@@ -86,9 +92,15 @@ spec:
           readinessProbe:
             httpGet:
               path: /
-              port: http
+              port: jupyter
             initialDelaySeconds: 5
-            periodSeconds: 5
+            periodSeconds: 2
+          livenessProbe:
+            httpGet:
+              path: /
+              port: jupyter
+            initialDelaySeconds: 10
+            periodSeconds: 2
           volumeMounts:
             - name: nfs-home
               mountPath: /home/jovyan


### PR DESCRIPTION
- Added `livenessProbe` to be sure pods are terminated when unhealthy
- Reduced probes' `periodSeconds` from `5` to `2`
- Renamed ports in `Deployment` to `proxy`/`jupyter` instead of using `http`
  for everything which could lead to confusion
- Fixed indentation in `Deployment` YAML file

Ticket: https://trello.com/c/92huREQl/1340-fix-liveness-probe-auth-proxy-crash-not-being-handled

Similar PR: https://github.com/ministryofjustice/analytics-platform-helm-charts/pull/237