### PR TITLE
PodDisruption Cluster AutoScaler

### DIFF
--- a/charts/cluster-autoscaler/templates/poddisruptionbudget.yaml
+++ b/charts/cluster-autoscaler/templates/poddisruptionbudget.yaml
@@ -13,3 +13,16 @@ spec:
 ---
     {{- end }}
 {{ end }}
+
+---
+
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: cluster-autoscaler
+  namespace: kube-system
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: cluster-autoscaler


### PR DESCRIPTION
    Another alpha observation where it could just be pure chance. CA
    (cluster-autoscaler) lands on a node that meets the criteria for scale
    down. Cluster Autoscaler has issues across AZs so when CA is evicted, it errors
    upon startup trying to acquire leader lease (I think) and requires
    manual intervention.

    Adding `PodDisruptionBudget` so CA leaves itself (node) alone.

    **note**

    This has been in flight for a few days and appears to have settled in.