### PR TITLE
Pod Priority Classess

### DIFF
--- a/charts/priority-classes/.helmignore
+++ b/charts/priority-classes/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/priority-classes/Chart.yaml
+++ b/charts/priority-classes/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+description: Pod Priority Classes
+name: priority-classes
+version: 0.1.0
+sources:
+  - https://github.com/ministryofjustice/analytics-platform-helm-charts
+  - https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption

--- a/charts/priority-classes/README.md
+++ b/charts/priority-classes/README.md
@@ -1,0 +1,36 @@
+# Priority Classes
+
+Creates `pod` [Priority Classes](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass)
+
+### Dependencies/Prerequisites
+
+* As of K8s `1.11` the admission plugin that enforces the pod priority and preemption predicates is enabled by default
+
+### Installing
+
+```bash
+helm upgrade priority-classes mojanalytics/priority-classes --install
+```
+
+### Configuration
+
+| Parameter        | Description                     | Default |
+| ----------       | ---------------                 | ------- |
+| `name`           | (__required__) The name of the priority class  | ""      |
+| `global`         | Setting to `true` indicates that this should be applied to pods that have not specified `priorityClassName` or `priority` (__This can only be applied once per cluster__) | `false` |
+| `priority_value` | (__required__) The priority value between `0` and 1 billion (So we do not interfere with __system critical pods__). Higher value equals higher priority | "" |
+| `description`    | Description of the `PriorityClass` use case    | ""      |
+
+### Usage
+
+Add `priorityClassName` and reference the name of the `PriorityClass` in the `pod` template spec:
+
+```yaml
+    spec:
+      priorityClassName: system
+      serviceAccountName: sysdig
+      containers:
+        - name: sysdig-inspect
+          image: store/sysdig/sysdig:0.12.0
+          imagePullPolicy: IfNotPresent
+```

--- a/charts/priority-classes/templates/system-priority-class.yaml
+++ b/charts/priority-classes/templates/system-priority-class.yaml
@@ -1,0 +1,11 @@
+{{ range .Values.priority_classes }}
+apiVersion: scheduling.k8s.io/v1beta1
+kind: PriorityClass
+metadata:
+  name: {{ .name }}
+globalDefault: {{ .global | default "false" }}
+value: {{ .priority_value }}
+description: {{ .description | quote | default "" }}
+
+---
+{{ end }}

--- a/charts/priority-classes/values.yaml
+++ b/charts/priority-classes/values.yaml
@@ -1,0 +1,8 @@
+priority_classes:
+  - name: system
+    priority_value: 1000000000
+    description: "Reserved for high priority system pods/daemonsets"
+# - name: default-priority
+#   global: true
+#   priority_value: 50000
+#   description: "Not low or high priority"


### PR DESCRIPTION
[Trello](https://trello.com/c/Ay2ryNvC)

Adding a priority class to be referenced by system pods

We want some pods (particularly those that handle log and metrics aggregation) to be considered a higher priority by the scheduler.
We had an instance where a node was experiencing resource contention and
a `daemonset` controlled pod was left in a `pending` state after the pod
restarted.  `Daemonset` pods have the `nodeName` field set so if the specified node has no room to
accommodate the workload then the Scheduler has no choice but to wait for
the specified node to become available.

A pod referencing the `system` priority class will always be scheduled.
Even if it means evicting other lower priority pods. Pods that have no
priority set has a priority of `0`.