### PR TITLE
Jupyter Lab: Update docker image tag

### DIFF
--- a/charts/jupyter-lab/CHANGELOG.md
+++ b/charts/jupyter-lab/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.1.17] - 2019-03-07
+### Changed
+- Run `usermod` in Docker build to avoid it being run on startup. This will
+improve startup time for users.
+
 ## [0.1.16] - 2018-12-13
 ### Changed
 - Revert previous change setting uid as 1001 at the pod level. We have

--- a/charts/jupyter-lab/Chart.yaml
+++ b/charts/jupyter-lab/Chart.yaml
@@ -1,4 +1,5 @@
 apiVersion: v1
 description: Jupyter Lab with Auth0 authentication proxy
 name: jupyter-lab
-version: 0.1.16
+version: 0.1.17
+appVersion: v0.6.5

--- a/charts/jupyter-lab/values.yaml
+++ b/charts/jupyter-lab/values.yaml
@@ -25,7 +25,7 @@ authProxy:
 
 jupyter:
   image: quay.io/mojanalytics/datascience-notebook
-  tag: v0.6.3
+  tag: v0.6.5
   imagePullPolicy: IfNotPresent
   containerPort: 8888
   resources:


### PR DESCRIPTION
New version of the image avoids slow startup problems for jupyter users.