### PR TITLE
JupyterLab: Upgrade auth_proxy image version

### DIFF
--- a/charts/jupyter-lab/Chart.yaml
+++ b/charts/jupyter-lab/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Jupyter Lab with Auth0 authentication proxy
 name: jupyter-lab
-version: 0.1.14
+version: 0.1.15

--- a/charts/jupyter-lab/values.yaml
+++ b/charts/jupyter-lab/values.yaml
@@ -9,7 +9,7 @@ service:
 
 authProxy:
   image: quay.io/mojanalytics/auth-proxy
-  tag: v0.1.3
+  tag: v0.1.6
   imagePullPolicy: IfNotPresent
   containerPort: 3000
   resources:


### PR DESCRIPTION
This solves a redirect login loop bug and also bumps some dependencies' versions