### PR TITLE
Prometheus Chart Migration

### DIFF
--- a/charts/prometheus-resources/CHANGELOG.md
+++ b/charts/prometheus-resources/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+
+## [0.1.0] - 2019-02-05
+### Upstream Chart Migration/Initial Commit
+- Initial commit
+- Migrated our deployment from [CoreOS's deprecated chart](https://github.com/coreos/prometheus-operator/tree/master/helm) to [Helm stable repo chart](https://github.com/helm/charts/tree/master/stable/prometheus-operator)
+- Secured [Prometheus](https://prometheus.services.dev.mojanalytics.xyz) and [AlertManager](https://alertmanager.services.dev.mojanalytics.xyz) front-ends with [auth-proxy](https://github.com/ministryofjustice/analytics-platform-auth-proxy)
+- Migrated Dashboard templates to Grafana 5.4.x spec  
+- Migrated Rules, Alerts and Dashboards from previous deployment
+- Added `PodSecurityPolicy` in preparation for [Trello](https://trello.com/c/0mfKXhjp)

--- a/charts/prometheus-resources/Chart.yaml
+++ b/charts/prometheus-resources/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+appVersion: "1.0"
+description: Deploys resources related to the [Prometheus-Operator](https://github.com/helm/charts/tree/master/stable/prometheus-operator) helm chart
+name: prometheus-resources
+version: 0.1.0
+engine: gotpl

--- a/charts/prometheus-resources/README.md
+++ b/charts/prometheus-resources/README.md
@@ -1,0 +1,91 @@
+# Prometheus-Resources
+
+Deploys resources related to the [Prometheus-Operator](https://github.com/helm/charts/tree/master/stable/prometheus-operator) helm chart
+
+This chart:
+- Adds our custom prometheus rules 
+- Secures the [Prometheus](https://prometheus.services.dev.mojanalytics.xyz) and [AlertManager](https://alertmanager.services.dev.mojanalytics.xyz) front-ends with [auth-proxy](https://github.com/ministryofjustice/analytics-platform-auth-proxy) 
+
+## Dependencies/Prerequisites 
+
+- This Chart requires that the [Prometheus-Operator](https://github.com/helm/charts/tree/master/stable/prometheus-operator) helm chart be deployed first
+- Helm version 2.10+
+- Kubernetes 1.10+ with Beta APIs
+
+## Installing and Deleting
+
+**Note**:
+
+There are some issues with race conditions pertaining to Custom Resource Definition hooks used by the [Prometheus-Operator](https://github.com/helm/charts/tree/master/stable/prometheus-operator) helm chart. 
+This prevents the [Prometheus-Operator](https://github.com/helm/charts/tree/master/stable/prometheus-operator) helm chart from being installed directly (__with the helm cmd__) 
+and indirectly (__with__ `requirements.yaml`).
+
+There is a [fix](https://github.com/helm/helm/pull/5112). However, this is not expected until __Helm version 2.13.x__.
+
+The steps to install a complete deployment are listed below.  
+
+
+**Before Proceeding**
+Ensure that the following value is set to `false`. (Relating to [bug](https://github.com/helm/helm/issues/4925) mentioned above)
+
+```yaml
+prometheusOperator:
+  createCustomResource: false
+```
+
+### Install Commands
+
+Install [Custom Resource Definitions](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/):
+```bash
+kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/master/example/prometheus-operator-crd/alertmanager.crd.yaml
+kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/master/example/prometheus-operator-crd/prometheus.crd.yaml
+kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/master/example/prometheus-operator-crd/prometheusrule.crd.yaml
+kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/master/example/prometheus-operator-crd/servicemonitor.crd.yaml
+```
+
+Install [Prometheus-Operator](https://github.com/helm/charts/tree/master/stable/prometheus-operator) helm chart:
+```bash
+helm install --name prometheus-operator stable/prometheus-operator -f chart-env-config/<ENV>/stable-prometheus.yaml --namespace=monitoring --no-crd-hook
+```
+**Note** the `--no-crd-hook`
+
+
+Install this chart:
+```bash
+helm upgrade prometheus-resources mojanalytics/prometheus-resources -f chart-env-config/<ENV>/stable-prometheus.yaml --namespace=monitoring --install
+```
+
+### Delete Commands
+
+Delete this chart:
+```bash
+helm del prometheus-resources --purge
+```
+
+Delete [Prometheus-Operator](https://github.com/helm/charts/tree/master/stable/prometheus-operator) helm chart:
+```bash
+helm del prometheus-operator --purge
+```
+
+Delete [Custom Resource Definitions](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/):
+```bash
+kubectl delete crd servicemonitors.monitoring.coreos.com prometheusrules.monitoring.coreos.com prometheuses.monitoring.coreos.com alertmanagers.monitoring.coreos.com
+```
+
+### Updating Resources
+
+Grafana Dashboards: 
+- Add/Modify `json` templates in [config repo](https://github.com/ministryofjustice/analytics-platform-config)`/chart-env-config/<ENV>/stable_prometheus.yaml`
+- `helm upgrade prometheus-resources mojanalytics/prometheus-resources -f chart-env-config/<ENV>/stable-prometheus.yaml --namespace=monitoring` 
+
+Prometheus/Alerting Config:
+- Add/Modify [values.yaml](./values.yaml) in this chart 
+- `helm upgrade prometheus-resources mojanalytics/prometheus-resources -f chart-env-config/<ENV>/stable-prometheus.yaml --namespace=monitoring`
+
+
+### Configuration
+
+| Parameter  | Description      | Default |
+| ---------- | ---------------  | ------- |
+| `prometheusRules` | An array of Prometheus expressions on which alerts can be configured from. See: [Docs](https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/) |  ""  |
+| `mojDashboardFiles` | A hash of inline `json` documents located in [config repo](https://github.com/ministryofjustice/analytics-platform-config)`/chart-env-config/<ENV>/stable_prometheus.yaml` to add or configure Grafana dashboards | "" |

--- a/charts/prometheus-resources/templates/_helpers.tpl
+++ b/charts/prometheus-resources/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "prometheus-operator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "prometheus-operator.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "prometheus-operator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/prometheus-resources/templates/analytics-rules.yaml
+++ b/charts/prometheus-resources/templates/analytics-rules.yaml
@@ -1,0 +1,14 @@
+# https://github.com/coreos/prometheus-operator/blob/master/Documentation/design.md#prometheusrule
+{{- if .Values.prometheusRules }}
+apiVersion: {{ printf "%s/v1" (.Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com") }}
+kind: PrometheusRule
+metadata:
+  name: {{ .Release.Name }}-ap-rules
+  namespace: {{ .Release.Namespace | default "monitoring" }}
+  labels:
+    app: {{ .Values.prometheusOperator.chartName }}
+    chart: {{ .Chart.Name }}
+spec:
+  groups:
+{{ toYaml .Values.prometheusRules | indent 4 }}
+{{ end }}

--- a/charts/prometheus-resources/templates/clusterrole-psp.yaml
+++ b/charts/prometheus-resources/templates/clusterrole-psp.yaml
@@ -1,0 +1,13 @@
+{{ $name := printf "%s-%s" .Release.Name .Values.authProxy.name }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ $name }}
+  labels:
+    app: {{ .Values.authProxy.name }}
+    chart: {{ .Chart.Name }}
+rules:
+  - apiGroups: ["policy"]
+    resources: ["podsecuritypolicies"]
+    resourceNames: ["{{ $name }}"]
+    verbs: ["use"]

--- a/charts/prometheus-resources/templates/configmap.yaml
+++ b/charts/prometheus-resources/templates/configmap.yaml
@@ -1,0 +1,13 @@
+{{ if .Values.mojDashboardFiles }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-ap-dashboards
+  namespace: {{ .Release.Namespace | default "monitoring" }}
+  labels:
+    grafana_dashboard: "1"
+    app: {{ .Values.prometheusOperator.chartName }}
+    chart: {{ .Chart.Name }}
+data:
+{{ toYaml .Values.mojDashboardFiles | indent 2 }}
+{{ end }}

--- a/charts/prometheus-resources/templates/deployment.yaml
+++ b/charts/prometheus-resources/templates/deployment.yaml
@@ -1,0 +1,79 @@
+{{ range .Values.apps }}
+  {{- $callBack := printf "https://%s.%s/callback" .name $.Values.servicesDomain }}
+  {{- $name := printf "%s-%s-%s" $.Release.Name .name $.Values.authProxy.name | trunc 63 }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $name }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    app: {{ $.Values.authProxy.name }}
+    target: {{ .name }}
+    chart: {{ $.Chart.Name }}
+spec:
+  progressDeadlineSeconds: 600
+  selector:
+    matchLabels:
+      target: {{ .name }}
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        target: {{ .name }}
+    spec:
+      serviceAccountName: {{ $.Release.Name }}-{{ .name }}
+      containers:
+        - name: {{ $name }}
+          image: {{ $.Values.authProxy.image }}:{{ $.Values.authProxy.tag }}
+          imagePullPolicy: {{ $.Values.authProxy.imagePullPolicy }}
+          ports:
+            - name: proxy
+              containerPort: {{ $.Values.authProxy.containerPort }}
+          env:
+            - name: TARGET_URL
+              value: http://{{ $.Release.Name }}-{{ .name }}.{{ $.Release.Namespace }}.svc.cluster.local
+            - name: AUTH0_DOMAIN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Release.Name }}
+                  key: auth0Domain
+            - name: AUTH0_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Release.Name }}
+                  key: auth0ClientId
+            - name: AUTH0_CALLBACK_URL
+              value: {{ $callBack }}
+            - name: AUTH0_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Release.Name }}
+                  key: auth0ClientSecret
+            - name: COOKIE_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Release.Name }}
+                  key: cookieSecret
+            - name: COOKIE_MAXAGE
+              value: {{ $.Values.authProxy.cookie_maxage | quote }}
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: proxy
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: proxy
+            initialDelaySeconds: 20
+            periodSeconds: 10
+          resources:
+{{ toYaml $.Values.authProxy.resources | indent 12 }}
+---
+{{ end }}

--- a/charts/prometheus-resources/templates/ingress.yaml
+++ b/charts/prometheus-resources/templates/ingress.yaml
@@ -1,0 +1,26 @@
+{{ range .Values.apps }}
+  {{- $host := printf "%s.%s" .name $.Values.servicesDomain }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $.Release.Name }}-{{ .name }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    app: {{ .name }}-{{ $.Values.authProxy.name }}
+    target: {{ .name }}
+  annotations:
+    kubernetes.io/ingress.class: {{ $.Values.ingressClass }}
+spec:
+  rules:
+    - host: {{ $host }}
+      http:
+        paths:
+          - backend:
+              serviceName: {{ printf "%s-%s-%s" $.Release.Name .name $.Values.authProxy.name | trunc 63 }}
+              servicePort: 80
+  tls:
+    - hosts:
+        - {{ $host }}
+
+---
+{{ end }}

--- a/charts/prometheus-resources/templates/psp-auth-proxy.yaml
+++ b/charts/prometheus-resources/templates/psp-auth-proxy.yaml
@@ -1,0 +1,46 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ printf "%s-%s" .Release.Name .Values.authProxy.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Values.authProxy.name }}
+    chart: {{ .Chart.Name }}
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
+    apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
+spec:
+  privileged: false
+  defaultAllowPrivilegeEscalation: false
+  requiredDropCapabilities: # DROP CAPABILITIES Listed below.  See: https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities
+    - SETPCAP
+    - MKNOD
+    - AUDIT_WRITE
+    - CHOWN
+    - NET_RAW
+    - FOWNER
+    - FSETID
+    - KILL
+    - SETGID
+    - SETUID
+    - NET_BIND_SERVICE
+    - SYS_CHROOT
+    - SETFCAP
+  volumes:
+    - secret
+    - emptyDir
+    - projected
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'
+  readOnlyRootFilesystem: false

--- a/charts/prometheus-resources/templates/rolebinding-psp.yaml
+++ b/charts/prometheus-resources/templates/rolebinding-psp.yaml
@@ -1,0 +1,19 @@
+{{ $name := printf "%s-%s" .Release.Name .Values.authProxy.name }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Values.authProxy.name }}
+    chart: {{ .Chart.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ $name }}
+subjects:
+  {{- range .Values.apps }}
+  - kind: ServiceAccount
+    name: {{ $.Release.Name }}-{{ .name }}
+    namespace: {{ $.Release.Namespace }}
+  {{- end }}

--- a/charts/prometheus-resources/templates/secrets.yaml
+++ b/charts/prometheus-resources/templates/secrets.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $.Release.Name }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    app: {{ $.Values.authProxy.name }}
+    chart: {{ $.Chart.Name }}
+type: Opaque
+data:
+  auth0Domain: {{ printf "%s" $.Values.grafana.env.GF_AUTH_GENERIC_OAUTH_AUTH_URL | replace "https://" "" | replace "/authorize" ""  | b64enc | quote }}
+  auth0ClientId: {{ $.Values.grafana.env.GF_AUTH_GENERIC_OAUTH_CLIENT_ID | b64enc | quote }}
+  auth0ClientSecret: {{ $.Values.grafana.env.GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET | b64enc | quote }}
+  cookieSecret: {{ $.Values.authProxy.cookie_secret | b64enc | quote }}

--- a/charts/prometheus-resources/templates/service-account.yaml
+++ b/charts/prometheus-resources/templates/service-account.yaml
@@ -1,0 +1,12 @@
+{{ range .Values.apps }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $.Release.Name }}-{{ .name }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    app: {{ $.Values.authProxy.name }}
+    target: {{ .name }}
+    chart: {{ $.Chart.Name }}
+---
+{{ end }}

--- a/charts/prometheus-resources/templates/service-monitor.yaml
+++ b/charts/prometheus-resources/templates/service-monitor.yaml
@@ -1,0 +1,27 @@
+{{ if .Values.serviceMonitors }}
+  {{- range .Values.serviceMonitors }}
+apiVersion: {{ printf "%s/v1" ($.Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com") }}
+kind: ServiceMonitor
+metadata:
+  name: {{ .labelSelector }}
+  namespace: monitoring
+  labels:
+    app: {{ .labelSelector }}
+    release: prometheus-operator
+spec:
+  endpoints:
+    - interval: {{ .scrapeInterval | default "30s" }}
+      port: {{ .targetPort }}
+    {{- if .targetPath }}
+      path: {{ .targetPath }}
+    {{- end }}
+  selector:
+    matchLabels:
+      app: {{ .labelSelector }}
+  namespaceSelector:
+    matchNames:
+      - {{ .targetNamespace }}
+
+---
+  {{- end }}
+{{ end }}

--- a/charts/prometheus-resources/templates/service.yaml
+++ b/charts/prometheus-resources/templates/service.yaml
@@ -1,0 +1,36 @@
+{{ range .Values.apps }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $.Release.Name }}-{{ .name }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    app: {{ .name }}
+    chart: {{ $.Chart.Name }}
+spec:
+  ports:
+    - port: 80
+      targetPort: {{ .port }}
+  selector:
+    app: {{ .name }}
+---
+{{ end }}
+
+---
+{{ range .Values.apps }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ printf "%s-%s-%s" $.Release.Name .name $.Values.authProxy.name | trunc 63 }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    app: {{ .name }}-{{ $.Values.authProxy.name }}
+    chart: {{ $.Chart.Name }}
+spec:
+  ports:
+    - port: 80
+      targetPort: {{ $.Values.authProxy.containerPort }}
+  selector:
+    target: {{ .name }}
+---
+{{ end }}

--- a/charts/prometheus-resources/values.yaml
+++ b/charts/prometheus-resources/values.yaml
@@ -1,0 +1,173 @@
+servicesDomain: ""
+
+ingressClass: nginx
+
+authProxy:
+  name: auth-proxy
+  image: quay.io/mojanalytics/auth-proxy
+  tag: v0.1.6
+  imagePullPolicy: IfNotPresent
+  containerPort: 3000
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 25m
+      memory: 64Mi
+  cookie_maxage: 36000 #10 hours
+  cookie_secret: "tony-montana"
+
+apps:
+  - name: alertmanager
+    port: 9093
+  - name: prometheus
+    port: 9090
+
+serviceMonitors:
+  - labelSelector: nginx-ingress
+    targetNamespace: default
+    targetPort: metrics
+ # - labelSelector: kubernetes-dashboard
+ #   targetNamespace: kube-system
+ #   targetPath: /metrics
+ #   targetPort: 8443
+ #   scrapeInterval: 20s
+
+
+
+prometheusOperator:
+  crdApiGroup: monitoring.coreos.com
+  chartName: prometheus-operator
+
+prometheusRules:
+    - name: analytics.rules
+      rules:
+      - alert: InstanceHighMemoryUsage
+        annotations:
+          description: '{{ $value }}% of cluster memory is in use'
+          summary: High Memory Load
+         # Alert if disk utilisation reaches 90%
+        expr: (sum(node_memory_MemTotal_bytes) - sum(node_memory_MemFree_bytes + node_memory_Buffers_bytes + node_memory_Cached_bytes) ) / sum(node_memory_MemTotal_bytes) * 100 > 90
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: PreditciveHostDiskSpace
+        annotations:
+          description: 'Based on recent sampling, the disk is likely to will fill on volume
+             {{ $labels.mountpoint }} within the next 5 hours for instace: {{ $labels.instance_id
+             }} tagged as: {{ $labels.instance_name_tag }}'
+          summary: Predictive Disk Space Utilisation Alert
+        expr: predict_linear(node_filesystem_free_bytes{mountpoint="/"}[4h], 5 * 3600) < 0
+        for: 10h
+        labels:
+          severity: warning
+
+      - alert: HighNumberOfUserHTTPErrors
+        annotations:
+          description: 'Ingress: {{ $labels.ingress }} has returned {{ $value }} 503 errors in the last 10 minutes'
+          summary: User getting a high number of 503 errors
+        expr: increase(nginx_ingress_controller_requests{status=~"503", exported_namespace=~"user-.*"}[10m]) > 5
+        for: 1m
+        label:
+          severity: warning
+
+      - alert: PrometheusConfigReloadFailed
+        expr: prometheus_config_last_reload_successful == 0
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          description: Reloading Prometheus' configuration has failed for {{ $labels.namespace }}/{{ $labels.pod }}
+          summary: Reloading Promehteus' configuration failed
+
+      - alert: PrometheusNotificationQueueRunningFull
+        expr: predict_linear(prometheus_notifications_queue_length[5m], 60 * 30) > prometheus_notifications_queue_capacity
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          description: Prometheus' alert notification queue is running full for {{ $labels.namespace }}/{{
+            $labels.pod }}
+          summary: Prometheus' alert notification queue is running full
+
+      - alert: PrometheusErrorSendingAlerts
+        expr: rate(prometheus_notifications_errors_total[5m]) / rate(prometheus_notifications_sent_total[5m])
+          > 0.01
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          description: Errors while sending alerts from Prometheus {{ $labels.namespace }}/{{
+            $labels.pod }} to Alertmanager {{ $labels.Alertmanager }}
+          summary: Errors while sending alert from Prometheus
+
+      - alert: PrometheusErrorSendingAlerts
+        expr: rate(prometheus_notifications_errors_total[5m]) / rate(prometheus_notifications_sent_total[5m])
+          > 0.03
+        for: 10m
+        labels:
+          severity: critical
+        annotations:
+          description: Errors while sending alerts from Prometheus {{ $labels.namespace }}/{{
+            $labels.pod }} to Alertmanager {{ $labels.Alertmanager }}
+          summary: Errors while sending alerts from Prometheus
+
+      - alert: PrometheusNotConnectedToAlertmanagers
+        expr: prometheus_notifications_alertmanagers_discovered < 1
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          description: Prometheus {{ $labels.namespace }}/{{ $labels.pod }} is not connected
+            to any Alertmanagers
+          summary: Prometheus is not connected to any Alertmanagers
+
+      - alert: PrometheusTSDBReloadsFailing
+        expr: increase(prometheus_tsdb_reloads_failures_total[2h]) > 0
+        for: 12h
+        labels:
+          severity: warning
+        annotations:
+          description: '{{ $labels.job }} at {{ $labels.instance }} had {{ $value | humanize }}
+        reload failures over the last four hours.'
+          summary: Prometheus has issues reloading data blocks from disk
+
+      - alert: PrometheusTSDBCompactionsFailing
+        expr: increase(prometheus_tsdb_compactions_failed_total[2h]) > 0
+        for: 12h
+        labels:
+          severity: warning
+        annotations:
+          description: '{{ $labels.job }} at {{ $labels.instance }} had {{ $value | humanize }}
+        compaction failures over the last four hours.'
+          summary: Prometheus has issues compacting sample blocks
+
+      - alert: PrometheusTSDBWALCorruptions
+        expr: tsdb_wal_corruptions_total > 0
+        for: 4h
+        labels:
+          severity: warning
+        annotations:
+          description: '{{ $labels.job }} at {{ $labels.instance }} has a corrupted write-ahead
+        log (WAL).'
+          summary: Prometheus write-ahead log is corrupted
+
+      - alert: PrometheusNotIngestingSamples
+        expr: rate(prometheus_tsdb_head_samples_appended_total[5m]) <= 0
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          description: 'Prometheus {{ $labels.namespace }}/{{ $labels.pod }} is not ingesting samples.'
+          summary: "Prometheus isn't ingesting samples"
+
+      - alert: PrometheusTargetScrapesDuplicate
+        expr: increase(prometheus_target_scrapes_sample_duplicate_timestamp_total[5m]) > 0
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          description: '{{ $labels.namespace }}/{{ $labels.pod }} has many samples rejected due to duplicate timestamps but different values'
+          summary: Prometheus has many samples rejected


### PR DESCRIPTION
Relates to: [PR](https://github.com/ministryofjustice/analytics-platform-config/pull/114)

- Initial commit
- Migrated our deployment from [CoreOS's deprecated chart](https://github.com/coreos/prometheus-operator/tree/master/helm) to [Helm stable repo chart](https://github.com/helm/charts/tree/master/stable/prometheus-operator)
- Secured [Prometheus](https://prometheus.services.dev.mojanalytics.xyz) and [AlertManager](https://alertmanager.services.dev.mojanalytics.xyz) front-ends with [auth-proxy](https://github.com/ministryofjustice/analytics-platform-auth-proxy)
- Migrated Dashboard templates to Grafana 5.4.x spec
- Migrated Rules, Alerts and Dashboards from the previous deployment
- Added `PodSecurityPolicy` in preparation for [Trello](https://trello.com/c/0mfKXhjp)