### PR TITLE
Remove Jupyter Probes

### DIFF
--- a/charts/jupyter-lab/CHANGELOG.md
+++ b/charts/jupyter-lab/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.1.13] - 2018-11-28
+### Changed
+- Removed `livenessProbe` and `readinessProbe` from Jupyter container
+
 ## [0.1.12] - 2018-11-19
 ### Changed
 - Modified `livenessProbe` and `readinessProbe` to type `exec` for Jupyter container

--- a/charts/jupyter-lab/Chart.yaml
+++ b/charts/jupyter-lab/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Jupyter Lab with Auth0 authentication proxy
 name: jupyter-lab
-version: 0.1.12
+version: 0.1.13

--- a/charts/jupyter-lab/templates/deployment.yaml
+++ b/charts/jupyter-lab/templates/deployment.yaml
@@ -89,22 +89,6 @@ spec:
           args:
             - "jupyter lab"
             - "--NotebookApp.token=''"
-          readinessProbe:
-            exec:
-              command:
-                - /usr/bin/pgrep
-                - jupyter-lab
-            initialDelaySeconds: 20
-            periodSeconds: 20
-            timeoutSeconds: 10
-          livenessProbe:
-            exec:
-              command:
-                - /usr/bin/pgrep
-                - jupyter-lab
-            initialDelaySeconds: 10
-            periodSeconds: 5
-            timeoutSeconds: 10
           volumeMounts:
             - name: nfs-home
               mountPath: /home/jovyan


### PR DESCRIPTION
Since last chart update stability has continued to decrese due what
appears to be a command in the Dockerfile taking a long time.  The base
image was updated 2 months ago and may have been fixed since.

This PR is on standby in case we have not confirmed a fix by COB.