### PR TITLE
FluentD Upgrade cipher version

### DIFF
--- a/charts/webapp/CHANGELOG.md
+++ b/charts/webapp/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.3.24] - 2019-04-02
+### FluentD Upgrade cipher version
+- Add `ssl_version TLSv1_2` to output configuration
+
 ## [1.3.23] - 2019-03-28
 ### FluentD Upgrade
 - Set `target_type_key` to `true` in output configuration 

--- a/charts/webapp/Chart.yaml
+++ b/charts/webapp/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 description: webapp Helm chart for Kubernetes
 name: webapp
 fluentdVersion: 2.5.0
-version: 1.3.23
+version: 1.3.24

--- a/charts/webapp/templates/fluentd-configmap.yml
+++ b/charts/webapp/templates/fluentd-configmap.yml
@@ -79,6 +79,7 @@ data:
        target_type_key time
        include_tag_key true
        log_es_400_reason true
+       ssl_version TLSv1_2
        scheme "#{ENV['FLUENT_ELASTICSEARCH_SCHEME']}"
        host "#{ENV['FLUENT_ELASTICSEARCH_HOST']}"
        port "#{ENV['FLUENT_ELASTICSEARCH_PORT']}"


### PR DESCRIPTION
Since upgrading `FluentD` does not always auto negotiate TLS

- Added `ssl_version TLSv1_2` to output configuration