### PR TITLE
webapp 1.3.16: Better probes

### DIFF
--- a/charts/webapp/CHANGELOG.md
+++ b/charts/webapp/CHANGELOG.md
@@ -4,11 +4,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+
+## [1.3.16] - 2018-10-19
+### Changed
+- Added `livenessProbe` to proxy container
+- Added `readinessProbe` to webapp container
+- Reduced proxy probe's `periodSeconds` to `2`
+- Named all ports in `Deployment` (`proxy`/`webapp`) instead of using `http`
+  for everything which could lead to confusion
+
+
 ## [1.3.15] - 2018-10-01
 ### Changed
 - Update ingress object created by this chart to have a tls block (required by
   nginx + nlb ingress)
 - Remove `path` from ingress object as it's not required (`/` is already the default)
+
 
 ## [1.3.14] - 2018-08-02
 ### Changed
@@ -16,36 +28,43 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   when a user fails to login but is redirected back to the login page without an
   error message.
 
+
 ## [1.3.13] - 2018-07-17
 ### Changed
 - Mismatched `FLUENT_ELASTICSEARCH_USERNAME` env var in configmap
 - Set reload on failure to __false__.  See: https://github.com/uken/fluent-plugin-elasticsearch/issues/257#issuecomment-348946393
 
+
 ## [1.3.12] - 2018-07-16
 ### Changed
-- After upgrading Elasticsearch. The webapp logs stopped working after a few days.  
-  This was due to deprecations with mappings and Elasticsearch 6 not supporting multiple mapping per index. 
+- After upgrading Elasticsearch. The webapp logs stopped working after a few days.
+  This was due to deprecations with mappings and Elasticsearch 6 not supporting multiple mapping per index.
   See: https://www.elastic.co/guide/en/elasticsearch/reference/6.0/breaking-changes-6.0.html
   Setting `type_name` to resolve this as fluentd-elasticsearch-plugin sets two mappings.
 - Switched to using the more stable Kubernetes tested fluentd image. Made config changes to deployment accordingly.
 - Fixed "No Method" error on `time_nano` filter
 
+
 ## [1.3.11] - 2018-07-16
 ### Changed
 - Use [auth-proxy `v0.1.3`](https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v0.1.3) which upgrades login-passwordless page to use `lock` library instead of `lock-passwordless`
+
 
 ## [1.3.10] - 2018-07-03
 ### Changed
 - Add webapp service account for auditing purposes
 
+
 ## [1.3.9] - 2018-06-04
 ### Changed
 - FluentD-Elasticsearch configuration. Increased buffer params, fixed no method errors from `time_nano` tag
+
 
 ## [1.3.8] - 2018-05-24
 ### Changed
 - Increased memory resources from 256MB(default if unspecified) to 512MB
 - Modified image repo tag to reflect quay.  Sorry (my bad)
+
 
 ## [1.3.7] - 2018-03-23
 ### Changed

--- a/charts/webapp/templates/deployment.yaml
+++ b/charts/webapp/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
           image: "{{ .Values.AuthProxy.Image.Repository }}:{{ .Values.AuthProxy.Image.Tag }}"
           imagePullPolicy: {{ .Values.AuthProxy.Image.PullPolicy }}
           ports:
-            - name: http
+            - name: proxy
               containerPort: 3000
           env:
             - name: USER
@@ -65,19 +65,33 @@ spec:
           readinessProbe:
             httpGet:
               path: /healthz
-              port: http
+              port: proxy
             initialDelaySeconds: 5
-            periodSeconds: 5
+            periodSeconds: 2
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: proxy
+            initialDelaySeconds: 10
+            periodSeconds: 2
 
         - name: webapp
           image: "{{ .Values.WebApp.Image.Repository }}:{{ .Values.WebApp.Image.Tag | replace ":" "" }}"
           imagePullPolicy: {{ .Values.WebApp.Image.PullPolicy }}
           ports:
-            - containerPort: {{ .Values.WebApp.Port }}
+            - name: webapp
+              containerPort: {{ .Values.WebApp.Port }}
+          readinessProbe:
+            httpGet:
+              path: /?healthz
+              port: webapp
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 60
           livenessProbe:
             httpGet:
               path: /?healthz
-              port: {{ .Values.WebApp.Port }}
+              port: webapp
             initialDelaySeconds: 180
             periodSeconds: 10
             timeoutSeconds: 60


### PR DESCRIPTION
- Added `livenessProbe` to proxy container
- Added `readinessProbe` to webapp container
- Reduced proxy probe' `periodSeconds` to `2`
- Named all ports in `Deployment` (`proxy`/`webapp`) instead of using `http`
  for everything which could lead to confusion

Ticket: https://trello.com/c/92huREQl/1340-fix-liveness-probe-auth-proxy-crash-not-being-handled

See similar PR: https://github.com/ministryofjustice/analytics-platform-helm-charts/pull/237