### PR TITLE
Update idler/unidler clusterrole permissions

### DIFF
--- a/charts/idler/CHANGELOG.md
+++ b/charts/idler/CHANGELOG.md
@@ -4,11 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [1.2.1] - 2018-02-05
+## [1.2.2] - 2019-02-14
+### Changed
+Corrected verb for read services
+Remove unused permissions for ingresses
+
+## [1.2.1] - 2019-02-05
 ### Changed
 Added permission to read and patch services
 
-## [1.2.0] - 2018-01-29
+## [1.2.0] - 2019-01-29
 ### Changed
 Idling was achieved by disabling the app ingress and adding the app hostname to the unidler ingress.
 If multiple users unidled at the same time, there could be a race condition when removing the hostnames from the unidler ingress.

--- a/charts/idler/Chart.yaml
+++ b/charts/idler/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: idler cronjob
 name: idler
-version: 1.2.1
+version: 1.2.2
 appVersion: v0.5.0

--- a/charts/idler/templates/clusterrole.yaml
+++ b/charts/idler/templates/clusterrole.yaml
@@ -15,11 +15,7 @@ rules:
 
   - apiGroups: [""]
     resources: ["services"]
-    verbs: ["patch", "read"]
-
-  - apiGroups: ["extensions"]
-    resources: ["ingresses"]
-    verbs: ["list", "patch"]
+    verbs: ["get", "patch"]
 
   - apiGroups: ["metrics.k8s.io"]
     resources: ["pods"]

--- a/charts/unidler/CHANGELOG.md
+++ b/charts/unidler/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [v3.1.3] - 2019-02-14
+### Changed
+Audit clusterrole rules, remove unused verbs
+
 ## [v3.1.2] - 2019-01-31
 ### Changed
 Fix api group name for core api group - should be ""

--- a/charts/unidler/Chart.yaml
+++ b/charts/unidler/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: unidler proxy
 name: unidler
-version: "v3.1.2"
+version: "v3.1.3"
 appVersion: "v0.1.0"

--- a/charts/unidler/templates/clusterrole.yaml
+++ b/charts/unidler/templates/clusterrole.yaml
@@ -5,32 +5,14 @@ metadata:
   labels:
     app: {{ .Release.Name }}
 rules:
-  - apiGroups:
-      - ""
-    resources:
-      - "services"
-    verbs:
-      - "get"
-      - "list"
-      - "patch"
-      - "update"
-      - "watch"
-  - apiGroups:
-      - "apps"
-    resources:
-      - "deployments"
-    verbs:
-      - "get"
-      - "list"
-      - "patch"
-      - "update"
-      - "watch"
-  - apiGroups:
-      - "extensions"
-    resources:
-      - "ingresses"
-    verbs:
-      - "get"
-      - "list"
-      - "patch"
-      - "update"
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["list", "patch"]
+
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["list", "patch", "watch"]
+
+  - apiGroups: ["extensions"]
+    resources: ["ingresses"]
+    verbs: ["list"]


### PR DESCRIPTION
Idler had `read` instead of `get`
Idler had permissions on ingresses that are no longer used
Unidler had several unused permissions