### PR TITLE
unidler v3.2.0: Fix for `undefined` error

### DIFF
--- a/charts/unidler/CHANGELOG.md
+++ b/charts/unidler/CHANGELOG.md
@@ -5,6 +5,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [v3.2.0] - 2019-03-13
+### Changed
+New version of unidler which should fix [Issue #95]:
+
+"Unidler giving misleading messages", specifically it sometimes shows a
+strange `undefined` JS error. We think this was caused by the unidler
+erroneously updating the app Service too early. If then the client
+for whatever reason makes another request to `/events` this will go to
+the actual app which doesn't have a `/events` endpoint.
+
+Other improvements:
+- users receive more updates as their app is being unidled
+- fixed space between text and image
+- unidler logs more useful things now
+- other internal refactorings which shouldn't be user-facing
+- Don't set `INGRESS_CLASS_NAME` variable as unidler doesn't use it anymore
+
+[Issue #95](https://github.com/ministryofjustice/analytics-platform/issues/95)
+
+
 ## [v3.1.3] - 2019-02-14
 ### Changed
 Audit clusterrole rules, remove unused verbs

--- a/charts/unidler/Chart.yaml
+++ b/charts/unidler/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: unidler proxy
 name: unidler
-version: "v3.1.3"
-appVersion: "v0.1.0"
+version: "v3.2.0"
+appVersion: "v0.2.0"

--- a/charts/unidler/templates/deployment.yaml
+++ b/charts/unidler/templates/deployment.yaml
@@ -20,9 +20,6 @@ spec:
         ports:
         - name: http
           containerPort: {{ .Values.service.internalPort }}
-        env:
-          - name: INGRESS_CLASS_NAME
-            value: "{{ .Values.ingress.className }}"
         readinessProbe:
           httpGet:
             path: /healthz

--- a/charts/unidler/values.yaml
+++ b/charts/unidler/values.yaml
@@ -1,7 +1,7 @@
 # Docker image
 image:
   name: quay.io/mojanalytics/go-unidler
-  tag: v0.1.0
+  tag: v0.2.0
   pullPolicy: IfNotPresent
 
 replicaCount: 3


### PR DESCRIPTION
New version of unidler which should fix [Issue #95]:

"Unidler giving misleading messages", specifically it sometimes shows a
strange `undefined` JS error. We think this was caused by the unidler
erroneously updating the app Service too early. If then the client
for whatever reason makes another request to `/events` this will go to
the actual app which doesn't have a `/events` endpoint.

Other improvements:
- users receive more updates as their app is being unidled
- fixed space between text and image
- unidler logs more useful things now
- other internal refactorings which shouldn't be user-facing
- Don't set `INGRESS_CLASS_NAME` variable as unidler doesn't use it anymore

[Issue #95]: https://github.com/ministryofjustice/analytics-platform/issues/95