### PR TITLE
Better Probes 3

### DIFF
--- a/charts/jupyter-lab/CHANGELOG.md
+++ b/charts/jupyter-lab/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.1.12] - 2018-11-19
+### Changed
+- Modified `livenessProbe` and `readinessProbe` to type `exec` for Jupyter container
+
 ## [0.1.11] - 2018-11-14
 ### Changed
 - Adjusted `livenessProbe` and `readinessProbe` to bigger values for Jupyter container

--- a/charts/jupyter-lab/Chart.yaml
+++ b/charts/jupyter-lab/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Jupyter Lab with Auth0 authentication proxy
 name: jupyter-lab
-version: 0.1.11
+version: 0.1.12

--- a/charts/jupyter-lab/templates/deployment.yaml
+++ b/charts/jupyter-lab/templates/deployment.yaml
@@ -90,18 +90,20 @@ spec:
             - "jupyter lab"
             - "--NotebookApp.token=''"
           readinessProbe:
-            httpGet:
-              path: /
-              port: jupyter
-            initialDelaySeconds: 30
+            exec:
+              command:
+                - /usr/bin/pgrep
+                - jupyter-lab
+            initialDelaySeconds: 20
             periodSeconds: 20
             timeoutSeconds: 10
           livenessProbe:
-            httpGet:
-              path: /
-              port: jupyter
-            initialDelaySeconds: 30
-            periodSeconds: 20
+            exec:
+              command:
+                - /usr/bin/pgrep
+                - jupyter-lab
+            initialDelaySeconds: 10
+            periodSeconds: 5
             timeoutSeconds: 10
           volumeMounts:
             - name: nfs-home


### PR DESCRIPTION
Modifying `livenessProbe` and `readinessProbe` to type `exec` for Jupyter container

Since introducing probes for Jupyter we have intermittently witnessed
instability when starting the `pod`.

At present we're still unsure as the root cause of the probes failing
for a seemingly healthy container.  The response from Jupyter to the probes on
some occassions appears to be invalid. Initially the probes were introduced
to address failures with the authentication proxy container and they
appear to be working.