### PR TITLE
Give control panel API access to list and read ingresses

### DIFF
--- a/charts/cpanel/CHANGELOG.md
+++ b/charts/cpanel/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+## [1.1.2] - 2019-02-01
+### Changed
+- Added permission to get and list ingresses
+
 ## [1.1.1] - 2018-10-16
 ### Added
 - BUGFIX: Environment variables for JupyterLab deployments added to secrets file 

--- a/charts/cpanel/Chart.yaml
+++ b/charts/cpanel/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Analytics Platform Control Panel API webapp
 name: cpanel
-version: 1.1.1
+version: 1.1.2

--- a/charts/cpanel/templates/cluster-role.yaml
+++ b/charts/cpanel/templates/cluster-role.yaml
@@ -15,3 +15,10 @@ rules:
       - "pods/portforward"
     verbs:
       - "create"
+  - apiGroups:
+      - "extensions"
+    resources:
+      - "ingresses"
+    verbs:
+      - "get"
+      - "list"


### PR DESCRIPTION
This is needed to get the hostname for an app to provide a link on the app details page.

This can be removed when webapps all have a `host` label.