### PR TITLE
Jupyter-lab: Bump docker image version

### DIFF
--- a/charts/jupyter-lab/CHANGELOG.md
+++ b/charts/jupyter-lab/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.1.16] - 2018-12-13
+### Changed
+- Revert previous change setting uid as 1001 at the pod level. We have
+put this back into the image as we found a couple of issues with this approach
+
 ## [0.1.14] - 2018-11-29
 ### Changed
 - Jupyter-lab container will run as uid 1001 to match r-studio. This is

--- a/charts/jupyter-lab/Chart.yaml
+++ b/charts/jupyter-lab/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Jupyter Lab with Auth0 authentication proxy
 name: jupyter-lab
-version: 0.1.15
+version: 0.1.16

--- a/charts/jupyter-lab/templates/deployment.yaml
+++ b/charts/jupyter-lab/templates/deployment.yaml
@@ -110,5 +110,3 @@ spec:
         - name: nfs-home
           persistentVolumeClaim:
             claimName: nfs-home
-      securityContext:
-        runAsUser: 1001

--- a/charts/jupyter-lab/values.yaml
+++ b/charts/jupyter-lab/values.yaml
@@ -25,7 +25,7 @@ authProxy:
 
 jupyter:
   image: quay.io/mojanalytics/datascience-notebook
-  tag: v0.6.2
+  tag: v0.6.3
   imagePullPolicy: IfNotPresent
   containerPort: 8888
   resources:


### PR DESCRIPTION
The new docker image,
revert previous change setting uid as 1001 at the pod level.
We have put this back into the image as we found a couple of issues with this approach