### PR TITLE
images-prepuller: Pre-pull/caches images on kubernetes nodes

### DIFF
--- a/charts/images-prepuller/.helmignore
+++ b/charts/images-prepuller/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/charts/images-prepuller/CHANGELOG.md
+++ b/charts/images-prepuller/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+
+
+## [0.1.0] - 2018-10-19
+### Added
+- Initial version based on [this GitHub gist].
+
+[this GitHub gist]: https://gist.github.com/itaysk/7bc3e56d69c4d72a549286d98fd557dd

--- a/charts/images-prepuller/Chart.yaml
+++ b/charts/images-prepuller/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: Pre-pull/cache docker images on k8s nodes
+name: images-prepuller
+version: 0.1.0

--- a/charts/images-prepuller/README.md
+++ b/charts/images-prepuller/README.md
@@ -118,3 +118,13 @@ Status: Downloaded newer image for busybox:1-musl
 In this case you can see that on this node (`ip-1-2-3-4.compute.internal`):
 - `gcr.io/google-containers/busybox:1.27` was already up-to-date
 - `busybox:1-musl` was new and it was downloaded
+
+
+## How to determine the images to prepull/cache?
+
+You can have a good idea of from where to start by listing all docker images
+used by all deployments in any namespace:
+
+```bash
+$ kubectl get deployment --all-namespaces -o custom-columns=images:.spec.template.spec.containers[*].image
+```

--- a/charts/images-prepuller/README.md
+++ b/charts/images-prepuller/README.md
@@ -46,9 +46,10 @@ lost when this container terminate.
 To install the chart:
 
 ```bash
-$ helm install charts/images-prepuller -f chart-env-config/ENV/images-prepuller.yml --name images-prepuller --namespace default
+$ helm upgrade --dry-run --debug --install images-prepuller --namespace default charts/images-prepuller -f chart-env-config/ENV/images-prepuller.yml
 ```
 
+**NOTE**: Remove `--dry-run` from command above.
 
 ## Configuration
 

--- a/charts/images-prepuller/README.md
+++ b/charts/images-prepuller/README.md
@@ -1,0 +1,60 @@
+# images-prepuller Helm Chart
+
+Helm chart to pre-pull/cache Docker images on the kubernetes notes.
+
+
+## Why?
+
+Some Docker images are quite big and it can take some time for
+them to be downloaded.
+
+If that image was not already downloaded on that node, the first user
+which spawns a tool pod using that docker image will have to wait more than
+the usual.
+
+This can be confusing for the users, as most of the time these
+tools starts relatively quickly. When this takes longer, the user
+perceive this delay as a symptom of "something that didn't work".
+
+This is made worse by the fact that we now have configured our
+kubernetes cluster to scale up and down. This means that new
+nodes will be created more often. These fresh nodes
+will not have the most used Docker images yet.
+
+
+## How does it work?
+
+This helm chart create a DaemonSet (ds) called `prepull`.
+It will start a pod with an [init container] on each of the nodes.
+This init container will go through the list of docker images to
+cache and will run a `docker pull $IMAGE`.
+
+This is based on this [gist].
+
+**NOTE**: As these init containers are, well, containers we need
+to mount the node's directory where the Docker images are stored
+(`/var/run` by default) in order for the docker images' files to not be
+lost when this container terminate.
+
+
+[init container]: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+[gist]: https://gist.github.com/itaysk/7bc3e56d69c4d72a549286d98fd557dd
+
+
+## Installing the Chart
+
+To install the chart:
+
+```bash
+$ helm install charts/images-prepuller -f chart-env-config/ENV/images-prepuller.yml --name images-prepuller --namespace default
+```
+
+
+## Configuration
+
+Listing only the required params here. See `/chart-env-config/` for more details.
+
+| Parameter  | Description     | Default |
+| ---------- | --------------- | ------- |
+| `docker.images` (required) | **List** of docker images to pre-pull/cache on all nodes. The images need to be in the normal Docker image format, for example `gcr.io/google-containers/busybox:1.27` | `[]` |
+| `docker.hostPath` | This is the path on the node where Docker images are stored. | `"/var/run"` |

--- a/charts/images-prepuller/templates/NOTES.txt
+++ b/charts/images-prepuller/templates/NOTES.txt
@@ -1,0 +1,9 @@
+A DaemonSet will now run an pull the following Docker images:
+{{ range .Values.docker.images }}
+- {{ . -}}
+{{ end }}
+
+NOTE: You can configure which images to pre-pull by changing the `images`
+value. See chart's README.md
+
+Have a great day :)

--- a/charts/images-prepuller/templates/_helpers.tpl
+++ b/charts/images-prepuller/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "images-prepuller.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "images-prepuller.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/images-prepuller/templates/configmap.yaml
+++ b/charts/images-prepuller/templates/configmap.yaml
@@ -10,11 +10,16 @@ data:
   prepull.sh: |
     #! /usr/bin/env sh
 
-    echo "Pulling images..."
+    set -eu
 
-    for image in `cat images.txt`; do
-        echo "\n\nPulling '$image'..."
-        docker image pull $image;
+    CONFIG_FILE=/images-prepuller/images.txt
+    IMAGES=$(cat $CONFIG_FILE)
+
+    printf "Pulling images on node '%s'..." "$NODE_NAME"
+
+    for image in $IMAGES; do
+        printf "\n\nPulling '%s'..." "$image"
+        docker image pull "$image";
     done
 
   images.txt: |

