### PR TITLE
Jupyter-lab: Upgrade auth proxy image

### DIFF
--- a/charts/jupyter-lab/CHANGELOG.md
+++ b/charts/jupyter-lab/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2019-03-28
+### Changed
+- Update version of auth-proxy to one that supports tunneling.
+- Allow people to tunnel dash apps.
+
 ## [0.2.0] - 2019-03-15
 ### Changed
 - added `host=` label to everything, this will help simplify the idler

--- a/charts/jupyter-lab/Chart.yaml
+++ b/charts/jupyter-lab/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: Jupyter Lab with Auth0 authentication proxy
 name: jupyter-lab
-version: 0.2.0
+version: 0.2.1
 appVersion: v0.6.5

--- a/charts/jupyter-lab/templates/deployment.yaml
+++ b/charts/jupyter-lab/templates/deployment.yaml
@@ -66,6 +66,10 @@ spec:
               value: {{ .Values.Username }}
             - name: COOKIE_MAXAGE
               value: {{ .Values.authProxy.cookie_maxage | quote }}
+            - name: TUNNEL_ENABLED
+              value: {{ .Values.authProxy.tunnel.enabled | quote }}
+            - name: TUNNEL_PORT_RANGE
+              value: {{ .Values.authProxy.tunnel.port_range | quote }}
           readinessProbe:
             httpGet:
               path: /healthz

--- a/charts/jupyter-lab/values.yaml
+++ b/charts/jupyter-lab/values.yaml
@@ -10,7 +10,7 @@ service:
 
 authProxy:
   image: quay.io/mojanalytics/auth-proxy
-  tag: v0.1.6
+  tag: v2.0.1
   imagePullPolicy: IfNotPresent
   containerPort: 3000
   resources:
@@ -22,7 +22,11 @@ authProxy:
       memory: 64Mi
   auth0_domain: ""
   auth0_client_id: ""
+  auth0_client_secret: "" # put dummy value here to stop helm lint complaining
   cookie_maxage: 36000 #10 hours
+  tunnel:
+    enabled: "true"
+    port_range: "8050,4040-4050"
 
 jupyter:
   image: quay.io/mojanalytics/datascience-notebook


### PR DESCRIPTION
upgrade to auth proxy that supports _tunneling_. Add environment variable to the
deployment to enable the feature.