### PR TITLE
FluentD Resources WebApp

### DIFF
--- a/charts/webapp/CHANGELOG.md
+++ b/charts/webapp/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.3.22] - 2019-03-14
+### FluentD Resources
+- Increased cpu shares for fluentd. Requests and limits from 200m to 500m and 500m to 1 core respectively 
+
 ## [1.3.21] - 2019-03-08
 ### FluentD Resources
 - Increased cpu shares for fluentd

--- a/charts/webapp/Chart.yaml
+++ b/charts/webapp/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: webapp Helm chart for Kubernetes
 name: webapp
-version: 1.3.21
+version: 1.3.22

--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -37,8 +37,8 @@ Elasticsearch:
   Password: ""
 resources:
   limits:
-    cpu: 500m
+    cpu: 1000m
     memory: 512Mi
   requests:
-    cpu: 200m
+    cpu: 500m
     memory: 512Mi


### PR DESCRIPTION
It appears that the increased cpu shares for webapps has not been enough
to settle the throttling alerts.  I’m going to increase the limits
further to 1 core.

- Increased cpu shares for fluentd. Requests and limits from 200m to 500m and 500m to 1 core respectively