### PR TITLE
idler 2.0.0: bumped idler tag to `v1.0.0`

### DIFF
--- a/charts/idler/CHANGELOG.md
+++ b/charts/idler/CHANGELOG.md
@@ -4,22 +4,48 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+## [2.0.0] - 2019-03-29
+### Changed
+- Use `idler` to `v1.0.0`:
+  - adds `mojanalytics.xyz/replicas-when-unidled` annotation with number of
+    replicas desired at the time of udling. This is used by `unidler`
+  - `mojanalytics.xyz/idled-at` only contains time when app was idled,
+    nothing else
+  - renamed env var `RSTUDIO_ACTIVITY_CPU_THRESHOLD` =>
+    `CPU_ACTIVITY_THRESHOLD`
+  - internal refactorings
+  - `labelSelector` defaults to `mojanalytics.xyz/idleable=true` now
+    (in `idler`)
+  - See PR: ministryofjustice/analytics-platform-idler#68
+- added `app=$RELEASE_NAME` to job's pods so that we can see logs and
+  investigate things much more easily
+- `labelSelector` defaults to `mojanalytics.xyz/idleable=true` now (in helm
+  chart)
+- `logLevel` defaults to `DEBUG`. We want to see what's going on unless
+  we explicit silence it for whatever reason.
+
+
 ## [1.2.4] - 2019-02-18
 ### Changed
 Bump to 0.5.2 to get bugfix for targetport
 
+
 ## [1.2.3] - 2019-02-18
 ### Changed
 Bump image version to 0.5.1 to pick up bugfix for incorrect service update
+
 
 ## [1.2.2] - 2019-02-14
 ### Changed
 Corrected verb for read services
 Remove unused permissions for ingresses
 
+
 ## [1.2.1] - 2019-02-05
 ### Changed
 Added permission to read and patch services
+
 
 ## [1.2.0] - 2019-01-29
 ### Changed
@@ -27,15 +53,18 @@ Idling was achieved by disabling the app ingress and adding the app hostname to 
 If multiple users unidled at the same time, there could be a race condition when removing the hostnames from the unidler ingress.
 This change does away with editing ingresses altogether and edits only the app service. By changing the service to what is essentially a CNAME forwarding to the unidler, requests to the app host are handled by the unidler.
 
+
 ## [1.1.0] - 2018-10-10
 ### Changed
 - Add support for idling Jupyter-lab
+
 
 ## [1.0.1] - 2018-10-09
 ### Changed
 - Using a new version of idler (`v0.3.1`) with more support for cpu metrics in
   microcorescores:
   https://github.com/ministryofjustice/analytics-platform-idler/pull/20
+
 
 ## [1.0.0] - 2018-10-03
 ### Changed

--- a/charts/idler/Chart.yaml
+++ b/charts/idler/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: idler cronjob
 name: idler
-version: 1.2.4
-appVersion: v0.5.2
+version: 2.0.0
+appVersion: v1.0.0

--- a/charts/idler/README.md
+++ b/charts/idler/README.md
@@ -7,32 +7,22 @@ The idler runs every night at 10pm and scales down RStudio deployments to 0
 replicas, unless the deployment has an average CPU usage of greater than 10%
 over the last minute (ie: it is active).
 
-## Installing the Chart
+## Installing/upgrading the Chart
+
 
 ```bash
-helm install mojanalytics/idler \
-  --name idler \
-  --namespace default
+$ helm upgrade --dry-run --debug --install idler charts/idler --namespace default
 ```
 
-You can optionally override some of the values, e.g.
-
-```bash
-helm install mojanalytics/idler \
-  --name idler \
-  --namespace default \
-  --set schedule=$SCHEDULE \
-  --set labelSelector=$LABEL_SELECTOR \
-  --set cpuActivityThreshold=$CPU_ACTIVITY_THRESHOLD
-```
+**NOTE**: Remove `--dry-run` to actually install/upgrade once you're
+happy with the output.
 
 
 ## Configuration
 
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
-| `cpuActivityThreshold` | Percentage of CPU usage to consider an "active" deployment which should not be idled | 10 |
-| `labelSelector` | Kubernetes label selector for deployments to consider for idling | `app=rstudio` |
-| `logLevel` | Log level. See [Python 3 log levels](https://docs.python.org/3/library/logging.html#levels) for valid values | `INFO` |
+| `cpuActivityThreshold` | Percentage of CPU usage to consider an "active" deployment which should not be idled | `10` |
+| `labelSelector` | Kubernetes label selector for deployments to consider for idling | `mojanalytics.xyz/idleable=true` |
+| `logLevel` | Log level. See [Python 3 log levels](https://docs.python.org/3/library/logging.html#levels) for valid values | `DEBUG` |
 | `schedule` | Cron format string defining time and frequency of runs | `0 22 * * *` (every day at 22:00) |
-

--- a/charts/idler/templates/cronjob.yaml
+++ b/charts/idler/templates/cronjob.yaml
@@ -12,6 +12,9 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          labels:
+            app: {{ .Release.Name }}
         spec:
           serviceAccountName: {{ .Release.Name }}
           containers:
@@ -22,6 +25,6 @@ spec:
               value: '{{ .Values.logLevel }}'
             - name: LABEL_SELECTOR
               value: '{{ .Values.labelSelector }}'
-            - name: RSTUDIO_ACTIVITY_CPU_THRESHOLD
+            - name: CPU_ACTIVITY_THRESHOLD
               value: '{{ .Values.cpuActivityThreshold }}'
           restartPolicy: Never

--- a/charts/idler/values.yaml
+++ b/charts/idler/values.yaml
@@ -1,5 +1,5 @@
 # Docker image version
-image: quay.io/mojanalytics/idler:v0.5.2
+image: quay.io/mojanalytics/idler:v1.0.0
 
 # Schedule when to run
 #   min    hour   day    month (Sun-Sat)
@@ -12,9 +12,9 @@ schedule: "0 22 * * *"
 # See https://kubernetes.io/docs/user-guide/cron-jobs/#concurrency_policy
 concurrencyPolicy: Forbid
 
-labelSelector: 'app=rstudio'
+labelSelector: 'mojanalytics.xyz/idleable=true'
 
-logLevel: 'INFO'
+logLevel: 'DEBUG'
 
 # percentage of a CPU in the last minute which marks an active instance
 # (which should not be idled)


### PR DESCRIPTION
- Use `idler` to `v1.0.0`:
  - adds `mojanalytics.xyz/replicas-when-unidled` annotation with number of
    replicas desired at the time of udling. This is used by `unidler`
  - `mojanalytics.xyz/idled-at` only contains time when app was idled,
    nothing else
  - renamed env var `RSTUDIO_ACTIVITY_CPU_THRESHOLD` =>
    `CPU_ACTIVITY_THRESHOLD`
  - internal refactorings
  - `labelSelector` defaults to `mojanalytics.xyz/idleable=true` now
    (in `idler`)
  - See PR: ministryofjustice/analytics-platform-idler#68
- added `app=$RELEASE_NAME` to job's pods so that we can see logs and
  investigate things much more easily
- `labelSelector` defaults to `mojanalytics.xyz/idleable=true` now (in helm
  chart)
- `logLevel` defaults to `DEBUG`. We want to see what's going on unless
  we explicit silence it for whatever reason.