### PR TITLE
unidler v3.2.2: Less errors reaching the user and UX tweaks

### DIFF
--- a/charts/unidler/CHANGELOG.md
+++ b/charts/unidler/CHANGELOG.md
@@ -5,6 +5,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [v3.2.2] - 2019-03-21
+### Changed
+Bumped unidler to version `v0.2.3`.
+
+**Less errors reaching the user and UX tweaks**
+
+- Removed #/6 "progress" messages as confusing (for some users)
+- Better handling of "nonexistent key" error when patching Service to avoid
+  showing "Failed to redirect back your app" when we can safely recover.
+- when unidling an app which has annotation with unidled number of replicas
+  of `0`, assume this is a mistake and set number of replicas to `1`.
+
+
 ## [v3.2.1] - 2019-03-14
 ### Changed
 Bumped unidler to version `v0.2.1`.

--- a/charts/unidler/Chart.yaml
+++ b/charts/unidler/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: unidler proxy
 name: unidler
-version: "v3.2.1"
-appVersion: "v0.2.1"
+version: "v3.2.2"
+appVersion: "v0.2.3"

--- a/charts/unidler/values.yaml
+++ b/charts/unidler/values.yaml
@@ -1,7 +1,7 @@
 # Docker image
 image:
   name: quay.io/mojanalytics/go-unidler
-  tag: v0.2.1
+  tag: v0.2.3
   pullPolicy: IfNotPresent
 
 replicaCount: 3


### PR DESCRIPTION
- Removed #/6 "progress" messages as confusing (for some users)
- Better handling of "nonexistent key" error when patching Service to avoid
  showing "Failed to redirect back your app" when we can safely recover.
- when unidling an app which has annotation with unidled number of replicas
  of `0`, assume this is a mistake and set number of replicas to `1`.

See PRs:
- https://github.com/ministryofjustice/analytics-platform-go-unidler/pull/7
- https://github.com/ministryofjustice/analytics-platform-go-unidler/pull/8