### PR TITLE
unidler v4.0.0: Bumped unidler version to `v1.0.0`

### DIFF
--- a/charts/unidler/CHANGELOG.md
+++ b/charts/unidler/CHANGELOG.md
@@ -5,6 +5,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [v4.0.0] - 2019-03-27
+### Changed
+Bumped unidler to version `v1.0.0`.
+
+**NOTE**: This is a breaking change as the unidler now uses the `host` labels
+to retrieve the resources to change. But these labels need to be there.
+So not exactly retro-compatible.
+
+- use `host` labels to find Ingress, Deployment, etc...
+- use `mojanalytics.xyz/replicas-when-unidled` annotation instead of old
+  `mojanalytics.xyz/idled-at` which was trying to do too many things at once
+
+SEE:
+- [unidler changes](https://github.com/ministryofjustice/analytics-platform-go-unidler/pull/9)
+- [migration to add labels](https://github.com/ministryofjustice/analytics-platform-ops/pull/266)
+
+
 ## [v3.2.2] - 2019-03-21
 ### Changed
 Bumped unidler to version `v0.2.3`.

--- a/charts/unidler/Chart.yaml
+++ b/charts/unidler/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: unidler proxy
 name: unidler
-version: "v3.2.2"
-appVersion: "v0.2.3"
+version: "v4.0.0"
+appVersion: "v1.0.0"

--- a/charts/unidler/values.yaml
+++ b/charts/unidler/values.yaml
@@ -1,7 +1,7 @@
 # Docker image
 image:
   name: quay.io/mojanalytics/go-unidler
-  tag: v0.2.3
+  tag: v1.0.0
   pullPolicy: IfNotPresent
 
 replicaCount: 3


### PR DESCRIPTION
**NOTE**: This is a breaking change as the unidler now uses the `host` labels
to retrieve the resources to change. But these labels need to be there.
So not exactly retro-compatible.

- use `host` labels to find Ingress, Deployment, etc...
- use `mojanalytics.xyz/replicas-when-unidled` annotation instead of old
  `mojanalytics.xyz/idled-at` which was trying to do too many things at once

**SEE**:
- [unidler changes](https://github.com/ministryofjustice/analytics-platform-go-unidler/pull/9)
- [migration to add labels](https://github.com/ministryofjustice/analytics-platform-ops/pull/266)

**Ticket**: https://trello.com/c/NMpN8B1j/132-add-host-label-to-all-idleable-apps-tools