### PR TITLE
CRAN-Proxy: bump version to v0.2.3

### DIFF
--- a/charts/cran-proxy/Chart.yaml
+++ b/charts/cran-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: Chart for Cran-Proxy (compiles binaries compatiable rocker/verse)
 name: cran-proxy
-version: 0.1.1
-appVersion: "v0.2.0"
+version: 0.1.2
+appVersion: "v0.2.3"

--- a/charts/cran-proxy/values.yaml
+++ b/charts/cran-proxy/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 
 image:
   name: quay.io/mojanalytics/cran-proxy
-  tag: v0.2.2
+  tag: v0.2.3
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
This version only updates documentation but I thought it would be good for the
chart to match the latest version.