### PR TITLE
Cran-Proxy v0.4.0: Bump image version

### DIFF
--- a/charts/cran-proxy/Chart.yaml
+++ b/charts/cran-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: Chart for Cran-Proxy (compiles binaries compatiable rocker/verse)
 name: cran-proxy
-version: 0.1.4
-appVersion: "v0.3.1"
+version: 0.1.5
+appVersion: "v0.4.0"

--- a/charts/cran-proxy/values.yaml
+++ b/charts/cran-proxy/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 
 image:
   name: quay.io/mojanalytics/cran-proxy
-  tag: v0.3.1
+  tag: v0.4.0
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
also bumps chart version; this new image makes more portable binary packages