### PR TITLE
WebApp Migration Helm List

### DIFF
--- a/charts/webapp/migrations/upgrade_releases.sh
+++ b/charts/webapp/migrations/upgrade_releases.sh
@@ -7,7 +7,7 @@ DRY_RUN=true
 CONFIG_PATH=
 ENV=alpha
 HELM_REPO=mojanalytics/webapp
-HELM_VER=2.9.1
+HELM_VER=2.13.0
 NAMESPACE=apps-prod
 MOJANALYTICS_REPO=http://moj-analytics-helm-repo.s3-website-eu-west-1.amazonaws.com
 PLATFORM=$(uname -s)
@@ -71,7 +71,7 @@ fi
 helm repo list | grep -F 'mojanalytics' && helm repo update || helm repo add mojanalytics $MOJANALYTICS_REPO
 
 # Get a list of shiny-apps
-SHINY_APPS=$(helm ls --max 10000 | grep "${NAMESPACE}" | awk '{print $1}')
+SHINY_APPS=$(helm ls --max 10000 --namespace "${NAMESPACE}" | awk '{print $1}')
 
 # When specifying values files.  The priority will be given to the last (right-most) file specified
 for shiny_app in $SHINY_APPS; do


### PR DESCRIPTION
__Long running issue__: `received message larger than max (6645791 vs. 4194304)`

Due to the number of releases deployed to the cluster helm exceeds it's
download cache limit.

- Workaround by using the namespace flag
- Upgrade helm version