### PR TITLE
Schedule to High Memory Nodes

### DIFF
--- a/charts/fluentd/CHANGELOG.md
+++ b/charts/fluentd/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2019-03-04
+## Schedule to High memory nodes
+- Added toleration for highmem node's taint
+- Added `operator` context to k8s master toleration
+
 ## [0.2.0] - 2018-04-25
 ### FluentD Tuning
 - Modifying to currently working config set.

--- a/charts/fluentd/Chart.yaml
+++ b/charts/fluentd/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: fluentd
-version: 0.2.0
+version: 0.2.1

--- a/charts/fluentd/templates/daemonset.yaml
+++ b/charts/fluentd/templates/daemonset.yaml
@@ -21,6 +21,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+          operator: Exists
+        - key: dedicated
+          effect: NoSchedule
+          value: highmem
       serviceAccountName: {{ template "fullname" . }}
       containers:
       - name: {{ .Chart.Name }}


### PR DESCRIPTION
There were no logs in Elasticsearch for workloads scheduled on highmem
nodes.
The fluentd log shipping addon/`daemonset` could not tolerate the highmem node's taint and therefore could not
be scheduled to the highmem node when it was provisioned.

- Added toleration for highmem node's taint
- Added `operator` context to k8s master toleration
- _Deployed_ and tested

[Saved_kibana_search](https://kibana.services.alpha.mojanalytics.xyz/app/kibana#/discover/cda3f6e0-3e88-11e9-bdc5-377aef7b1bc9?_g=())
