### PR TITLE
WebApp: FluentD Upgrade

### DIFF
--- a/charts/webapp/CHANGELOG.md
+++ b/charts/webapp/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.3.23] - 2019-03-28
+### FluentD Upgrade
+- Set `target_type_key` to `true` in output configuration 
+- Set `log_es_400_reason` to `true` in output configuration
+- Removed record transformer `types` key because it's not needed
+- Changed FluentD image tag from `v2.0.4` to `v2.4.0`
+
 ## [1.3.22] - 2019-03-14
 ### FluentD Resources
 - Increased cpu shares for fluentd. Requests and limits from 200m to 500m and 500m to 1 core respectively 

--- a/charts/webapp/Chart.yaml
+++ b/charts/webapp/Chart.yaml
@@ -1,4 +1,5 @@
 apiVersion: v1
 description: webapp Helm chart for Kubernetes
 name: webapp
-version: 1.3.22
+fluentdVersion: 2.5.0
+version: 1.3.23

--- a/charts/webapp/templates/fluentd-configmap.yml
+++ b/charts/webapp/templates/fluentd-configmap.yml
@@ -60,7 +60,6 @@ data:
     <filter web_app.**>
       @type record_transformer
       enable_ruby true
-      types time_nano:integer
       <record>
         app_name "#{ENV['FLUENT_SOURCE_TAG']}"
       </record>
@@ -77,7 +76,9 @@ data:
        @type elasticsearch
        @log_level info
        type_name time
+       target_type_key time
        include_tag_key true
+       log_es_400_reason true
        scheme "#{ENV['FLUENT_ELASTICSEARCH_SCHEME']}"
        host "#{ENV['FLUENT_ELASTICSEARCH_HOST']}"
        port "#{ENV['FLUENT_ELASTICSEARCH_PORT']}"

--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -27,7 +27,7 @@ AWS:
 Fluentd:
   Image:
     Repository: gcr.io/google-containers/fluentd-elasticsearch
-    Tag: v2.0.4
+    Tag: v2.4.0
     PullPolicy: "IfNotPresent"
 Elasticsearch:
   Scheme: "http"


### PR DESCRIPTION
Upgrading image to make use of better error handling features, log
output and compatibility with elasticsearch `6.x`.

- Setting target `target_type_key` is more explicit and means the
elasticsearch plugin won't need to fall through the stack or error out to determine the
indexing type
- __Newwer Feature__: `log_es_400_reason` means we get log output on why
Elasticsearch returned a `400: bad request` without having to set log to
`DEBUG`
- Removed record transformer `types` key because it's not needed