### PR TITLE
Added `host` label to all idleable tools (RStudio and Jupyter)

### DIFF
--- a/charts/jupyter-lab/CHANGELOG.md
+++ b/charts/jupyter-lab/CHANGELOG.md
@@ -4,15 +4,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2019-03-15
+### Changed
+- added `host=` label to everything, this will help simplify the idler
+- simplified installation/upgrade instructions in README
+- added `host` template to remove duplication
+- added NOTES.txt so that jupyter URL will be shown after installation
+
+
 ## [0.1.17] - 2019-03-07
 ### Changed
 - Run `usermod` in Docker build to avoid it being run on startup. This will
 improve startup time for users.
 
+
 ## [0.1.16] - 2018-12-13
 ### Changed
 - Revert previous change setting uid as 1001 at the pod level. We have
 put this back into the image as we found a couple of issues with this approach
+
 
 ## [0.1.14] - 2018-11-29
 ### Changed
@@ -20,17 +30,21 @@ put this back into the image as we found a couple of issues with this approach
   no longer done by the image itself
 - Re-added `livenessProbe` and `readinessProbe` from Jupyter container
 
+
 ## [0.1.13] - 2018-11-28
 ### Changed
 - Removed `livenessProbe` and `readinessProbe` from Jupyter container
+
 
 ## [0.1.12] - 2018-11-19
 ### Changed
 - Modified `livenessProbe` and `readinessProbe` to type `exec` for Jupyter container
 
+
 ## [0.1.11] - 2018-11-14
 ### Changed
 - Adjusted `livenessProbe` and `readinessProbe` to bigger values for Jupyter container
+
 
 ## [0.1.10] - 2018-10-19
 ### Changed

--- a/charts/jupyter-lab/Chart.yaml
+++ b/charts/jupyter-lab/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: Jupyter Lab with Auth0 authentication proxy
 name: jupyter-lab
-version: 0.1.17
+version: 0.2.0
 appVersion: v0.6.5

--- a/charts/jupyter-lab/README.md
+++ b/charts/jupyter-lab/README.md
@@ -1,12 +1,13 @@
 # Jupyter-Lab Helm Chart
 
 
-## Installing the Chart
+## Installing/upgrading the Chart
 
-To install an jupyter instance for the user specified in the Username variable (Github username):
+To install/upgrade an jupyter instance for the user specified in the Username
+variable (Github username):
 
 ```bash
-$ helm install charts/jupyter-lab -f chart-env-config/ENV/jupyter.yml --set aws.iamRole=ENV_user_USERNAME --set Username=USERNAME --namespace user-USERNAME --name=USERNAME-jupyter
+$ helm upgrade --dry-run --debug --install USERNAME-jupyter charts/jupyter-lab --namespace user-USERNAME --set Username=USERNAME --set aws.iamRole=ENV_user_USERNAME -f chart-env-config/ENV/jupyter.yml
 ```
 
 The instance will be available at <https://USERNAME-jupyter-lab.tools.ENV.mojanalytics.xyz>.
@@ -14,13 +15,7 @@ The instance will be available at <https://USERNAME-jupyter-lab.tools.ENV.mojana
 **NOTE**: Change the environment config file to deploy in a different environment
           (the URL will change accordingly)
 
-
-## Upgrading the Chart
-
-To upgrade a user jupyter chart:
-```bash
-$ helm upgrade USERNAME-jupyter charts/jupyter-lab -f chart-env-config/ENV/jupyter.yml --set Username=USERNAME
-```
+**NOTE**: Remove the `--dry-run` option to install/upgrade for real.
 
 
 ## Configuration

--- a/charts/jupyter-lab/templates/NOTES.txt
+++ b/charts/jupyter-lab/templates/NOTES.txt
@@ -1,0 +1,3 @@
+JupyterLab will be available at the following address:
+
+https://{{ template "host" .}}

