### PR TITLE
kube2iam: add toleration for highmem nodes

### DIFF
--- a/charts/kube2iam/Chart.yaml
+++ b/charts/kube2iam/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Allows k8s pods to be started with AWS IAM roles attached
 name: kube2iam
-version: 1.1.0
+version: 1.1.1

--- a/charts/kube2iam/templates/daemonset.yml
+++ b/charts/kube2iam/templates/daemonset.yml
@@ -36,3 +36,8 @@ spec:
               name: http
           securityContext:
             privileged: true
+      tolerations:
+      - effect: NoSchedule
+        key: dedicated
+        operator: Equal
+        value: highmem


### PR DESCRIPTION
new `highmem` instanceGroups are tainted with `NoSchedule`, but kube2iam must be scheduled on those nodes too, so a hardcoded `tolerations` block has been added to the `Deployment` resource. This is a short-term fix however, and `tolerations` should either be added to the chart values, or we should replace the use of our own chart with that of the kube2iam chart in the main chart repo.