### PR TITLE
jupyter-lab 0.1.11: Better probes adjustment

### DIFF
--- a/charts/jupyter-lab/CHANGELOG.md
+++ b/charts/jupyter-lab/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.1.10] - 2018-10-19
+### Changed
+- Adjusted `livenessProbe` and `readinessProbe` to bigger values for Jupyter container
 
 ## [0.1.10] - 2018-10-19
 ### Changed

--- a/charts/jupyter-lab/Chart.yaml
+++ b/charts/jupyter-lab/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Jupyter Lab with Auth0 authentication proxy
 name: jupyter-lab
-version: 0.1.10
+version: 0.1.11

--- a/charts/jupyter-lab/templates/deployment.yaml
+++ b/charts/jupyter-lab/templates/deployment.yaml
@@ -93,14 +93,16 @@ spec:
             httpGet:
               path: /
               port: jupyter
-            initialDelaySeconds: 5
-            periodSeconds: 2
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 10
           livenessProbe:
             httpGet:
               path: /
               port: jupyter
-            initialDelaySeconds: 10
-            periodSeconds: 2
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 10
           volumeMounts:
             - name: nfs-home
               mountPath: /home/jovyan


### PR DESCRIPTION
Related to [PR](https://github.com/ministryofjustice/analytics-platform-helm-charts/pull/240)

Intermittently some users are unable to launch Jupyter-Lab successfully
due to probe failures.  There doesn't appear to be a pattern to failing replicas. All we see in the pod
description are the `Liveness/Readiness probes are failing with
getsockopt: connection refused` errors.

The errors are resolved by increasing the values of the probes for
Jupyter or removing the probes entirely.  See [Probe Configuration](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)