### PR TITLE
Cran-Proxy: Update image to v0.5.0

### DIFF
--- a/charts/cran-proxy/Chart.yaml
+++ b/charts/cran-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: Chart for Cran-Proxy (compiles binaries compatiable rocker/verse)
 name: cran-proxy
-version: 0.1.5
-appVersion: "v0.4.0"
+version: 0.2.0
+appVersion: "v0.5.0"

--- a/charts/cran-proxy/templates/deployment.yaml
+++ b/charts/cran-proxy/templates/deployment.yaml
@@ -21,10 +21,14 @@ spec:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.name }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        {{ if .Values.logLevel }}
         env:
+        {{ if .Values.logLevel }}
           - name: LOG_LEVEL
             value: {{ .Values.logLevel | quote }}
+        {{ end }}
+        {{ if .Values.passive }}
+          - name: PASSIVE
+            value: {{ .Values.passive | quote }}
         {{ end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}

--- a/charts/cran-proxy/values.yaml
+++ b/charts/cran-proxy/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 
 image:
   name: quay.io/mojanalytics/cran-proxy
-  tag: v0.4.0
+  tag: v0.5.0
   pullPolicy: IfNotPresent
 
 service:
@@ -17,6 +17,7 @@ ingress:
 
 servicesDomain: ""
 logLevel: ""
+passive: "FALSE"
 ## CPU and memory limits for cran server
 ##
 resources:


### PR DESCRIPTION
This new image (v0.5.0) allows an environment variable called `PASSIVE`
which this chart is updated to support