### PR TITLE
Rstudio v1.6.0: Switch to conda rstudio image

### DIFF
--- a/charts/rstudio/CHANGELOG.md
+++ b/charts/rstudio/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.6.0] - 2019-02-14
+
+### Changed
+- Version of RStudio image with conda (r3.5.1-py3.7-conda)
+- it doesn't point at the cran proxy
+- does initial setup in an init container
+- has a rstudio conda environment
+- maintains support for projects still using packrat
+
 ## [1.5.8] - 2018-10-17
 
 ### Changed

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -1,4 +1,5 @@
 apiVersion: v1
 description: RStudio with Auth0 authentication proxy
 name: rstudio
-version: 1.5.8
+version: 1.6.0
+appVersion: "RStudio: 1.1.463+conda, R: 3.5.1, Python: 3.7"

--- a/charts/rstudio/templates/deployment.yml
+++ b/charts/rstudio/templates/deployment.yml
@@ -21,6 +21,26 @@ spec:
         iam.amazonaws.com/role: {{ .Values.aws.iamRole }}
     spec:
       serviceAccountName: {{ .Values.username }}-rstudio
+      {{ if and .Values.rstudio.image.init }}
+      initContainers:
+        - name: r-studio-server-init
+          image: "{{ .Values.rstudio.image.repository }}:{{ .Values.rstudio.image.tag }}"
+          imagePullPolicy: {{ .Values.rstudio.image.pullPolicy }}
+          command:
+            - /usr/local/bin/start.sh
+            - init
+          env:
+            - name: USER
+              value: {{ .Values.username }}
+            - name: AWS_DEFAULT_REGION
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "fullname" . }}
+                  key: aws_default_region
+          volumeMounts:
+            - name: home
+              mountPath: "/home/{{ .Values.username }}"
+      {{ end }}
       containers:
 
         - name: rstudio-auth-proxy
@@ -97,6 +117,9 @@ spec:
         - name: r-studio-server
           image: "{{ .Values.rstudio.image.repository }}:{{ .Values.rstudio.image.tag }}"
           imagePullPolicy: {{ .Values.rstudio.image.pullPolicy }}
+          command:
+            - /usr/local/bin/start.sh
+            - start
           ports:
             - name: rstudio
               containerPort: {{ .Values.rstudio.port }}

--- a/charts/rstudio/values.yaml
+++ b/charts/rstudio/values.yaml
@@ -30,8 +30,13 @@ rstudio:
   port: "8787"
   image:
     repository: quay.io/mojanalytics/rstudio
-    tag: "3.4.2-6"
+    tag: "r3.5.1-py3.7-conda"
     pullPolicy: "IfNotPresent"
+    # init option allows you to run an init container that does the setup of the conda environment
+    # this is quite slow and if it was run as part of the main container then it would cause problems.
+    # This exists here because you might want to downgrade to an older image, which doesn't take the arg
+    # to the ./start.sh script
+    init: true
   resources:
     limits:
       cpu: 1.5


### PR DESCRIPTION
- Version of RStudio image with conda (r3.5.1-py3.7-conda)
- it doesn't point at the cran proxy
- does initial setup in an init container
- has a rstudio conda environment
- maintains support for projects still using packrat
- can point to an older image that doesn't support init by setting `rstudio.image.init` to false