### PR TITLE
Rstudio: bump image version

### DIFF
--- a/charts/rstudio/CHANGELOG.md
+++ b/charts/rstudio/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.5.8] - 2018-10-17
+
+### Changed
+- Version of rstudio image (3.4.2-6), it now points at the cran proxy, has boto3
+  installed by default and is able to build udunits2 r package
+- Change pull policy for rstudio container to be 'IfNotPresent' instead of 'Always'
 
 ## [1.5.7] - 2018-10-17
 

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: RStudio with Auth0 authentication proxy
 name: rstudio
-version: 1.5.7
+version: 1.5.8

--- a/charts/rstudio/values.yaml
+++ b/charts/rstudio/values.yaml
@@ -30,8 +30,8 @@ rstudio:
   port: "8787"
   image:
     repository: quay.io/mojanalytics/rstudio
-    tag: "3.4.2-5"
-    pullPolicy: "Always"
+    tag: "3.4.2-6"
+    pullPolicy: "IfNotPresent"
   resources:
     limits:
       cpu: 1.5


### PR DESCRIPTION
- Bump version of rstudio image (3.4.2-6), it now points at the cran proxy, has boto3
  installed by default and is able to build udunits2 r package
- Change pull policy for rstudio container to be 'IfNotPresent' instead of 'Always'