### PR TITLE
Cluster AutoScaler (alpha)

### DIFF
--- a/charts/cluster-autoscaler/CHANGELOG.md
+++ b/charts/cluster-autoscaler/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+
+## [0.1.1] - 2018-11-20
+### Added
+- Added `Rolebinding` that allows __cluster-autoscaler__ to read the `configmap: cluster-autoscaler-status` in `namespace: default`
+- Added `--namespace=default` flag as __cluster-autoscaler__ assumes that it's deployed to `namespace: kube-system`

--- a/charts/cluster-autoscaler/Chart.yaml
+++ b/charts/cluster-autoscaler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.12.0
 description: Scales worker nodes within autoscaling groups
 name: cluster-autoscaler
-version: 0.1.0
+version: 0.1.1
 sources:
 - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 - https://github.com/spotinst/kubernetes-autoscaler/tree/master/cluster-autoscaler

--- a/charts/cluster-autoscaler/templates/deployment.yaml
+++ b/charts/cluster-autoscaler/templates/deployment.yaml
@@ -31,6 +31,7 @@ spec:
             - --logtostderr=true
             - --cloud-provider=aws
             - --skip-nodes-with-local-storage=false
+            - --namespace=default
           {{- if .Values.autoscalingGroups }}
             {{- range .Values.autoscalingGroups }}
             - --nodes={{ .minSize }}:{{ .maxSize }}:{{ .name }}

--- a/charts/cluster-autoscaler/templates/rolebinding.yaml
+++ b/charts/cluster-autoscaler/templates/rolebinding.yaml
@@ -14,3 +14,22 @@ subjects:
   - kind: ServiceAccount
     name: {{ .Release.Name }}
     namespace: default
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-configmap
+  namespace: default
+  labels:
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-configmap
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}
+    namespace: default


### PR DESCRIPTION
Not sure why yet but for some reason (in alpha), __cluster-autoscaler__ deployed it's status `configmap` to `namespace: default`.

- Added `Rolebinding` that allows __cluster-autoscaler__ to read the `configmap: cluster-autoscaler-status` in `namespace: default`

__Cluster-AutoScaler__ assumes (in alpha only) that it's deployed to `namespace: kube-system`

- Added `--namespace=default` flag as __cluster-autoscaler__ assumes that it's deployed to `namespace: kube-system`

Added __CHANGELOG__