### PR TITLE
airflow-k8s 0.1.1: Fix for some requests made over **non-secure** HTTP

### DIFF
--- a/charts/airflow-k8s/CHANGELOG.md
+++ b/charts/airflow-k8s/CHANGELOG.md
@@ -5,6 +5,24 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [0.1.1] - 2019-02-19
+### Security
+- Fixed problem where some of the authentication requests were done over
+  **non-secure** HTTP connection.
+- added `airflow.config.webserver.enable_proxy_fix` which
+  by default is `True` but can be changed if necessary
+- See:
+  - Airflow issue: [`AIRFLOW-3137`](https://issues.apache.org/jira/browse/AIRFLOW-3137)
+  - Airflow fix: [`PR #3983`](https://github.com/apache/airflow/pull/3983)
+
+**NOTE**: You should only enable the `ProxyFix` middleware when running
+Airflow behind a trusted proxy (AWS ELB, nginx, etc.).
+
+### Cosmetic
+- Added some newlines in `airflow` Configmap / `airflow.cfg` to
+  improve readability and reduce time necessary to find things in it.
+
+
 ## [0.1.0] - 2019-01-30
 ### Features
 - Bumped Airflow version to [`1.10.2`] (docker image tag

--- a/charts/airflow-k8s/Chart.yaml
+++ b/charts/airflow-k8s/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 description: Airflow on kubernetes. Tasks are run as pods
 name: airflow-k8s
 icon: https://airflow.incubator.apache.org/_images/pin_large.png
-version: 0.1.0
+version: 0.1.1
 appVersion: 1.10.2

--- a/charts/airflow-k8s/templates/configmap.yml
+++ b/charts/airflow-k8s/templates/configmap.yml
@@ -70,6 +70,7 @@ data:
     # however it can be set on a per DAG basis in the
     # DAG definition (catchup)
     catchup_by_default = True
+
     [webserver]
     # The base url of your website as airflow cannot guess what domain or
     # cname you are using. This is used in automated emails that
@@ -135,6 +136,9 @@ data:
     page_size = 100
     # Use FAB-based webserver with RBAC feature
     rbac = True
+    # Enable werkzeug `ProxyFix` middleware
+    enable_proxy_fix = {{ .Values.airflow.config.webserver.enable_proxy_fix }}
+
     [smtp]
     # If you want airflow to send emails on retries, failure, and you want to use
     # the airflow.utils.email.send_email_smtp function, you have to configure an
@@ -147,6 +151,7 @@ data:
     smtp_password = $SMTP_PASSWORD
     smtp_port = {{ .Values.airflow.config.smtp.smtp_port }}
     smtp_mail_from = {{ .Values.airflow.config.smtp.smtp_mail_from }}
+
     [kubernetes]
     airflow_configmap = {{ .Release.Name }}
     worker_container_repository = {{ .Values.airflow.image.repository }}
@@ -167,14 +172,17 @@ data:
     namespace = {{ .Release.Namespace }}
     gcp_service_account_keys =
     # For cloning DAGs from git repositories into volumes: https://github.com/kubernetes/git-sync
+
     [kubernetes_secrets]
     SQL_ALCHEMY_CONN = {{ .Release.Name }}=sql-alchemy-conn
     FERNET_KEY = {{ .Release.Name }}=fernet-key
     SMTP_USER = {{ .Release.Name }}=smtp-user
     SMTP_PASSWORD = {{ .Release.Name }}=smtp-password
+
     [hive]
     # Default mapreduce queue for HiveOperator tasks
     default_hive_mapred_queue =
+
     [celery]
     # This section only applies if you are using the CeleryExecutor in
     # [core] section above
@@ -215,6 +223,7 @@ data:
     default_queue = default
     # Import path for celery configuration options
     celery_config_options = airflow.config_templates.default_celery.DEFAULT_CELERY_CONFIG
+
     [celery_broker_transport_options]
     # The visibility timeout defines the number of seconds to wait for the worker
     # to acknowledge the task before the message is redelivered to another worker.
@@ -226,6 +235,7 @@ data:
     ssl_key =
     ssl_cert =
     ssl_cacert =
+
     [dask]
     # This section only applies if you are using the DaskExecutor in
     # [core] section above
@@ -235,6 +245,7 @@ data:
     tls_ca =
     tls_cert =
     tls_key =
+
     [ldap]
     # set this to ldaps://<your.ldap.server>:<port>
     uri =
@@ -248,6 +259,7 @@ data:
     basedn = dc=example,dc=com
     cacert = /etc/ca/ldap_ca.crt
     search_scope = LEVEL
+
     [mesos]
     # Mesos master address which MesosExecutor will connect to.
     master = localhost:5050
@@ -281,6 +293,7 @@ data:
     # This image should be accessible from mesos slave i.e mesos slave
     # should be able to pull this docker image before executing the command.
     # docker_image_slave = puckel/docker-airflow
+
     [kerberos]
     ccache = /tmp/airflow_krb5_ccache
     # gets augmented with fqdn
@@ -288,18 +301,24 @@ data:
     reinit_frequency = 3600
     kinit_path = kinit
     keytab = airflow.keytab
+
     [cli]
     api_client = airflow.api.client.json_client
     endpoint_url = http://localhost:8080
+
     [api]
     auth_backend = airflow.api.auth.backend.default
+
     [github_enterprise]
     api_rev = v3
+
     [admin]
     # UI to hide sensitive variable fields when set to True
     hide_sensitive_variable_fields = True
+
     [elasticsearch]
     elasticsearch_host =
+
   webserver_config.py: |
     import os
     from werkzeug.contrib.cache import RedisCache

--- a/charts/airflow-k8s/values.yaml
+++ b/charts/airflow-k8s/values.yaml
@@ -34,6 +34,8 @@ airflow:
       smtp_password: airflow
       smtp_port: 25
       smtp_mail_from: airflow@example.com
+    webserver:
+      enable_proxy_fix: "True"
   admin:
     username: ""
     password: ""


### PR DESCRIPTION
- Fixed problem where some of the authentication requests were done over
  **non-secure** HTTP connection.
- added `airflow.config.webserver.enable_proxy_fix` which
  by default is `True` but can be changed if necessary
- See:
  - Airflow issue: [`AIRFLOW-3137`](https://issues.apache.org/jira/browse/AIRFLOW-3137)
  - Airflow fix: [`PR #3983`](https://github.com/apache/airflow/pull/3983)

**NOTE**: You should only enable the `ProxyFix` middleware when running
Airflow behind a trusted proxy (AWS ELB, nginx, etc.).

Ticket: https://trello.com/c/6AbABA6a/161-make-sure-airflow-is-always-using-https