### PR TITLE
Fix unidler clusterrole

### DIFF
--- a/charts/unidler/CHANGELOG.md
+++ b/charts/unidler/CHANGELOG.md
@@ -5,7 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [v3.1.1] - 2019-0131-
+## [v3.1.2] - 2019-01-31
+### Changed
+Fix api group name for core api group - should be ""
+
+## [v3.1.1] - 2019-01-31
 ### Changed
 Grant unidler permission to list and patch services
 

--- a/charts/unidler/Chart.yaml
+++ b/charts/unidler/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: unidler proxy
 name: unidler
-version: "v3.1.1"
+version: "v3.1.2"
 appVersion: "v0.1.0"

--- a/charts/unidler/templates/clusterrole.yaml
+++ b/charts/unidler/templates/clusterrole.yaml
@@ -6,7 +6,7 @@ metadata:
     app: {{ .Release.Name }}
 rules:
   - apiGroups:
-      - "core"
+      - ""
     resources:
       - "services"
     verbs:


### PR DESCRIPTION
Core API group name is `""` not `"core"` ☹️ 