### PR TITLE
JupyterLab v0.1.14: Return of the probes

### DIFF
--- a/charts/jupyter-lab/CHANGELOG.md
+++ b/charts/jupyter-lab/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.1.14] - 2018-11-29
+### Changed
+- Jupyter-lab container will run as uid 1001 to match r-studio. This is
+  no longer done by the image itself
+- Re-added `livenessProbe` and `readinessProbe` from Jupyter container
+
 ## [0.1.13] - 2018-11-28
 ### Changed
 - Removed `livenessProbe` and `readinessProbe` from Jupyter container

--- a/charts/jupyter-lab/Chart.yaml
+++ b/charts/jupyter-lab/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Jupyter Lab with Auth0 authentication proxy
 name: jupyter-lab
-version: 0.1.13
+version: 0.1.14

--- a/charts/jupyter-lab/templates/deployment.yaml
+++ b/charts/jupyter-lab/templates/deployment.yaml
@@ -68,14 +68,14 @@ spec:
             httpGet:
               path: /healthz
               port: proxy
-            initialDelaySeconds: 5
-            periodSeconds: 2
+            initialDelaySeconds: 15
+            periodSeconds: 10
           livenessProbe:
             httpGet:
               path: /healthz
               port: proxy
-            initialDelaySeconds: 10
-            periodSeconds: 2
+            initialDelaySeconds: 20
+            periodSeconds: 10
           resources:
 {{ toYaml .Values.authProxy.resources | indent 12 }}
         - name: {{ .Chart.Name }}
@@ -89,6 +89,18 @@ spec:
           args:
             - "jupyter lab"
             - "--NotebookApp.token=''"
+          readinessProbe:
+            httpGet:
+              path: /
+              port: jupyter
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: jupyter
+            initialDelaySeconds: 15
+            periodSeconds: 10
           volumeMounts:
             - name: nfs-home
               mountPath: /home/jovyan
@@ -98,3 +110,5 @@ spec:
         - name: nfs-home
           persistentVolumeClaim:
             claimName: nfs-home
+      securityContext:
+        runAsUser: 1001

--- a/charts/jupyter-lab/values.yaml
+++ b/charts/jupyter-lab/values.yaml
@@ -25,7 +25,7 @@ authProxy:
 
 jupyter:
   image: quay.io/mojanalytics/datascience-notebook
-  tag: v0.6.0
+  tag: v0.6.2
   imagePullPolicy: IfNotPresent
   containerPort: 8888
   resources:


### PR DESCRIPTION
The probes are back now the underlying problem causing slow jupyter startup has
been identified and fixed. The fix was to run the jupyter container as uid=1001
so it matches rstudio. We were doing this in the docker file before using the
NB_UID environment variable but the presence of that caused the underlying
jupyter base image to `chown` the users' home directory. The bigger the home
directory, the slower this made startup.