--- a/charts/images-prepuller/templates/configmap.yaml
+++ b/charts/images-prepuller/templates/configmap.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: {{ .Release.Name }}
+data:
+  prepull.sh: |
+    #! /usr/bin/env sh
+
+    echo "Pulling images..."
+
+    for image in `cat images.txt`; do
+        echo "\n\nPulling '$image'..."
+        docker pull $image;
+    done
+
+  images.txt: |
+    {{ range .Values.docker.images }}
+    {{- . }}
+    {{ end }}

--- a/charts/images-prepuller/templates/configmap.yaml
+++ b/charts/images-prepuller/templates/configmap.yaml
@@ -14,7 +14,7 @@ data:
 
     for image in `cat images.txt`; do
         echo "\n\nPulling '$image'..."
-        docker pull $image;
+        docker image pull $image;
     done
 
   images.txt: |

--- a/charts/images-prepuller/templates/deamonset.yaml
+++ b/charts/images-prepuller/templates/deamonset.yaml
@@ -30,6 +30,11 @@ spec:
       initContainers:
         - name: prepull
           image: "docker:2.7.0"
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
           command: ["/images-prepuller/prepull.sh"]
           volumeMounts:
           - name: docker
@@ -53,3 +58,4 @@ spec:
         - name: configmap
           configMap:
             name: {{ .Release.Name }}
+            defaultMode: 0500 # can read/exec

--- a/charts/images-prepuller/templates/deamonset.yaml
+++ b/charts/images-prepuller/templates/deamonset.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1  # apiVersion: apps/v1beta2
+kind: DaemonSet
+metadata:
+  name: prepull
+  annotations:
+    source: "https://gist.github.com/itaysk/7bc3e56d69c4d72a549286d98fd557dd"
+  labels:
+    app: {{ template "images-prepuller.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  selector:
+    matchLabels:
+      name: prepull
+  updateStrategy:
+    # NOTE: This is important as it re-create the ds's pods when
+    # its template changes. The default is to only update them when k8s
+    # operator manually delete these pods
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: prepull
+      annotations:
+        # Force DaemonSet's pods to be re-created when config changes
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+
+    spec:
+      initContainers:
+        - name: prepull
+          image: docker
+          command: ["docker", "pull", "hello-world"]
+          volumeMounts:
+          - name: docker
+            mountPath: /var/run
+          - name: configmap
+            mountPath: /images-prepuller/prepull.sh
+            subPath: prepull.sh
+          - name: configmap
+            mountPath: /images-prepuller/images.txt
+            subPath: images.txt
+
+      containers:
+        - name: pause
+          image: gcr.io/google_containers/pause
+
+      volumes:
+        - name: docker
+          hostPath:
+            path: {{ .Values.docker.hostPath }}
+        - name: configmap
+          configMap:
+            name: {{ .Release.Name }}

--- a/charts/images-prepuller/templates/deamonset.yaml
+++ b/charts/images-prepuller/templates/deamonset.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       initContainers:
         - name: prepull
-          image: "docker:2.7.0"
+          image: "docker:18.09.1"
           env:
             - name: NODE_NAME
               valueFrom:

--- a/charts/images-prepuller/templates/deamonset.yaml
+++ b/charts/images-prepuller/templates/deamonset.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       initContainers:
         - name: prepull
-          image: docker
+          image: "docker:2.7.0"
           command: ["docker", "pull", "hello-world"]
           volumeMounts:
           - name: docker

--- a/charts/images-prepuller/templates/deamonset.yaml
+++ b/charts/images-prepuller/templates/deamonset.yaml
@@ -33,7 +33,8 @@ spec:
           command: ["/images-prepuller/prepull.sh"]
           volumeMounts:
           - name: docker
-            mountPath: /var/run
+            mountPath: /var/run/docker.sock
+            subPath: docker.sock
           - name: configmap
             mountPath: /images-prepuller/prepull.sh
             subPath: prepull.sh

--- a/charts/images-prepuller/templates/deamonset.yaml
+++ b/charts/images-prepuller/templates/deamonset.yaml
@@ -30,7 +30,7 @@ spec:
       initContainers:
         - name: prepull
           image: "docker:2.7.0"
-          command: ["docker", "pull", "hello-world"]
+          command: ["/images-prepuller/prepull.sh"]
           volumeMounts:
           - name: docker
             mountPath: /var/run

--- a/charts/images-prepuller/values.yaml
+++ b/charts/images-prepuller/values.yaml
@@ -1,0 +1,18 @@
+# Default values for images-prepuller.
+
+docker:
+  hostPath: "/var/run"
+  images:
+    - gcr.io/google-containers/busybox:1.27
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi


### PR DESCRIPTION
Why?
=====================================================================

Some of our Docker images are quite big and it can take some time for
them to be downloaded.

If that image was not already downloaded on that node, the first user
which spawns a tool using that docker image will have to wait more than
the usual.

This can be confusing for the users as most of the time these
tools starts relatively quickly. When this takes longer the user
perceive this delay as a symptom of "something didn't work".

This is made worse by the fact that we now have configured our
kubernetes cluster to scale up and down. This means that new
nodes could be created more often. These fresh nodes
will not have the most used Docker images yet.

How does it work?
=====================================================================

This helm chart create a DaemonSet (ds) called `prepull`.
It will start a pod with an init container on each of the nodes.
This init container will go through the list of docker images to
cache and will run a `docker pull $IMAGE`.

**NOTE**: As these init containers are, well, containers we need
to mount the node's path where the Docker images are stored
(`/var/run`) in order for the docker images' files to not be
lost when this container terminate.