### PR TITLE
airflow-k8s 0.1.0: Bumped Airflow to 1.10.2

### DIFF
--- a/charts/airflow-k8s/CHANGELOG.md
+++ b/charts/airflow-k8s/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [0.1.0] - 2019-01-30
 ### Changed
-- Bumped Airflow version/docker tag to [`1.10.2`]
+- Bumped Airflow version/docker tag to [`1.10.2-2`]
 - Bumped `bitnami/redis` docker image from `4.0.10-debian-9` to
   `4.0.12-debian-9-r46`
 - Change redis image pull policy from `Always` to `IfNotPresent`

--- a/charts/airflow-k8s/CHANGELOG.md
+++ b/charts/airflow-k8s/CHANGELOG.md
@@ -5,6 +5,20 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [0.1.0] - 2019-01-30
+### Changed
+- Bumped Airflow version/docker tag to [`1.10.2`]
+- Bumped `bitnami/redis` docker image from `4.0.10-debian-9` to
+  `4.0.12-debian-9-r46`
+- Change redis image pull policy from `Always` to `IfNotPresent`
+  (as we're not using `latest` therefore image with a given tag
+  shouldn't change!)
+- Added `appVersion` to chart metadata to improve visibility of
+  which Airflow version the chart is using.
+
+[`1.10.2`]: https://github.com/ministryofjustice/analytics-platform-airflow-docker-image/pull/3
+
+
 ## [0.0.9] - 2019-02-05
 ### Fixed
 Chart installation when chart was previously installed and purged.

--- a/charts/airflow-k8s/CHANGELOG.md
+++ b/charts/airflow-k8s/CHANGELOG.md
@@ -6,17 +6,38 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [0.1.0] - 2019-01-30
-### Changed
-- Bumped Airflow version/docker tag to [`1.10.2-2`]
-- Bumped `bitnami/redis` docker image from `4.0.10-debian-9` to
-  `4.0.12-debian-9-r46`
-- Change redis image pull policy from `Always` to `IfNotPresent`
-  (as we're not using `latest` therefore image with a given tag
-  shouldn't change!)
+### Features
+- Bumped Airflow version to [`1.10.2`] (docker image tag
+  is [`1.10.2-2`])
 - Added `appVersion` to chart metadata to improve visibility of
   which Airflow version the chart is using.
 
+### Improvements
+- Use user-provided `.Values.airflow.image.pullPolicy`
+  value in all places where `airflow` docker image
+  is used
+- Bumped `bash` image tag to latest stable and be explicit
+  about tag instead of using `latest`
+- Bumped `gcr.io/google_containers/hyperkube` tag from
+  `v1.11.2` => `v1.11.7`
+- Bumped `bitnami/redis` docker image from `4.0.10-debian-9` to
+  `4.0.12-debian-9-r46`
+- Set `redis` image pull policy from `Always` to `IfNotPresent`
+  (as we're not using `latest` therefore image with a given tag
+  shouldn't change!)
+- Set `git-sync`'s `pullPolicy` to `IfNotPresent` as
+  we're not using `latest` as image tag
+
+### Fixed
+- `git-sync` pod was using wrong value as pullPolicy
+
+### Cosmetic
+- Consistency in the way we have `image`, `tag` and
+  `pullPolicy` in the same order and next to each other
+
+
 [`1.10.2`]: https://github.com/ministryofjustice/analytics-platform-airflow-docker-image/pull/3
+[`1.10.2-2`]: https://github.com/ministryofjustice/analytics-platform-airflow-docker-image/pull/4
 
 
 ## [0.0.9] - 2019-02-05

--- a/charts/airflow-k8s/CHANGELOG.md
+++ b/charts/airflow-k8s/CHANGELOG.md
@@ -20,11 +20,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   about tag instead of using `latest`
 - Bumped `gcr.io/google_containers/hyperkube` tag from
   `v1.11.2` => `v1.11.7`
-- Bumped `bitnami/redis` docker image from `4.0.10-debian-9` to
-  `4.0.12-debian-9-r46`
-- Set `redis` image pull policy from `Always` to `IfNotPresent`
-  (as we're not using `latest` therefore image with a given tag
-  shouldn't change!)
 - Set `git-sync`'s `pullPolicy` to `IfNotPresent` as
   we're not using `latest` as image tag
 

--- a/charts/airflow-k8s/Chart.yaml
+++ b/charts/airflow-k8s/Chart.yaml
@@ -2,4 +2,5 @@ apiVersion: v1
 description: Airflow on kubernetes. Tasks are run as pods
 name: airflow-k8s
 icon: https://airflow.incubator.apache.org/_images/pin_large.png
-version: 0.0.9
+version: 0.1.0
+appVersion: 1.10.2

--- a/charts/airflow-k8s/README.md
+++ b/charts/airflow-k8s/README.md
@@ -22,6 +22,9 @@ Airflow will be available at <https://airflow.tools.ENV.mojanalytics.xyz>.
 
 ## Configuration
 
+**IMPORTANT**: Please change credentials from the default/weak ones to proper/strong credentials.
+
+
 | Parameter           | Description     | Default.    |
 | ------------------- | --------------- | ----------- |
 | `airflow.admin.username` | Airflow admin username | `""` |

--- a/charts/airflow-k8s/templates/create-nfs-dirs.yml
+++ b/charts/airflow-k8s/templates/create-nfs-dirs.yml
@@ -14,8 +14,9 @@ spec:
       containers:
       - name: "create-nfs-dirs"
         restart: Never
-        image: bash
-        imagePullPolicy: IfNotPresent
+        image: "bash"
+        tag: "5.0.2"
+        imagePullPolicy: "IfNotPresent"
         volumeMounts:
           - name: {{ .Release.Name }}-storage
             mountPath: "/tmp/airflow/"

--- a/charts/airflow-k8s/templates/git-sync-deployment.yml
+++ b/charts/airflow-k8s/templates/git-sync-deployment.yml
@@ -33,7 +33,7 @@ spec:
       containers:
         - name: git-sync
           image: {{ .Values.gitSync.image.repository }}:{{ .Values.gitSync.image.tag }}
-          imagePullPolicy: {{ .Values.airflow.image.pullPolicy }}
+          imagePullPolicy: {{ .Values.gitSync.image.pullPolicy }}
           env:
             - name: GIT_SYNC_REPO
               value: "{{ .Values.gitSync.repository }}"

--- a/charts/airflow-k8s/templates/hooks/init-airflow-ns-hook.yml
+++ b/charts/airflow-k8s/templates/hooks/init-airflow-ns-hook.yml
@@ -21,7 +21,9 @@ spec:
     spec:
       containers:
       - name: annotator
-        image: gcr.io/google_containers/hyperkube:v1.11.2
+        image: gcr.io/google_containers/hyperkube:v1.11.7
+        imagePullPolicy: "IfNotPresent"
+        restartPolicy: Never
         command:
         - kubectl
         - annotate
@@ -30,5 +32,4 @@ spec:
         - {{ .Release.Namespace }}
         - |
             iam.amazonaws.com/allowed-roles=[{{ .Values.kube2iam.allowedRoles | quote }}]
-      restartPolicy: Never
       serviceAccountName: {{ .Values.kube2iam.serviceAccountName }}

--- a/charts/airflow-k8s/templates/scheduler-deployment.yml
+++ b/charts/airflow-k8s/templates/scheduler-deployment.yml
@@ -26,7 +26,7 @@ spec:
       initContainers:
       - name: "init"
         image: {{ .Values.airflow.image.repository }}:{{ .Values.airflow.image.tag }}
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{ .Values.airflow.image.pullPolicy }}
         volumeMounts:
           - name: {{ .Release.Name }}-config
             mountPath: /root/airflow/airflow.cfg
@@ -71,11 +71,11 @@ spec:
       containers:
         - name: scheduler
           image: {{ .Values.airflow.image.repository }}:{{ .Values.airflow.image.tag }}
+          imagePullPolicy: {{ .Values.airflow.image.pullPolicy }}
           command:
             - "airflow"
           args:
             - "scheduler"
-          imagePullPolicy: {{ .Values.airflow.image.pullPolicy }}
           ports:
             - name: http
               containerPort: {{ .Values.airflow.image.port }}

--- a/charts/airflow-k8s/templates/scheduler-deployment.yml
+++ b/charts/airflow-k8s/templates/scheduler-deployment.yml
@@ -56,7 +56,7 @@ spec:
         args:
           - "-cx"
           - >
-              cd /usr/local/lib/python3.6/site-packages/airflow &&
+              cd `python -c "import site; print(site.getsitepackages()[0])"` &&
               airflow initdb && airflow upgradedb &&
               (
               airflow create_user

--- a/charts/airflow-k8s/templates/webserver-deployment.yml
+++ b/charts/airflow-k8s/templates/webserver-deployment.yml
@@ -25,11 +25,11 @@ spec:
       containers:
         - name: webserver
           image: {{ .Values.airflow.image.repository }}:{{ .Values.airflow.image.tag }}
+          imagePullPolicy: {{ .Values.airflow.image.pullPolicy }}
           command:
             - "airflow"
           args:
             - "webserver"
-          imagePullPolicy: {{ .Values.airflow.image.pullPolicy }}
           ports:
             - name: http
               containerPort: {{ .Values.airflow.image.port }}

--- a/charts/airflow-k8s/values.yaml
+++ b/charts/airflow-k8s/values.yaml
@@ -45,6 +45,7 @@ gitSync:
   image:
     repository: "openweb/git-sync"
     tag: "0.0.1"
+    pullPolicy: "IfNotPresent"
 postgres:
   host: ""
   port: "5432"

--- a/charts/airflow-k8s/values.yaml
+++ b/charts/airflow-k8s/values.yaml
@@ -56,10 +56,6 @@ redis:
   password: "airflow"
   cluster:
     enabled: false
-  image:
-    pullPolicy: "IfNotPresent"
-    repository: "bitnami/redis"
-    tag: "4.0.12-debian-9-r46"
   persistence:
     enabled: false
 kube2iam:

--- a/charts/airflow-k8s/values.yaml
+++ b/charts/airflow-k8s/values.yaml
@@ -13,7 +13,7 @@ airflow:
       accessTokenUrl: ""
   image:
     repository: "quay.io/mojanalytics/airflow"
-    tag: "1.10.2"
+    tag: "1.10.2-2"
     pullPolicy: "IfNotPresent"
     port: "8080"
   volumes:

--- a/charts/airflow-k8s/values.yaml
+++ b/charts/airflow-k8s/values.yaml
@@ -55,6 +55,10 @@ redis:
   password: "airflow"
   cluster:
     enabled: false
+  image:
+    pullPolicy: "IfNotPresent"
+    repository: "bitnami/redis"
+    tag: "4.0.12-debian-9-r46"
   persistence:
     enabled: false
 kube2iam:

--- a/charts/airflow-k8s/values.yaml
+++ b/charts/airflow-k8s/values.yaml
@@ -13,7 +13,7 @@ airflow:
       accessTokenUrl: ""
   image:
     repository: "quay.io/mojanalytics/airflow"
-    tag: "0.0.9"
+    tag: "1.10.2"
     pullPolicy: "IfNotPresent"
     port: "8080"
   volumes:


### PR DESCRIPTION
- [Bumped Airflow version/docker tag to `1.10.2`](https://github.com/ministryofjustice/analytics-platform-airflow-docker-image/pull/3)
- Bumped `bitnami/redis` docker image from `4.0.10-debian-9` to
  `4.0.12-debian-9-r46`
- Change redis image pull policy from `Always` to `IfNotPresent` (as we're not using `latest` 
   therefore image with a given tag shouldn't change!)
- Added `appVersion` to chart metadata to improve visibility of which Airflow version the chart is using.
- [x] fixed `git-sync` wrong pullPolicy value used
- [x] use `Values.airflow.image.pullPolicy` for `airflow-scheduler.init` container

Ticket: https://trello.com/c/7yqU330n/144-upgrade-airflow-version-and-its-redis-image-version

#### TODO
- [x] Wait for [docker image PR #4](https://github.com/ministryofjustice/analytics-platform-airflow-docker-image/pull/4 ) to be merged/tagged (`1.10.2-2`) and for docker image to be built
- [x] Wait for [docker image PR #3](https://github.com/ministryofjustice/analytics-platform-airflow-docker-image/pull/3) to be merged/tagged (`1.10.2`) and for docker image to be built
- [ ] ~Upgrade `redis` dependency~ [I'll work on this independently](https://trello.com/c/m6m3onzw/160-airflow-helm-chart-upgrade-redis-dependency)
