### PR TITLE
Cran-Proxy: Bump docker image version

### DIFF
--- a/charts/cran-proxy/Chart.yaml
+++ b/charts/cran-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: Chart for Cran-Proxy (compiles binaries compatiable rocker/verse)
 name: cran-proxy
-version: 0.1.3
-appVersion: "v0.3.0"
+version: 0.1.4
+appVersion: "v0.3.1"

--- a/charts/cran-proxy/values.yaml
+++ b/charts/cran-proxy/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 
 image:
   name: quay.io/mojanalytics/cran-proxy
-  tag: v0.3.0
+  tag: v0.3.1
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
This new image pins the version of the Prometheus client to one that is
compatible with sanic-prometheus