### PR TITLE
airflow-k8s 0.0.9: Fixed failing init job when re-installing

### DIFF
--- a/charts/airflow-k8s/CHANGELOG.md
+++ b/charts/airflow-k8s/CHANGELOG.md
@@ -5,6 +5,21 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [0.0.9] - 2019-02-05
+### Fixed
+Chart installation when chart was previously installed and purged.
+This was caused by `init-airflow-ns` job that annotate the
+`airflow` namespace.
+
+Techical details: The problem was that the `Job` created on new
+install (`else` statement) was not idempotent because it was
+missing the `--overwrite` flag (which the `if` block had).
+
+I've simplified the init job template to factor all the
+common parts and have a smaller `if` just for the
+`helm.sh/hook` annotation.
+
+
 ## [0.0.8] - 2019-01-25
 ### Changed
 Removed admin credentials from scheduler's init container definition.

--- a/charts/airflow-k8s/Chart.yaml
+++ b/charts/airflow-k8s/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 description: Airflow on kubernetes. Tasks are run as pods
 name: airflow-k8s
 icon: https://airflow.incubator.apache.org/_images/pin_large.png
-version: 0.0.8
+version: 0.0.9

--- a/charts/airflow-k8s/templates/hooks/init-airflow-ns-hook.yml
+++ b/charts/airflow-k8s/templates/hooks/init-airflow-ns-hook.yml
@@ -1,17 +1,20 @@
-# This hook depends on helm creating the target namespace if it doesn't exist
-# before the hook is called. This is the case on Helm >v2.9.1
-{{ if eq .Chart.Version "0.0.3"}}
 ## apply this only on one upgrade - like a database migration
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: upgrade-airflow-ns
+  name: annotate-airflow-ns
   namespace: kube-system
   labels:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
+    # This hook depends on helm creating the target namespace if it doesn't exist
+    # before the hook is called. This is the case on Helm >v2.9.1
+    {{ if eq .Chart.Version "0.0.3" }}
     helm.sh/hook: pre-install,pre-upgrade
+    {{ else }}
+    helm.sh/hook: pre-install
+    {{ end }}
     helm.sh/hook-delete-policy: hook-succeeded
 spec:
   template:
@@ -29,32 +32,3 @@ spec:
             iam.amazonaws.com/allowed-roles=[{{ .Values.kube2iam.allowedRoles | quote }}]
       restartPolicy: Never
       serviceAccountName: {{ .Values.kube2iam.serviceAccountName }}
-{{ else }}
-# Apply this on a new install
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: init-airflow-ns
-  namespace: kube-system
-  labels:
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-  annotations:
-    helm.sh/hook: pre-install
-    helm.sh/hook-delete-policy: hook-succeeded
-spec:
-  template:
-    spec:
-      containers:
-      - name: annotator
-        image: gcr.io/google_containers/hyperkube:v1.11.2
-        command:
-        - kubectl
-        - annotate
-        - ns
-        - {{ .Release.Namespace }}
-        - |
-            iam.amazonaws.com/allowed-roles=[{{ .Values.kube2iam.allowedRoles | quote }}]
-      restartPolicy: Never
-      serviceAccountName: {{ .Values.kube2iam.serviceAccountName }}
-{{ end }}


### PR DESCRIPTION
Chart installation when chart was previously installed and purged.
This was caused by `init-airflow-ns` job that annotate the
`airflow` namespace.

Techical details: The problem was that the `Job` created on new
install (`else` statement) was not idempotent because it was
missing the `--overwrite` flag (which the `if` block had).

I've simplified the init job template to factor all the
common parts and have a smaller `if` just for the
`helm.sh/hook` annotation.