### PR TITLE
Webhook Dispatcher

### DIFF
--- a/charts/webhook-dispatcher/.helmignore
+++ b/charts/webhook-dispatcher/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/charts/webhook-dispatcher/Chart.yaml
+++ b/charts/webhook-dispatcher/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+description: Chart for Concourse Webhook dispatcher
+name: webhook-dispatcher
+version: 0.1.0
+appVersion: "v0.1.1"

--- a/charts/webhook-dispatcher/templates/_helpers.tpl
+++ b/charts/webhook-dispatcher/templates/_helpers.tpl
@@ -1,0 +1,39 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "webhook-dispatcher.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "webhook-dispatcher.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Hostname
+*/}}
+{{- define "hostname" -}}
+{{ .Release.Name }}.{{ .Values.servicesDomain }}
+{{- end -}}

--- a/charts/webhook-dispatcher/templates/deployment.yaml
+++ b/charts/webhook-dispatcher/templates/deployment.yaml
@@ -1,0 +1,49 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: {{ .Release.Name }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}
+    spec:
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.name }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+        - name: http
+          containerPort: {{ .Values.service.internalPort }}
+        env:
+        - name: CONCOURSE_BASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}
+              key: CONCOURSE_BASE_URL
+        - name: CONCOURSE_WEBHOOK_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}
+              key: CONCOURSE_WEBHOOK_TOKEN
+        - name: SECRET
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}
+              key: SECRET
+        readinessProbe:
+          httpGet:
+            path: /?healthz
+            port: http
+          initialDelaySeconds: 1
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /?healthz
+            port: http
+          initialDelaySeconds: 1
+          periodSeconds: 20

--- a/charts/webhook-dispatcher/templates/ingress.yaml
+++ b/charts/webhook-dispatcher/templates/ingress.yaml
@@ -1,0 +1,23 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: "{{ .Release.Name }}"
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: "{{ .Chart.Name }}"
+  annotations:
+    kubernetes.io/ingress.class: "{{ .Values.ingress.className }}"
+spec:
+  rules:
+  - host: {{ template "hostname" . }}
+    http:
+      paths:
+      - backend:
+          serviceName: {{ .Release.Name }}
+          servicePort: 80
+{{ if .Values.ingress.addTlsBlock }}
+  tls:
+  - hosts:
+    - {{ template "hostname" . }}
+{{ end }}
+

--- a/charts/webhook-dispatcher/templates/secrets.yaml
+++ b/charts/webhook-dispatcher/templates/secrets.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    app: {{ template "fullname" . }}
+type: Opaque
+data:
+  CONCOURSE_BASE_URL: {{ .Values.concourse.base_url | b64enc | quote }}
+  CONCOURSE_WEBHOOK_TOKEN: {{ .Values.concourse.token | b64enc | quote }}
+  SECRET: {{ .Values.secret | b64enc | quote }}

--- a/charts/webhook-dispatcher/templates/service.yaml
+++ b/charts/webhook-dispatcher/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: {{ .Release.Name }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - name: http
+    port: {{ .Values.service.externalPort }}
+    targetPort: {{ .Values.service.internalPort }}
+  selector:
+    app: {{ .Release.Name }}
+

--- a/charts/webhook-dispatcher/values.yaml
+++ b/charts/webhook-dispatcher/values.yaml
@@ -1,0 +1,22 @@
+# Default values for webhook-dispatcher.
+replicaCount: 1
+
+image:
+  name: quay.io/mojanalytics/webhook-dispatcher
+  tag: v0.1.1
+  pullPolicy: IfNotPresent
+
+service:
+  externalPort: 80
+  internalPort: 8000
+  type: ClusterIP
+
+ingress:
+  addTlsBlock: true
+  className: "nginx"
+
+servicesDomain: ""
+
+concourse:
+  base_url: ""
+  token: ""


### PR DESCRIPTION
This is a new chart for deploying a github org hook to concourse pipeline
service. This will allow us to reduce polling frequency for concourse pipelines
because they will now be triggered by a single org webhook