### PR TITLE
rstudio/jupyter-lab: Added `ideable` label to pods

### DIFF
--- a/charts/jupyter-lab/CHANGELOG.md
+++ b/charts/jupyter-lab/CHANGELOG.md
@@ -4,10 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+## [0.3.0] - 2019-04-04
+### Changed
+- Added `"mojanalytics.xyz/idleable": "true"` label to pods. This will
+  make the "don't idle if CPU usage is above X%" logic work again.
+
+
 ## [0.2.1] - 2019-03-28
 ### Changed
 - Update version of auth-proxy to one that supports tunneling.
 - Allow people to tunnel dash apps.
+
 
 ## [0.2.0] - 2019-03-15
 ### Changed

--- a/charts/jupyter-lab/Chart.yaml
+++ b/charts/jupyter-lab/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: Jupyter Lab with Auth0 authentication proxy
 name: jupyter-lab
-version: 0.2.1
+version: 0.3.0
 appVersion: v0.6.5

--- a/charts/jupyter-lab/templates/deployment.yaml
+++ b/charts/jupyter-lab/templates/deployment.yaml
@@ -23,6 +23,7 @@ spec:
       labels:
         app: {{ .Chart.Name }}
         host: {{ template "host" . }}
+        "mojanalytics.xyz/idleable": "true"
       annotations:
         iam.amazonaws.com/role: {{ .Values.aws.iamRole }}
     spec:

--- a/charts/rstudio/CHANGELOG.md
+++ b/charts/rstudio/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+## [1.8.0] - 2019-03-15
+
+### Changed
+- Added `"mojanalytics.xyz/idleable": "true"` label to pods. This will
+  make the "don't idle if CPU usage is above X%" logic work again.
+
+
 ## [1.7.0] - 2019-03-15
 
 ### Changed
@@ -12,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - simplified installation/upgrade instructions in README
 - added `host` template to remove duplication
 - removed unused `name` template
+
 
 ## [1.6.0] - 2019-02-14
 
@@ -22,12 +31,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - has a rstudio conda environment
 - maintains support for projects still using packrat
 
+
 ## [1.5.8] - 2018-10-17
 
 ### Changed
 - Version of rstudio image (3.4.2-6), it now points at the cran proxy, has boto3
   installed by default and is able to build udunits2 r package
 - Change pull policy for rstudio container to be 'IfNotPresent' instead of 'Always'
+
 
 ## [1.5.7] - 2018-10-17
 

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: RStudio with Auth0 authentication proxy
 name: rstudio
-version: 1.7.0
+version: 1.8.0
 appVersion: "RStudio: 1.1.463+conda, R: 3.5.1, Python: 3.7"

--- a/charts/rstudio/templates/deployment.yml
+++ b/charts/rstudio/templates/deployment.yml
@@ -19,6 +19,7 @@ spec:
       labels:
         app: "{{ .Chart.Name }}"
         host: "{{ template "host" .}}"
+        "mojanalytics.xyz/idleable": "true"
       annotations:
         iam.amazonaws.com/role: {{ .Values.aws.iamRole }}
     spec:


### PR DESCRIPTION
This will make the "don't idle if CPU usage is above X%" logic work
again.