### PR TITLE
CRAN Proxy Chart

### DIFF
--- a/charts/cran-proxy/.helmignore
+++ b/charts/cran-proxy/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/charts/cran-proxy/Chart.yaml
+++ b/charts/cran-proxy/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+description: Chart for Cran-Proxy (compiles binaries compatiable rocker/verse)
+name: cran-proxy
+version: 0.1.1
+appVersion: "v0.2.0"

--- a/charts/cran-proxy/templates/_helpers.tpl
+++ b/charts/cran-proxy/templates/_helpers.tpl
@@ -1,0 +1,39 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "cran-proxy.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "cran-proxy.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Hostname
+*/}}
+{{- define "hostname" -}}
+{{ .Release.Name }}.{{ .Values.servicesDomain }}
+{{- end -}}

--- a/charts/cran-proxy/templates/deployment.yaml
+++ b/charts/cran-proxy/templates/deployment.yaml
@@ -1,0 +1,40 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: {{ .Release.Name }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}
+    spec:
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.name }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{ if .Values.logLevel }}
+        env:
+          - name: LOG_LEVEL
+            value: {{ .Values.logLevel | quote }}
+        {{ end }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+        ports:
+        - name: http
+          containerPort: {{ .Values.service.internalPort }}
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: http
+          initialDelaySeconds: 10
+          periodSeconds: 20
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: http
+          initialDelaySeconds: 10
+          periodSeconds: 20

--- a/charts/cran-proxy/templates/ingress.yaml
+++ b/charts/cran-proxy/templates/ingress.yaml
@@ -1,0 +1,23 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: "{{ .Release.Name }}"
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: "{{ .Chart.Name }}"
+  annotations:
+    kubernetes.io/ingress.class: "{{ .Values.ingress.className }}"
+spec:
+  rules:
+  - host: {{ template "hostname" . }}
+    http:
+      paths:
+      - backend:
+          serviceName: {{ .Release.Name }}
+          servicePort: 80
+{{ if .Values.ingress.addTlsBlock }}
+  tls:
+  - hosts:
+    - {{ template "hostname" . }}
+{{ end }}
+

--- a/charts/cran-proxy/templates/service.yaml
+++ b/charts/cran-proxy/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: {{ .Release.Name }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - name: http
+    port: {{ .Values.service.externalPort }}
+    targetPort: {{ .Values.service.internalPort }}
+  selector:
+    app: {{ .Release.Name }}
+

--- a/charts/cran-proxy/values.yaml
+++ b/charts/cran-proxy/values.yaml
@@ -1,0 +1,28 @@
+# Default values for cran-proxy.
+replicaCount: 1
+
+image:
+  name: quay.io/mojanalytics/cran-proxy
+  tag: v0.2.2
+  pullPolicy: IfNotPresent
+
+service:
+  externalPort: 80
+  internalPort: 8000
+  type: ClusterIP
+
+ingress:
+  addTlsBlock: true
+  className: "nginx"
+
+servicesDomain: ""
+logLevel: ""
+## CPU and memory limits for cran server
+##
+resources:
+  requests:
+    memory: 1Gi
+    cpu: 1
+  limits:
+    memory: 5Gi
+    cpu: 2


### PR DESCRIPTION
This is a chart for hosting a CRAN proxy in our cluster. The cran proxy can
speed up installation of binary R packages for both users and webapps.