### PR TITLE
rbac: Added "generic-support" group with read-only access to main resources

### DIFF
--- a/charts/rbac/CHANGELOG.md
+++ b/charts/rbac/CHANGELOG.md
@@ -4,12 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2018-01-24
+### Added
+- Created `ClusterRoleBinding` for __generic-support__ users. [Trello](https://trello.com/c/LsQcIL12)
+
 ## [0.1.2] - 2018-12-18
-### Initial Commit
+### Added
 - Created `ClusterRoleBinding` for __kubelet-api__ user. [Trello](https://trello.com/c/YNDTzEIx)
 
 ## [0.1.1] - 2018-08-06
-### Initial Commit
+### Added
 - Created `Rolebinding` for airflow support that binds to __app-support__ `Clusterrole`. [Trello](https://trello.com/c/Tq1xQCf3)
 
 ## [0.1.0] - 2018-07-23

--- a/charts/rbac/Chart.yaml
+++ b/charts/rbac/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: User and Group RBAC resources
 name: rbac
-version: 0.1.2
+version: 0.2.0

--- a/charts/rbac/README.md
+++ b/charts/rbac/README.md
@@ -23,7 +23,7 @@ helm upgrade rbac-chart charts/rbac --install
 | `description` | Short description of RBAC resources use | "" |
 
 
-## Contributing 
+## Contributing
 
 - Add your `rbac` resources under the `./templates` directory keeping related resources in the same file where possible
 - Optionally add a hash/map using the configuration parameters above to `values.yaml`. See [Example](#example)
@@ -36,12 +36,13 @@ Configured Resources
 | App-Support     | `Group`         | moj-analytical-services | Shiny application support |
 | Cluster-Admins  | `Group`         | moj-analytical-services | Kubernetes Cluster Admins |
 | Airflow_support | `Group`         | moj-analytical-services | Airflow job support       |
-| kubelet-api     | `User`          | ""                      | Binding for builtin account|   
+| generic-support | `Group`         | moj-analytical-services | Read-only access to non-sensitive resources in all namespaces |
+| kubelet-api     | `User`          | ""                      | Binding for builtin account|
 
 
 #### Example
 
-Add the `superdevs` github team values to be used by you template 
+Add the `superdevs` github team values to be used by you template
 
 ```
 teams:

--- a/charts/rbac/templates/generic-support.yaml
+++ b/charts/rbac/templates/generic-support.yaml
@@ -1,0 +1,42 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.teams.genericSupport.name }}
+  labels:
+    chart: {{ template "rbac.chart" . }}
+  annotations:
+    moj-analytical-services/teams: {{ .Values.teams.genericSupport.name }}
+    description: {{ .Values.teams.genericSupport.description | quote }}
+rules:
+    # Read only access to main resources
+    # NOTE: They can **NOT** read secrets/configmaps or exec into pods
+  - apiGroups: ["", "apps", "batch", "extensions"]
+    resources:
+      - "ingresses"
+      - "services"
+      - "deployments"
+      - "pods"
+      # - "pods/log"
+      - "cronjobs"
+      - "jobs"
+    verbs: ["get", "list", "watch"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.teams.genericSupport.name }}
+  labels:
+    chart: {{ template "rbac.chart" . }}
+  annotations:
+    moj-analytical-services/teams: {{ .Values.teams.genericSupport.name }}
+    description: {{ .Values.teams.genericSupport.description | quote }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Values.teams.genericSupport.name }}
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: {{ .Values.teams.genericSupport.name }}

--- a/charts/rbac/values.yaml
+++ b/charts/rbac/values.yaml
@@ -10,6 +10,9 @@ teams:
     name: airflow-support
     namespace: airflow
     description: "Airflow job support. Namespace: airflow"
+  genericSupport:
+    name: generic-support
+    description: "Read-only access to non-sensitive resources in all namespaces"
   kubeletAPI:
     name: kubelet-api
     description: "Assigns the builtin kubelet-api-admin Clusterrole to the kubelet-api user"


### PR DESCRIPTION
These users will be able to read/list the main kubernetes resources:
  - ingresses
  - services
  - deployments
  - pods
  - cronjobs
  - jobs

These users will have these permissions across the whole cluster, so
in all namespaces.

**NOTE**: Users will not be able to edit these resources (or at least
not at this stage) and they will not be able to read secrets or
configmaps.

Ticket: https://trello.com/c/LsQcIL12