### PR TITLE
Upgrade Cluster AutoScaler

### DIFF
--- a/charts/cluster-autoscaler/CHANGELOG.md
+++ b/charts/cluster-autoscaler/CHANGELOG.md
@@ -7,5 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [0.1.1] - 2018-11-20
 ### Added
+- Modified image tag from `v1.2.2` to `v1.3.5` after cluster upgrade. See [version table](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler#releases)
+
+## [0.1.1] - 2018-11-20
+### Added
 - Added `Rolebinding` that allows __cluster-autoscaler__ to read the `configmap: cluster-autoscaler-status` in `namespace: default`
 - Added `--namespace=default` flag as __cluster-autoscaler__ assumes that it's deployed to `namespace: kube-system`

--- a/charts/cluster-autoscaler/Chart.yaml
+++ b/charts/cluster-autoscaler/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 1.12.0
+appVersion: 1.3.5
 description: Scales worker nodes within autoscaling groups
 name: cluster-autoscaler
-version: 0.1.1
+version: 0.1.2
 sources:
 - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 - https://github.com/spotinst/kubernetes-autoscaler/tree/master/cluster-autoscaler

--- a/charts/cluster-autoscaler/values.yaml
+++ b/charts/cluster-autoscaler/values.yaml
@@ -4,7 +4,7 @@ replicaCount: 1
 
 image:
   repository: k8s.gcr.io/cluster-autoscaler
-  tag: v1.2.2
+  tag: v1.3.5
   pullPolicy: IfNotPresent
 
 autoscalingGroups:


### PR DESCRIPTION
[Trello](https://trello.com/c/FTCJKlbh)

Cluster autoscaler is version specific.  From K8s 1.12 the cluster autoscaler version lock steps.  For now, I am upgrading the cluster autoscaler image to `gcr.io/google-containers/cluster-autoscaler:v1.3.5`

See: https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler#releases

**Note** Already deployed