### PR TITLE
Cran-Proxy: Bump version of base image

### DIFF
--- a/charts/cran-proxy/Chart.yaml
+++ b/charts/cran-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: Chart for Cran-Proxy (compiles binaries compatiable rocker/verse)
 name: cran-proxy
-version: 0.1.2
-appVersion: "v0.2.3"
+version: 0.1.3
+appVersion: "v0.3.0"

--- a/charts/cran-proxy/templates/deployment.yaml
+++ b/charts/cran-proxy/templates/deployment.yaml
@@ -7,6 +7,11 @@ metadata:
     app: {{ .Release.Name }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   template:
     metadata:
       labels:

--- a/charts/cran-proxy/values.yaml
+++ b/charts/cran-proxy/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 
 image:
   name: quay.io/mojanalytics/cran-proxy
-  tag: v0.2.3
+  tag: v0.3.0
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
New base image now supports compiling udunits2

only merge after: https://github.com/ministryofjustice/analytics-platform-cran-proxy/pull/3 is merged and a v0.3.0 release is tagged