### PR TITLE
kube2iam 1.1.2: Added support for regional STS endpoint

### DIFF
--- a/charts/kube2iam/CHANGELOG.md
+++ b/charts/kube2iam/CHANGELOG.md
@@ -5,6 +5,26 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [1.1.2] - 2018-12-14
+### Added
+Added support for regional STS endpoint.
+
+> STS also has regional endpoints which can only be explicitly used
+> programatically. The use of a regional sts endpoint can reduce the
+> latency for STS requests
+
+By passing the `sts_region` value kube2iam will use regional endpoint
+which can improve STS requests' latency.
+
+By defaul kube2iam **will not** use regional STS endpoint.
+
+See: https://github.com/jtblin/kube2iam#aws-sts-endpoint-and-regions
+
+### Changed
+- Pin version of kube2iam docker image and pull it only if necessary.
+- Set Daemonset update strategy to `RollingUpdate`
+
+
 ## [1.0.0] - 2018-01-24
 ### Added
 Added `ServiceAccount`, `ClusterRole`, `ClusterRoleBinding` and make

--- a/charts/kube2iam/Chart.yaml
+++ b/charts/kube2iam/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Allows k8s pods to be started with AWS IAM roles attached
 name: kube2iam
-version: 1.1.1
+version: 1.1.2

--- a/charts/kube2iam/templates/daemonset.yml
+++ b/charts/kube2iam/templates/daemonset.yml
@@ -13,6 +13,8 @@ spec:
     spec:
       serviceAccountName: kube2iam
       hostNetwork: true
+      updateStrategy:
+        type: RollingUpdate
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -25,11 +27,18 @@ spec:
             - "--default-role={{ .Values.default_role }}"
             - "--namespace-restrictions=true"
             - "--namespace-restriction-format=regexp"
+            {{- if .Values.sts_region }}
+            - "--use-regional-sts-endpoint=true"
+            {{- end }}
           env:
             - name: HOST_IP
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+            {{- if .Values.sts_region }}
+            - name: AWS_REGION
+              value: {{ .Values.sts_region }}
+            {{- end }}
           ports:
             - containerPort: 8181
               hostPort: 8181

--- a/charts/kube2iam/values.yaml
+++ b/charts/kube2iam/values.yaml
@@ -1,7 +1,8 @@
 host_interface: docker0
 base_role: ""
 default_role: ""
+sts_region: ""
 image:
   repository: jtblin/kube2iam
-  tag: latest
-  pullPolicy: Always
+  tag: 0.10.4
+  pullPolicy: IfNotPresent


### PR DESCRIPTION
From : https://github.com/jtblin/kube2iam#aws-sts-endpoint-and-regions

> STS also has regional endpoints which can only be explicitly used
> programatically. The use of a regional sts endpoint can reduce the
> latency for STS requests

By passing the `sts_region` value to the helm chart, kube2iam will use the regional endpoint
which can improve STS requests' latency.

By defaul kube2iam **will not** use regional STS endpoint.