--- a/charts/jupyter-lab/templates/_helpers.tpl
+++ b/charts/jupyter-lab/templates/_helpers.tpl
@@ -1,11 +1,3 @@
-{{/* vim: set filetype=mustache: */}}
-{{/*
-Expand the name of the chart.
-*/}}
-{{- define "name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 24 | trimSuffix "-" -}}
-{{- end -}}
-
 {{/*
 Create a default fully qualified app name.
 We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).

--- a/charts/jupyter-lab/templates/_helpers.tpl
+++ b/charts/jupyter-lab/templates/_helpers.tpl
@@ -6,3 +6,13 @@ We truncate at 24 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 24 | trimSuffix "-" -}}
 {{- end -}}
+
+
+{{/*
+Host
+
+e.g. username-jupyter-lab.example.com
+*/}}
+{{- define "host" -}}
+{{- (printf "%s-jupyter-lab.%s" .Values.Username .Values.toolsDomain) | lower -}}
+{{- end -}}

--- a/charts/jupyter-lab/templates/configmap-bash-profile.yaml
+++ b/charts/jupyter-lab/templates/configmap-bash-profile.yaml
@@ -6,5 +6,6 @@ metadata:
   labels:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app: {{ .Chart.Name }}
+    host: {{ template "host" . }}
 data:
 {{ (.Files.Glob "files/*").AsConfig | indent 2 }} # Flatten script into yaml map

--- a/charts/jupyter-lab/templates/deployment.yaml
+++ b/charts/jupyter-lab/templates/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app: {{ .Chart.Name }}
+    host: {{ template "host" . }}
     "mojanalytics.xyz/idleable": "true"
 spec:
   selector:
@@ -21,6 +22,7 @@ spec:
     metadata:
       labels:
         app: {{ .Chart.Name }}
+        host: {{ template "host" . }}
       annotations:
         iam.amazonaws.com/role: {{ .Values.aws.iamRole }}
     spec:

--- a/charts/jupyter-lab/templates/ingress.yaml
+++ b/charts/jupyter-lab/templates/ingress.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app: {{ .Chart.Name }}
+    host: {{ template "host" . }}
   annotations:
     kubernetes.io/ingress.class: "nginx"
 spec:

--- a/charts/jupyter-lab/templates/ingress.yaml
+++ b/charts/jupyter-lab/templates/ingress.yaml
@@ -10,7 +10,7 @@ metadata:
     kubernetes.io/ingress.class: "nginx"
 spec:
   rules:
-    - host: {{ .Values.Username | lower }}-jupyter-lab.{{ .Values.toolsDomain }}
+    - host: {{ template "host" . }}
       http:
         paths:
           - backend:
@@ -18,4 +18,4 @@ spec:
               servicePort: {{ .Values.service.port }}
   tls:
     - hosts:
-        - {{ .Values.Username | lower }}-jupyter-lab.{{ .Values.toolsDomain }}
+        - {{ template "host" . }}

--- a/charts/jupyter-lab/templates/job-bash-profile.yaml
+++ b/charts/jupyter-lab/templates/job-bash-profile.yaml
@@ -6,10 +6,17 @@ metadata:
   labels:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app: {{ .Chart.Name }}
+    host: {{ template "host" . }}
 spec:
   template:
     metadata:
       name: {{ template "fullname" . }}-job
+      labels:
+        chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+        host: {{ template "host" . }}
+        # NOTE: DO NOT add `app` label here as it's used by the service
+        #       to direct traffic to the jupyter pod and we don't want the
+        #       Job's pod to receive that traffic.
     spec:
       serviceAccountName: {{ .Values.Username }}-jupyter
       restartPolicy: Never

--- a/charts/jupyter-lab/templates/secrets.yaml
+++ b/charts/jupyter-lab/templates/secrets.yaml
@@ -6,10 +6,11 @@ metadata:
   labels:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app: {{ .Chart.Name }}
+    host: {{ template "host" . }}
 type: Opaque
 data:
   auth0_domain: {{ .Values.authProxy.auth0_domain | b64enc | quote }}
   auth0_client_id: {{ .Values.authProxy.auth0_client_id | b64enc | quote }}
   auth0_client_secret: {{ .Values.authProxy.auth0_client_secret | b64enc | quote }}
-  auth0_callback_url: {{ printf "https://%s-%s.%s/callback" .Values.Username .Chart.Name .Values.toolsDomain | lower | b64enc | quote }}
+  auth0_callback_url: {{ printf "https://%s/callback" (include "host" .) | b64enc | quote }}
   cookie_secret: {{ .Values.cookie_secret | b64enc | quote }}

--- a/charts/jupyter-lab/templates/service.yaml
+++ b/charts/jupyter-lab/templates/service.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app: {{ .Chart.Name }}
+    host: {{ template "host" . }}
 spec:
   ports:
     - name: http

--- a/charts/jupyter-lab/values.yaml
+++ b/charts/jupyter-lab/values.yaml
@@ -1,4 +1,5 @@
 Username: ""
+toolsDomain: "tools.example.com"
 
 aws:
   iamRole: ""

--- a/charts/rstudio/CHANGELOG.md
+++ b/charts/rstudio/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.7.0] - 2019-03-15
+
+### Changed
+- added `host=` label to everything, this will help simplify the idler
+- don't set unused `TOOLS_DOMAIN` environment variable
+- simplified installation/upgrade instructions in README
+- added `host` template to remove duplication
+- removed unused `name` template
+
 ## [1.6.0] - 2019-02-14
 
 ### Changed

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: RStudio with Auth0 authentication proxy
 name: rstudio
-version: 1.6.0
+version: 1.7.0
 appVersion: "RStudio: 1.1.463+conda, R: 3.5.1, Python: 3.7"

--- a/charts/rstudio/README.md
+++ b/charts/rstudio/README.md
@@ -1,12 +1,12 @@
 # RStudio Helm Chart
 
 
-## Installing the Chart
+## Install/upgrade the Chart
 
-To install an rstudio instance for the user specified in the username variable (Github username):
+To install/upgrade an rstudio instance for the user specified in the username variable (Github username):
 
 ```bash
-$ helm install charts/rstudio -f chart-env-config/ENV/rstudio.yml --set username=USERNAME --namespace user-USERNAME --name=USERNAME-rstudio
+$ helm upgrade --dry-run --debug --install USERNAME-rstudio charts/rstudio -f chart-env-config/ENV/rstudio.yml --set username=USERNAME
 ```
 
 The instance will be available in <https://USERNAME-rstudio.tools.ENV.mojanalytics.xyz>.
@@ -14,13 +14,7 @@ The instance will be available in <https://USERNAME-rstudio.tools.ENV.mojanalyti
 **NOTE**: Change the environment config file to deploy in a different environment
           (the URL will change accordingly)
 
-
-## Upgrading the Chart
-
-To upgrade a user rstudio chart:
-```bash
-$ helm upgrade USERNAME-rstudio charts/rstudio -f chart-env-config/ENV/rstudio.yml --set username=USERNAME
-```
+**NOTE**: Remove the `--dry-run` option to install/upgrade for real.
 
 
 ## Configuration

--- a/charts/rstudio/README.md
+++ b/charts/rstudio/README.md
@@ -6,7 +6,7 @@
 To install/upgrade an rstudio instance for the user specified in the username variable (Github username):
 
 ```bash
-$ helm upgrade --dry-run --debug --install USERNAME-rstudio charts/rstudio -f chart-env-config/ENV/rstudio.yml --set username=USERNAME
+$ helm upgrade --dry-run --debug --install USERNAME-rstudio --namespace user-USERNAME --set username=USERNAME charts/rstudio -f chart-env-config/ENV/rstudio.yml
 ```
 
 The instance will be available in <https://USERNAME-rstudio.tools.ENV.mojanalytics.xyz>.

--- a/charts/rstudio/templates/NOTES.txt
+++ b/charts/rstudio/templates/NOTES.txt
@@ -1,0 +1,3 @@
+RStudio will be available at the following address:
+
+https://{{ template "host" .}}

--- a/charts/rstudio/templates/_helpers.tpl
+++ b/charts/rstudio/templates/_helpers.tpl
@@ -6,3 +6,13 @@ We truncate at 24 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 24 | trimSuffix "-" -}}
 {{- end -}}
