### PR TITLE
Add git sync repo for ariflow dags to a kube secret

### DIFF
--- a/charts/airflow-k8s/CHANGELOG.md
+++ b/charts/airflow-k8s/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [0.2.1] - 2019-03-20
+### Changed
+- Set git-sync repo to a kube secret as it now contains access token for github
+
+
 ## [0.2.0] - 2019-02-25
 ### Changed
 - Upgraded `redis` chart dependency `3.6.4` => `6.1.3`

--- a/charts/airflow-k8s/Chart.yaml
+++ b/charts/airflow-k8s/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 description: Airflow on kubernetes. Tasks are run as pods
 name: airflow-k8s
 icon: https://airflow.incubator.apache.org/_images/pin_large.png
-version: 0.2.0
+version: 0.2.1
 appVersion: 1.10.2

--- a/charts/airflow-k8s/templates/git-sync-deployment.yml
+++ b/charts/airflow-k8s/templates/git-sync-deployment.yml
@@ -36,8 +36,11 @@ spec:
           imagePullPolicy: {{ .Values.gitSync.image.pullPolicy }}
           env:
             - name: GIT_SYNC_REPO
-              value: "{{ .Values.gitSync.repository }}"
-            - name: GIT_SYNC_DEST
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Release.Name }}-git-sync"
+                  key: git-sync-repo
+            - name: GIT_SYNC_ROOT
               value: "/git"
             - name: GIT_SYNC_BRANCH
               value: "{{ .Values.gitSync.branch }}"

--- a/charts/airflow-k8s/templates/secrets.yml
+++ b/charts/airflow-k8s/templates/secrets.yml
@@ -32,3 +32,15 @@ stringData:
             "userinfo_uri": "{{ .Values.airflow.auth.oauth.baseUrl }}userinfo"
           }
     }
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{ .Release.Name }}-git-sync"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: {{ .Release.Name }}
+type: Opaque
+data:
+  git-sync-repo: {{ printf .Values.gitSync.repository | b64enc | quote }}

--- a/charts/airflow-k8s/values.yaml
+++ b/charts/airflow-k8s/values.yaml
@@ -45,9 +45,9 @@ gitSync:
   repository: "https://github.com/ministryofjustice/analytics-platform-airflow-example-dags"
   branch: "master"
   image:
-    repository: "openweb/git-sync"
-    tag: "0.0.1"
-    pullPolicy: "IfNotPresent"
+    repository: "appertly/git-sync"
+    tag: "2.0.4"
+    pullPolicy: "Always"
 postgres:
   host: ""
   port: "5432"


### PR DESCRIPTION
Add git sync repo for ariflow dags to a kube secret so we can add the github access token to pull private repos - specifically making the `airflow-dags` repo private