### PR TITLE
RBAC: Kubelet

### DIFF
--- a/charts/rbac/CHANGELOG.md
+++ b/charts/rbac/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] - 2018-12-18
+### Initial Commit
+- Created `ClusterRoleBinding` for __kubelet-api__ user. [Trello](https://trello.com/c/YNDTzEIx)
+
 ## [0.1.1] - 2018-08-06
 ### Initial Commit
 - Created `Rolebinding` for airflow support that binds to __app-support__ `Clusterrole`. [Trello](https://trello.com/c/Tq1xQCf3)

--- a/charts/rbac/Chart.yaml
+++ b/charts/rbac/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: User and Group RBAC resources
 name: rbac
-version: 0.1.1
+version: 0.1.2

--- a/charts/rbac/README.md
+++ b/charts/rbac/README.md
@@ -36,6 +36,7 @@ Configured Resources
 | App-Support     | `Group`         | moj-analytical-services | Shiny application support |
 | Cluster-Admins  | `Group`         | moj-analytical-services | Kubernetes Cluster Admins |
 | Airflow_support | `Group`         | moj-analytical-services | Airflow job support       |
+| kubelet-api     | `User`          | ""                      | Binding for builtin account|   
 
 
 #### Example

--- a/charts/rbac/templates/kubelet-api.yaml
+++ b/charts/rbac/templates/kubelet-api.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.teams.kubeletAPI.name }}
+  labels:
+    chart: {{ template "rbac.chart" . }}
+  annotations:
+    description: {{ .Values.teams.kubeletAPI.description | quote }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: "system:{{ .Values.teams.kubeletAPI.name }}-admin"
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: {{ .Values.teams.kubeletAPI.name }}

--- a/charts/rbac/values.yaml
+++ b/charts/rbac/values.yaml
@@ -10,3 +10,6 @@ teams:
     name: airflow-support
     namespace: airflow
     description: "Airflow job support. Namespace: airflow"
+  kubeletAPI:
+    name: kubelet-api
+    description: "Assigns the builtin kubelet-api-admin Clusterrole to the kubelet-api user"


### PR DESCRIPTION
[Trello](https://trello.com/c/YNDTzEIx)

When we became aware of this[ vulnerability](https://medium.com/handy-tech/analysis-of-a-kubernetes-hack-backdooring-through-kubelet-823be5c3d67c)

We decided to disable anonymous auth.  However, this prevents Prometheus via the node exporter and possibly other components from successfully
querying the API to gather metrics.

Enabling [RBAC](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) ensures that all workloads, cluster or user-defined
should use a serviceaccount.  Serviceaccounts use auth tokens when making requests to the API. Disabling anonymous auth on the kubelet API and setting it to use these tokens to authenticate and a clusterrole for authorisation mitigates the vulnerability mentioned above while allowing the workloads like the node exporter to continue functioning.