+
+
+{{/*
+Host
+
+e.g. username-rstudio.example.com
+*/}}
+{{- define "host" -}}
+{{- (printf "%s-rstudio.%s" .Values.username .Values.toolsDomain) | lower -}}
+{{- end -}}

--- a/charts/rstudio/templates/_helpers.tpl
+++ b/charts/rstudio/templates/_helpers.tpl
@@ -1,11 +1,3 @@
-{{/* vim: set filetype=mustache: */}}
-{{/*
-Expand the name of the chart.
-*/}}
-{{- define "name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 24 | trimSuffix "-" -}}
-{{- end -}}
-
 {{/*
 Create a default fully qualified app name.
 We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).

--- a/charts/rstudio/templates/deployment.yml
+++ b/charts/rstudio/templates/deployment.yml
@@ -138,8 +138,6 @@ spec:
                 secretKeyRef:
                   name: {{ template "fullname" . }}
                   key: secure_cookie_key
-            - name: TOOLS_DOMAIN
-              value: {{ .Values.toolsDomain }}
           readinessProbe:
             httpGet:
               path: /

--- a/charts/rstudio/templates/deployment.yml
+++ b/charts/rstudio/templates/deployment.yml
@@ -5,6 +5,7 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: "{{ .Chart.Name }}"
+    host: "{{ template "host" .}}"
     "mojanalytics.xyz/idleable": "true"
 spec:
   replicas: 1
@@ -17,6 +18,7 @@ spec:
     metadata:
       labels:
         app: "{{ .Chart.Name }}"
+        host: "{{ template "host" .}}"
       annotations:
         iam.amazonaws.com/role: {{ .Values.aws.iamRole }}
     spec:

--- a/charts/rstudio/templates/ingress.yml
+++ b/charts/rstudio/templates/ingress.yml
@@ -9,7 +9,7 @@ metadata:
     kubernetes.io/ingress.class: "nginx"
 spec:
   rules:
-  - host: {{ .Values.username | lower }}-rstudio.{{ .Values.toolsDomain }}
+  - host: {{ template "host" . }}
     http:
       paths:
       - backend:
@@ -17,4 +17,4 @@ spec:
           servicePort: 80
   tls:
     - hosts:
-        - {{ .Values.username | lower }}-rstudio.{{ .Values.toolsDomain }}
+        - {{ template "host" . }}

--- a/charts/rstudio/templates/ingress.yml
+++ b/charts/rstudio/templates/ingress.yml
@@ -5,6 +5,7 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: "{{ .Chart.Name }}"
+    host: "{{ template "host" .}}"
   annotations:
     kubernetes.io/ingress.class: "nginx"
 spec:

--- a/charts/rstudio/templates/secrets.yml
+++ b/charts/rstudio/templates/secrets.yml
@@ -10,8 +10,8 @@ data:
   client_secret: {{ .Values.authProxy.auth0.clientSecret | b64enc | quote }}
   client_id: {{ .Values.authProxy.auth0.clientId | b64enc | quote }}
   domain: {{ .Values.authProxy.auth0.domain | b64enc | quote }}
-  app_host: {{ printf "%s-rstudio.%s" .Values.username .Values.toolsDomain | lower | b64enc | quote }}
-  callback_url: {{ printf "https://%s-rstudio.%s/callback" .Values.username .Values.toolsDomain | lower | b64enc | quote }}
+  app_host: {{ (include "host" .) | b64enc | quote }}
+  callback_url: {{ printf "https://%s/callback" (include "host" .) | b64enc | quote }}
   cookie_secret: {{ .Values.authProxy.cookieSecret | b64enc | quote }}
   secure_cookie_key: {{ .Values.rstudio.secureCookieKey | b64enc | quote }}
   aws_default_region: {{ .Values.aws.defaultRegion | b64enc | quote }}

--- a/charts/rstudio/templates/secrets.yml
+++ b/charts/rstudio/templates/secrets.yml
@@ -5,6 +5,7 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: "{{ .Chart.Name }}"
+    host: "{{ template "host" .}}"
 type: Opaque
 data:
   client_secret: {{ .Values.authProxy.auth0.clientSecret | b64enc | quote }}

--- a/charts/rstudio/templates/service.yml
+++ b/charts/rstudio/templates/service.yml
@@ -5,6 +5,7 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: "{{ .Chart.Name }}"
+    host: "{{ template "host" .}}"
 spec:
   sessionAffinity: ClientIP
   selector:


### PR DESCRIPTION
RStudio 1.7.0: Added `host` label to all resources
===================================

- added `host=` label to everything, this will help simplify the idler
- don't set unused `TOOLS_DOMAIN` environment variable
- simplified installation/upgrade instructions in README
- added `host` template to remove duplication
- removed unused `name` template

Jupyter 0.2.0: Added `host` label to all resources
===================================

- added `host=` label to everything, this will help simplify the idler
- simplified installation/upgrade instructions in README
- added `host` template to remove duplication
- added NOTES.txt so that jupyter URL will be shown after installation