### PR TITLE
rbac: Improved install command in README and fixed value key typo

### DIFF
--- a/charts/rbac/README.md
+++ b/charts/rbac/README.md
@@ -11,8 +11,11 @@ kubectl create ns apps-prod
 ```
 Now install the chart:
 ```
-helm upgrade rbac-chart charts/rbac --install
+helm upgrade --dry-run --debug --install --namespace default rbac-chart charts/rbac
 ```
+
+**NOTE**: Double-check output and remove `--dry-run` flag to install the chart for real.
+
 
 ## Configuration
 

--- a/charts/rbac/templates/app-support.yaml
+++ b/charts/rbac/templates/app-support.yaml
@@ -29,7 +29,7 @@ rules:
 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
-metadata: 
+metadata:
   name: {{ .Values.teams.appSupport.name }}
   namespace: {{ .Values.teams.appSupport.namespace }}
   labels:

--- a/charts/rbac/values.yaml
+++ b/charts/rbac/values.yaml
@@ -5,7 +5,7 @@ teams:
   appSupport:
     name: app-support
     namespace: apps-prod
-    desciprtion: "Analytical Platform Shiny Application Support. Namespace: apps-prod"
+    description: "Analytical Platform Shiny Application Support. Namespace: apps-prod"
   airflowSupport:
     name: airflow-support
     namespace: airflow


### PR DESCRIPTION
- added `--namespace` param to install/upgrade command so that
  if the user is on a different namespace they'll not accidentally
  install the helm chart in the wrong namespace
- added `--dry-run` flag, so that users will need to check helm
  output before actually installing the helm chart
- fixed typo in `appSupport` value: `desciprtion` => `description`