### PR TITLE
Add airflow-sqlite helm chart

### DIFF
--- a/charts/airflow-sqlite/.helmignore
+++ b/charts/airflow-sqlite/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/charts/airflow-sqlite/CHANGELOG.md
+++ b/charts/airflow-sqlite/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [0.0.1] - 2019-04-04
+### Added
+First attempt at self service Airflow running on Sqlite with no Redis

--- a/charts/airflow-sqlite/Chart.yaml
+++ b/charts/airflow-sqlite/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+description: Airflow with sqlite. Tasks are run as pods
+name: airflow-sqlite
+icon: https://airflow.incubator.apache.org/_images/pin_large.png
+version: 0.0.0
+appVersion: 1.10.2

--- a/charts/airflow-sqlite/Chart.yaml
+++ b/charts/airflow-sqlite/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 description: Airflow with sqlite. Tasks are run as pods
 name: airflow-sqlite
 icon: https://airflow.incubator.apache.org/_images/pin_large.png
-version: 0.0.0
+version: 0.0.1
 appVersion: 1.10.2

--- a/charts/airflow-sqlite/README.md
+++ b/charts/airflow-sqlite/README.md
@@ -1,0 +1,26 @@
+# Airflow Helm Chart
+
+Run Airflow on demand in kubernetes user namespace.
+
+It looks for DAGs in the users home directory under /home/{user}/airflow/dags. Tasks are executed as new k8s pods if you use KubernetesPodOperator.
+
+Users can test dags here by adding them to their home directory.
+
+## Install/Upgrade the Chart
+
+This chart is run by the control panel so shouldn't need to be run manually other than testing.
+
+Run:
+
+```bash
+$ helm upgrade --dry-run --debug --install \
+{username}-airflow-sqlite \
+charts/airflow-sqlite \
+--namespace {user-namespace} \
+-f chart-env-config/ENV/airflow-sqlite.yml \
+--set Username={username} \
+--set aws.iamRole={iam-user-role} \
+--set toolsDomain={base-domain} \
+--set authProxy.auth0_domain={auth0domain}
+
+```

--- a/charts/airflow-sqlite/templates/_env.yml
+++ b/charts/airflow-sqlite/templates/_env.yml
@@ -1,0 +1,27 @@
+{{/*
+Shared env for workers
+*/}}
+{{- define "env" }}
+- name: SQL_ALCHEMY_CONN
+  value: sqlite:////home/{{ .Values.Username }}/airflow/db/airflow.sqlite
+- name: FERNET_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Release.Name }}
+      key: fernet-key
+- name: SECRET_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Release.Name }}
+      key: secret-key
+- name: SMTP_USER
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Release.Name }}
+      key: smtp-user
+- name: SMTP_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Release.Name }}
+      key: smtp-password
+{{- end }}

--- a/charts/airflow-sqlite/templates/_helpers.tpl
+++ b/charts/airflow-sqlite/templates/_helpers.tpl
@@ -1,0 +1,24 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 24 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 24 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Host
+e.g. username-airflow.example.com
+*/}}
+{{- define "host" -}}
+{{- (printf "%s-airflow.%s" .Values.Username .Values.toolsDomain) | lower -}}
+{{- end -}}

--- a/charts/airflow-sqlite/templates/configmap.yml
+++ b/charts/airflow-sqlite/templates/configmap.yml
@@ -75,7 +75,7 @@ data:
     # The base url of your website as airflow cannot guess what domain or
     # cname you are using. This is used in automated emails that
     # airflow sends to point links to the right web server
-    base_url = https://{{ printf "%s.%s" .Release.Name .Values.toolsDomain | lower }}
+    base_url = https://{{ template "host" . }}
     # The ip specified when starting the web server
     web_server_host = 0.0.0.0
     # The port on which to run the web server
@@ -135,7 +135,7 @@ data:
     # Consistent page size across all listing views in the UI
     page_size = 100
     # Use FAB-based webserver with RBAC feature
-    rbac = True
+    rbac = False
     # Enable werkzeug `ProxyFix` middleware
     enable_proxy_fix = {{ .Values.airflow.config.webserver.enable_proxy_fix }}
 
@@ -307,7 +307,7 @@ data:
     endpoint_url = http://localhost:8080
 
     [api]
-    auth_backend = airflow.api.auth.backend.default
+    # auth_backend = airflow.api.auth.backend.default
 
     [github_enterprise]
     api_rev = v3
@@ -321,57 +321,13 @@ data:
 
   webserver_config.py: |
     import os
-    from werkzeug.contrib.cache import RedisCache
     from airflow import configuration as conf
-    # from flask_appbuilder.security.manager import AUTH_LDAP
-    from flask_appbuilder.security.manager import AUTH_OAUTH
-    from flask_appbuilder.security.manager import AUTH_OID
-
-    from flask_appbuilder.security.manager import AUTH_DB
-    from fab_oidc.security import AirflowOIDCSecurityManager
-    from fab_oidc.store import WerkzeugCacheBackedCredentialStore
-
-    # from flask_appbuilder.security.manager import AUTH_OID
-    basedir = os.path.abspath(os.path.dirname(__file__))
 
     # The SQLAlchemy connection string.
     SQLALCHEMY_DATABASE_URI = conf.get('core', 'SQL_ALCHEMY_CONN')
 
     # Flask-WTF flag for CSRF
     CSRF_ENABLED = True
-    REDIS_HOST = os.environ.get('REDIS_HOST')
-    REDIS_PASSWORD = os.environ.get('REDIS_PASSWORD')
-    REDIS_TIMEOUT = int(os.environ.get('REDIS_TIMEOUT', 86400))
-    # AUTH_REMOTE_USER : Is for using REMOTE_USER from web server
-    # AUTH_OAUTH : Is for OAuth
-    # AUTH_TYPE = AUTH_REMOTE_USER
-    # Uncomment to setup Full admin role name
-    AUTH_ROLE_ADMIN = 'Admin'
-
-    # Uncomment to setup Public role name, no authentication needed
-    # AUTH_ROLE_PUBLIC = 'Public'
-    # Will allow user self registration
-    AUTH_USER_REGISTRATION = True
-
-    # The default user self registration role
-    AUTH_USER_REGISTRATION_ROLE = "Admin"
-
-    OIDC_CLIENT_SECRETS = '/root/airflow/client_secret.json'
-    SECURITY_MANAGER_CLASS = AirflowOIDCSecurityManager
-    OIDC_USER_INFO_ENABLED = False
-    OIDC_SCOPES = ['openid', 'email', 'profile']
-
-    if REDIS_HOST:
-      OIDC_CREDENTIALS_STORE = WerkzeugCacheBackedCredentialStore(
-        RedisCache(host=REDIS_HOST, password=REDIS_PASSWORD)
-      )
-
-
-    OPENID_PROVIDERS = [
-       { 'name': 'Yahoo', 'url': 'https://me.yahoo.com' },
-       { 'name': 'AOL', 'url': 'http://openid.aol.com/<username>' },
-       { 'name': 'Flickr', 'url': 'http://www.flickr.com/<username>' },
-       { 'name': 'MyOpenID', 'url': 'https://www.myopenid.com' }]
 
     PREFERRED_URL_SCHEME = 'https'
 

--- a/charts/airflow-sqlite/templates/configmap.yml
+++ b/charts/airflow-sqlite/templates/configmap.yml
@@ -1,0 +1,378 @@
+#  Licensed to the Apache Software Foundation (ASF) under one   *
+#  or more contributor license agreements.  See the NOTICE file *
+#  distributed with this work for additional information        *
+#  regarding copyright ownership.  The ASF licenses this file   *
+#  to you under the Apache License, Version 2.0 (the            *
+#  "License"); you may not use this file except in compliance   *
+#  with the License.  You may obtain a copy of the License at   *
+#                                                               *
+#    http://www.apache.org/licenses/LICENSE-2.0                 *
+#                                                               *
+#  Unless required by applicable law or agreed to in writing,   *
+#  software distributed under the License is distributed on an  *
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+#  KIND, either express or implied.  See the License for the    *
+#  specific language governing permissions and limitations      *
+#  under the License.                                           *
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: {{ .Release.Name }}
+data:
+  airflow.cfg: |
+    [core]
+    airflow_home = /root/airflow
+    dags_folder = /home/{{ .Values.Username }}/airflow/dags
+    base_log_folder = /home/{{ .Values.Username }}/airflow/logs
+    logging_level = INFO
+    executor = SequentialExecutor
+    parallelism = {{ .Values.airflow.config.core.parallelism }}
+    load_examples = False
+    plugins_folder = /root/airflow/plugins
+    sql_alchemy_conn = $SQL_ALCHEMY_CONN
+    fernet_key = $FERNET_KEY
+
+    [scheduler]
+    dag_dir_list_interval = 300
+    child_process_log_directory = /root/airflow/logs/scheduler
+    # Task instances listen for external kill signal (when you clear tasks
+    # from the CLI or the UI), this defines the frequency at which they should
+    # listen (in seconds).
+    job_heartbeat_sec = 5
+    max_threads = 2
+    # The scheduler constantly tries to trigger new tasks (look at the
+    # scheduler section in the docs for more information). This defines
+    # how often the scheduler should run (in seconds).
+    scheduler_heartbeat_sec = 5
+    # after how much time should the scheduler terminate in seconds
+    # -1 indicates to run continuously (see also num_runs)
+    run_duration = -1
+    # after how much time a new DAGs should be picked up from the filesystem
+    min_file_process_interval = 0
+    statsd_on = False
+    statsd_host = localhost
+    statsd_port = 8125
+    statsd_prefix = airflow
+    # How many seconds to wait between file-parsing loops to prevent the logs from being spammed.
+    min_file_parsing_loop_time = 1
+    print_stats_interval = 30
+    scheduler_zombie_task_threshold = 300
+    max_tis_per_query = 0
+    authenticate = False
+    # Turn off scheduler catchup by setting this to False.
+    # Default behavior is unchanged and
+    # Command Line Backfills still work, but the scheduler
+    # will not do scheduler catchup if this is False,
+    # however it can be set on a per DAG basis in the
+    # DAG definition (catchup)
+    catchup_by_default = False
+
+    [webserver]
+    # The base url of your website as airflow cannot guess what domain or
+    # cname you are using. This is used in automated emails that
+    # airflow sends to point links to the right web server
+    base_url = https://{{ printf "%s.%s" .Release.Name .Values.toolsDomain | lower }}
+    # The ip specified when starting the web server
+    web_server_host = 0.0.0.0
+    # The port on which to run the web server
+    web_server_port = 8080
+    # Paths to the SSL certificate and key for the web server. When both are
+    # provided SSL will be enabled. This does not change the web server port.
+    web_server_ssl_cert =
+    web_server_ssl_key =
+    # Number of seconds the webserver waits before killing gunicorn master that doesn't respond
+    web_server_master_timeout = 120
+    # Number of seconds the gunicorn webserver waits before timing out on a worker
+    web_server_worker_timeout = 120
+    # Number of workers to refresh at a time. When set to 0, worker refresh is
+    # disabled. When nonzero, airflow periodically refreshes webserver workers by
+    # bringing up new ones and killing old ones.
+    worker_refresh_batch_size = 1
+    # Number of seconds to wait before refreshing a batch of workers.
+    worker_refresh_interval = 30
+    # Secret key used to run your flask app
+    secret_key = $SECRET_KEY
+    # Number of workers to run the Gunicorn web server
+    workers = 4
+    # The worker class gunicorn should use. Choices include
+    # sync (default), eventlet, gevent
+    worker_class = sync
+    # Log files for the gunicorn webserver. '-' means log to stderr.
+    access_logfile = -
+    error_logfile = -
+    # Expose the configuration file in the web server
+    expose_config = False
+    # Set to true to turn on authentication:
+    # https://airflow.incubator.apache.org/security.html#web-authentication
+    authenticate = False
+    # Filter the list of dags by owner name (requires authentication to be enabled)
+    filter_by_owner = False
+    # Filtering mode. Choices include user (default) and ldapgroup.
+    # Ldap group filtering requires using the ldap backend
+    #
+    # Note that the ldap server needs the "memberOf" overlay to be set up
+    # in order to user the ldapgroup mode.
+    owner_mode = user
+    # Default DAG view.  Valid values are:
+    # tree, graph, duration, gantt, landing_times
+    dag_default_view = tree
+    # Default DAG orientation. Valid values are:
+    # LR (Left->Right), TB (Top->Bottom), RL (Right->Left), BT (Bottom->Top)
+    dag_orientation = LR
+    # Puts the webserver in demonstration mode; blurs the names of Operators for
+    # privacy.
+    demo_mode = False
+    # The amount of time (in secs) webserver will wait for initial handshake
+    # while fetching logs from other worker machine
+    log_fetch_timeout_sec = 5
+    # By default, the webserver shows paused DAGs. Flip this to hide paused
+    # DAGs by default
+    hide_paused_dags_by_default = False
+    # Consistent page size across all listing views in the UI
+    page_size = 100
+    # Use FAB-based webserver with RBAC feature
+    rbac = True
+    # Enable werkzeug `ProxyFix` middleware
+    enable_proxy_fix = {{ .Values.airflow.config.webserver.enable_proxy_fix }}
+
+    [smtp]
+    # If you want airflow to send emails on retries, failure, and you want to use
+    # the airflow.utils.email.send_email_smtp function, you have to configure an
+    # smtp server here
+    smtp_host = {{ .Values.airflow.config.smtp.smtp_host }}
+    smtp_starttls = {{ .Values.airflow.config.smtp.smtp_starttls }}
+    smtp_ssl = {{ .Values.airflow.config.smtp.smtp_ssl }}
+    # Uncomment and set the user/pass settings if you want to use SMTP AUTH
+    smtp_user = $SMTP_USER
+    smtp_password = $SMTP_PASSWORD
+    smtp_port = {{ .Values.airflow.config.smtp.smtp_port }}
+    smtp_mail_from = {{ .Values.airflow.config.smtp.smtp_mail_from }}
+
+    [kubernetes]
+    airflow_configmap = {{ .Release.Name }}
+    worker_container_repository = {{ .Values.airflow.image.repository }}
+    worker_container_tag = {{ .Values.airflow.image.tag }}
+    worker_container_image_pull_policy = {{ .Values.airflow.image.pullPolicy }}
+    delete_worker_pods = True
+    worker_service_account_name = {{ .Release.Name}}-tasks
+    git_repo = https://github.com/apache/incubator-airflow.git
+    git_branch = master
+    git_subpath = airflow/example_dags/
+    git_user =
+    git_password =
+    dags_volume_claim = nfs-home
+    dags_volume_subpath = /home/{{ .Values.Username }}/airflow/dags
+    logs_volume_claim = nfs-home
+    logs_volume_subpath = /home/{{ .Values.Username }}/airflow/logs
+    in_cluster = True
+    namespace = {{ .Release.Namespace }}
+    gcp_service_account_keys =
+    # For cloning DAGs from git repositories into volumes: https://github.com/kubernetes/git-sync
+
+    [kubernetes_secrets]
+    SQL_ALCHEMY_CONN = {{ .Release.Name }}=sql-alchemy-conn
+    FERNET_KEY = {{ .Release.Name }}=fernet-key
+    SMTP_USER = {{ .Release.Name }}=smtp-user
+    SMTP_PASSWORD = {{ .Release.Name }}=smtp-password
+
+    [hive]
+    # Default mapreduce queue for HiveOperator tasks
+    default_hive_mapred_queue =
+
+    [celery]
+    # This section only applies if you are using the CeleryExecutor in
+    # [core] section above
+    # The app name that will be used by celery
+    celery_app_name = airflow.executors.celery_executor
+    # The concurrency that will be used when starting workers with the
+    # "airflow worker" command. This defines the number of task instances that
+    # a worker will take, so size up your workers based on the resources on
+    # your worker box and the nature of your tasks
+    worker_concurrency = 16
+    # When you start an airflow worker, airflow starts a tiny web server
+    # subprocess to serve the workers local log files to the airflow main
+    # web server, who then builds pages and sends them to users. This defines
+    # the port on which the logs are served. It needs to be unused, and open
+    # visible from the main web server to connect into the workers.
+    worker_log_server_port = 8793
+    # The Celery broker URL. Celery supports RabbitMQ, Redis and experimentally
+    # a sqlalchemy database. Refer to the Celery documentation for more
+    # information.
+    # http://docs.celeryproject.org/en/latest/userguide/configuration.html#broker-settings
+    broker_url = sqla+mysql://airflow:airflow@localhost:3306/airflow
+    # The Celery result_backend. When a job finishes, it needs to update the
+    # metadata of the job. Therefore it will post a message on a message bus,
+    # or insert it into a database (depending of the backend)
+    # This status is used by the scheduler to update the state of the task
+    # The use of a database is highly recommended
+    # http://docs.celeryproject.org/en/latest/userguide/configuration.html#task-result-backend-settings
+    result_backend = db+mysql://airflow:airflow@localhost:3306/airflow
+    # Celery Flower is a sweet UI for Celery. Airflow has a shortcut to start
+    # it `airflow flower`. This defines the IP that Celery Flower runs on
+    flower_host = 0.0.0.0
+    # The root URL for Flower
+    # Ex: flower_url_prefix = /flower
+    flower_url_prefix =
+    # This defines the port that Celery Flower runs on
+    flower_port = 5555
+    # Default queue that tasks get assigned to and that worker listen on.
+    default_queue = default
+    # Import path for celery configuration options
+    celery_config_options = airflow.config_templates.default_celery.DEFAULT_CELERY_CONFIG
+
+    [celery_broker_transport_options]
+    # The visibility timeout defines the number of seconds to wait for the worker
+    # to acknowledge the task before the message is redelivered to another worker.
+    # Make sure to increase the visibility timeout to match the time of the longest
+    # ETA you're planning to use. Especially important in case of using Redis or SQS
+    visibility_timeout = 21600
+    # In case of using SSL
+    ssl_active = False
+    ssl_key =
+    ssl_cert =
+    ssl_cacert =
+
+    [dask]
+    # This section only applies if you are using the DaskExecutor in
+    # [core] section above
+    # The IP address and port of the Dask cluster's scheduler.
+    cluster_address = 127.0.0.1:8786
+    # TLS/ SSL settings to access a secured Dask scheduler.
+    tls_ca =
+    tls_cert =
+    tls_key =
+
+    [ldap]
+    # set this to ldaps://<your.ldap.server>:<port>
+    uri =
+    user_filter = objectClass=*
+    user_name_attr = uid
+    group_member_attr = memberOf
+    superuser_filter =
+    data_profiler_filter =
+    bind_user = cn=Manager,dc=example,dc=com
+    bind_password = insecure
+    basedn = dc=example,dc=com
+    cacert = /etc/ca/ldap_ca.crt
+    search_scope = LEVEL
+
+    [mesos]
+    # Mesos master address which MesosExecutor will connect to.
+    master = localhost:5050
+    # The framework name which Airflow scheduler will register itself as on mesos
+    framework_name = Airflow
+    # Number of cpu cores required for running one task instance using
+    # 'airflow run <dag_id> <task_id> <execution_date> --local -p <pickle_id>'
+    # command on a mesos slave
+    task_cpu = 1
+    # Memory in MB required for running one task instance using
+    # 'airflow run <dag_id> <task_id> <execution_date> --local -p <pickle_id>'
+    # command on a mesos slave
+    task_memory = 256
+    # Enable framework checkpointing for mesos
+    # See http://mesos.apache.org/documentation/latest/slave-recovery/
+    checkpoint = False
+    # Failover timeout in milliseconds.
+    # When checkpointing is enabled and this option is set, Mesos waits
+    # until the configured timeout for
+    # the MesosExecutor framework to re-register after a failover. Mesos
+    # shuts down running tasks if the
+    # MesosExecutor framework fails to re-register within this timeframe.
+    # failover_timeout = 604800
+    # Enable framework authentication for mesos
+    # See http://mesos.apache.org/documentation/latest/configuration/
+    authenticate = False
+    # Mesos credentials, if authentication is enabled
+    # default_principal = admin
+    # default_secret = admin
+    # Optional Docker Image to run on slave before running the command
+    # This image should be accessible from mesos slave i.e mesos slave
+    # should be able to pull this docker image before executing the command.
+    # docker_image_slave = puckel/docker-airflow
+
+    [kerberos]
+    ccache = /tmp/airflow_krb5_ccache
+    # gets augmented with fqdn
+    principal = airflow
+    reinit_frequency = 3600
+    kinit_path = kinit
+    keytab = airflow.keytab
+
+    [cli]
+    api_client = airflow.api.client.json_client
+    endpoint_url = http://localhost:8080
+
+    [api]
+    auth_backend = airflow.api.auth.backend.default
+
+    [github_enterprise]
+    api_rev = v3
+
+    [admin]
+    # UI to hide sensitive variable fields when set to True
+    hide_sensitive_variable_fields = True
+
+    [elasticsearch]
+    elasticsearch_host =
+
+  webserver_config.py: |
+    import os
+    from werkzeug.contrib.cache import RedisCache
+    from airflow import configuration as conf
+    # from flask_appbuilder.security.manager import AUTH_LDAP
+    from flask_appbuilder.security.manager import AUTH_OAUTH
+    from flask_appbuilder.security.manager import AUTH_OID
+
+    from flask_appbuilder.security.manager import AUTH_DB
+    from fab_oidc.security import AirflowOIDCSecurityManager
+    from fab_oidc.store import WerkzeugCacheBackedCredentialStore
+
+    # from flask_appbuilder.security.manager import AUTH_OID
+    basedir = os.path.abspath(os.path.dirname(__file__))
+
+    # The SQLAlchemy connection string.
+    SQLALCHEMY_DATABASE_URI = conf.get('core', 'SQL_ALCHEMY_CONN')
+
+    # Flask-WTF flag for CSRF
+    CSRF_ENABLED = True
+    REDIS_HOST = os.environ.get('REDIS_HOST')
+    REDIS_PASSWORD = os.environ.get('REDIS_PASSWORD')
+    REDIS_TIMEOUT = int(os.environ.get('REDIS_TIMEOUT', 86400))
+    # AUTH_REMOTE_USER : Is for using REMOTE_USER from web server
+    # AUTH_OAUTH : Is for OAuth
+    # AUTH_TYPE = AUTH_REMOTE_USER
+    # Uncomment to setup Full admin role name
+    AUTH_ROLE_ADMIN = 'Admin'
+
+    # Uncomment to setup Public role name, no authentication needed
+    # AUTH_ROLE_PUBLIC = 'Public'
+    # Will allow user self registration
+    AUTH_USER_REGISTRATION = True
+
+    # The default user self registration role
+    AUTH_USER_REGISTRATION_ROLE = "Admin"
+
+    OIDC_CLIENT_SECRETS = '/root/airflow/client_secret.json'
+    SECURITY_MANAGER_CLASS = AirflowOIDCSecurityManager
+    OIDC_USER_INFO_ENABLED = False
+    OIDC_SCOPES = ['openid', 'email', 'profile']
+
+    if REDIS_HOST:
+      OIDC_CREDENTIALS_STORE = WerkzeugCacheBackedCredentialStore(
+        RedisCache(host=REDIS_HOST, password=REDIS_PASSWORD)
+      )
+
+
+    OPENID_PROVIDERS = [
+       { 'name': 'Yahoo', 'url': 'https://me.yahoo.com' },
+       { 'name': 'AOL', 'url': 'http://openid.aol.com/<username>' },
+       { 'name': 'Flickr', 'url': 'http://www.flickr.com/<username>' },
+       { 'name': 'MyOpenID', 'url': 'https://www.myopenid.com' }]
+
+    PREFERRED_URL_SCHEME = 'https'
+
+    SESSION_COOKIE_SECURE = True

--- a/charts/airflow-sqlite/templates/ingress.yml
+++ b/charts/airflow-sqlite/templates/ingress.yml
@@ -1,0 +1,21 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: {{ .Release.Name }}
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+spec:
+  rules:
+  - host: {{ template "host" . }}
+    http:
+      paths:
+      - backend:
+          serviceName: {{ .Release.Name }}
+          servicePort: 80
+  tls:
+    - hosts:
+      - {{ template "host" . }}

--- a/charts/airflow-sqlite/templates/scheduler-deployment.yml
+++ b/charts/airflow-sqlite/templates/scheduler-deployment.yml
@@ -1,0 +1,79 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-scheduler
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: {{ .Release.Name }}
+    component: scheduler
+  annotations:
+    checksum/config: {{ include (print $.Template.BasePath "/configmap.yml") . | sha256sum }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}
+      component: scheduler
+
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}
+        component: scheduler
+    spec:
+      serviceAccountName: {{ .Release.Name }}
+      initContainers:
+      - name: "init"
+        image: {{ .Values.airflow.image.repository }}:{{ .Values.airflow.image.tag }}
+        imagePullPolicy: {{ .Values.airflow.image.pullPolicy }}
+        volumeMounts:
+          - name: {{ .Release.Name }}-config
+            mountPath: /root/airflow/airflow.cfg
+            subPath: airflow.cfg
+          - name: home
+            mountPath: "/home/{{ .Values.Username }}"
+        env:
+          {{ include "env" . | indent 10 }}
+        command:
+          - "bash"
+        args:
+          - "-cx"
+          - >
+              ls -al /home &&
+              cd /home/{{ .Values.Username }} &&
+              mkdir -p airflow &&
+              cd /home/{{ .Values.Username }}/airflow &&
+              mkdir -p dags &&
+              mkdir -p db &&
+              mkdir -p logs &&
+              chmod -R 777 /home/{{ .Values.Username }}/airflow &&
+              cd `python -c "import site; print(site.getsitepackages()[0])"` &&
+              airflow initdb && airflow upgradedb
+
+      containers:
+        - name: scheduler
+          image: {{ .Values.airflow.image.repository }}:{{ .Values.airflow.image.tag }}
+          imagePullPolicy: {{ .Values.airflow.image.pullPolicy }}
+          command:
+            - "airflow"
+          args:
+            - "scheduler"
+          ports:
+            - name: http
+              containerPort: {{ .Values.airflow.image.port }}
+          env:
+            {{ include "env" . | indent 12 }}
+          volumeMounts:
+            - name: {{ .Release.Name }}-config
+              mountPath: /root/airflow/airflow.cfg
+              subPath: airflow.cfg
+            - name: home
+              mountPath: "/home/{{ .Values.Username }}"
+      volumes:
+        - name: {{ .Release.Name }}-config
+          configMap:
+            name: {{ .Release.Name }}
+        - name: home
+          persistentVolumeClaim:
+            claimName: nfs-home

--- a/charts/airflow-sqlite/templates/secrets.yml
+++ b/charts/airflow-sqlite/templates/secrets.yml
@@ -18,6 +18,3 @@ data:
   secret-key: {{ printf .Values.airflow.secretKey | b64enc | quote }}
   smtp-user: {{ printf .Values.airflow.config.smtp.smtp_user | b64enc | quote }}
   smtp-password: {{ printf .Values.airflow.config.smtp.smtp_password | b64enc | quote }}
-  admin-username: {{ printf .Values.airflow.admin.username | b64enc | quote }}
-  admin-password: {{ printf .Values.airflow.admin.password | b64enc | quote }}
-  admin-email: {{ printf .Values.airflow.admin.email | b64enc | quote }}

--- a/charts/airflow-sqlite/templates/secrets.yml
+++ b/charts/airflow-sqlite/templates/secrets.yml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app: {{ .Release.Name }}
+    host: {{ template "host" . }}
+type: Opaque
+data:
+  auth0_domain: {{ .Values.authProxy.auth0_domain | b64enc | quote }}
+  auth0_client_id: {{ .Values.authProxy.auth0_client_id | b64enc | quote }}
+  auth0_client_secret: {{ .Values.authProxy.auth0_client_secret | b64enc | quote }}
+  auth0_callback_url: {{ printf "https://%s/callback" (include "host" .) | b64enc | quote }}
+  cookie_secret: {{ .Values.cookie_secret | b64enc | quote }}
+  fernet-key: {{ printf .Values.airflow.fernetKey | b64enc | quote }}
+  secret-key: {{ printf .Values.airflow.secretKey | b64enc | quote }}
+  smtp-user: {{ printf .Values.airflow.config.smtp.smtp_user | b64enc | quote }}
+  smtp-password: {{ printf .Values.airflow.config.smtp.smtp_password | b64enc | quote }}
+  admin-username: {{ printf .Values.airflow.admin.username | b64enc | quote }}
+  admin-password: {{ printf .Values.airflow.admin.password | b64enc | quote }}
+  admin-email: {{ printf .Values.airflow.admin.email | b64enc | quote }}

--- a/charts/airflow-sqlite/templates/service-account.yml
+++ b/charts/airflow-sqlite/templates/service-account.yml
@@ -1,0 +1,142 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-tasks
+  namespace: {{ .Release.Namespace }}
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: pod-reader
+rules:
+- apiGroups: [""] # "" indicates the core API group
+  resources: ["pods"]
+  verbs: ["get", "watch", "list"]
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: pod-deleter
+rules:
+- apiGroups: [""] # "" indicates the core API group
+  resources: ["pods"]
+  verbs: ["delete"]
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: pod-creator
+rules:
+- apiGroups: [""] # "" indicates the core API group
+  resources: ["pods"]
+  verbs: ["create"]
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: pod-logs
+rules:
+- apiGroups: [""] # "" indicates the core API group
+  resources: ["pods/log"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: service-can-read-pods
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: pod-reader
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: service-can-read-pods-logs
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: pod-logs
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: service-can-delete-pods
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: pod-deleter
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: service-can-create-pods
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: pod-creator
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tasks-can-create-pods
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-tasks
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: pod-creator
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tasks-can-get-pods-logs
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-tasks
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: pod-logs
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tasks-can-get-pods
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-tasks
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: pod-reader
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/airflow-sqlite/templates/service.yml
+++ b/charts/airflow-sqlite/templates/service.yml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: {{ .Release.Name }}
+    component: "webserver"
+spec:
+  sessionAffinity: ClientIP
+  selector:
+    app: {{ .Release.Name }}
+    component: "webserver"
+  ports:
+    - port: 80
+      targetPort: {{ .Values.authProxy.containerPort }}

--- a/charts/airflow-sqlite/templates/webserver-deployment.yml
+++ b/charts/airflow-sqlite/templates/webserver-deployment.yml
@@ -1,0 +1,106 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-webserver
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: {{ .Release.Name }}
+    component: webserver
+  annotations:
+    checksum/config: {{ include (print $.Template.BasePath "/configmap.yml") . | sha256sum }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}
+      component: webserver
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}
+        component: webserver
+        airflow-redis-client: "false"
+    spec:
+      serviceAccountName: {{ .Release.Name }}
+      containers:
+        - name: {{ .Chart.Name }}-auth-proxy
+          image: {{ .Values.authProxy.image }}:{{ .Values.authProxy.tag }}
+          imagePullPolicy: {{ .Values.authProxy.imagePullPolicy }}
+          ports:
+            - name: proxy
+              containerPort: {{ .Values.authProxy.containerPort }}
+          env:
+            - name: TARGET_URL
+              value: http://localhost:{{ .Values.airflow.image.port }}
+            - name: AUTH0_DOMAIN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}
+                  key: auth0_domain
+            - name: AUTH0_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}
+                  key: auth0_client_id
+            - name: AUTH0_CALLBACK_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}
+                  key: auth0_callback_url
+            - name: AUTH0_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}
+                  key: auth0_client_secret
+            - name: COOKIE_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}
+                  key: cookie_secret
+            - name: NICKNAME_RE
+              value: {{ .Values.Username }}
+            - name: COOKIE_MAXAGE
+              value: {{ .Values.authProxy.cookie_maxage | quote }}
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: proxy
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: proxy
+            initialDelaySeconds: 20
+            periodSeconds: 10
+          resources:
+{{ toYaml .Values.authProxy.resources | indent 12 }}
+        - name: webserver
+          image: {{ .Values.airflow.image.repository }}:{{ .Values.airflow.image.tag }}
+          imagePullPolicy: {{ .Values.airflow.image.pullPolicy }}
+          command:
+            - "airflow"
+          args:
+            - "webserver"
+          ports:
+            - name: http
+              containerPort: {{ .Values.airflow.image.port }}
+          env:
+            {{ include "env" . | indent 12 }}
+          volumeMounts:
+            - name: {{ .Release.Name }}-config
+              mountPath: /root/airflow/airflow.cfg
+              subPath: airflow.cfg
+            - name: {{ .Release.Name }}-config
+              mountPath: /root/airflow/webserver_config.py
+              subPath: webserver_config.py
+            - name: home
+              mountPath: "/home/{{ .Values.Username }}"
+      volumes:
+        - name: {{ .Release.Name }}-config
+          configMap:
+            name: {{ .Release.Name }}
+        - name: home
+          persistentVolumeClaim:
+            claimName: nfs-home

--- a/charts/airflow-sqlite/templates/webserver-deployment.yml
+++ b/charts/airflow-sqlite/templates/webserver-deployment.yml
@@ -14,7 +14,7 @@ spec:
     matchLabels:
       app: {{ .Release.Name }}
       component: webserver
-  replicas: 3
+  replicas: 1
   template:
     metadata:
       labels:

--- a/charts/airflow-sqlite/templates/webserver-deployment.yml
+++ b/charts/airflow-sqlite/templates/webserver-deployment.yml
@@ -59,7 +59,7 @@ spec:
                   name: {{ .Release.Name }}
                   key: cookie_secret
             - name: NICKNAME_RE
-              value: {{ .Values.Username }}
+              value: "^{{ .Values.Username }}$"
             - name: COOKIE_MAXAGE
               value: {{ .Values.authProxy.cookie_maxage | quote }}
           readinessProbe:

--- a/charts/airflow-sqlite/values.yaml
+++ b/charts/airflow-sqlite/values.yaml
@@ -21,15 +21,13 @@ airflow:
       smtp_mail_from: airflow@example.com
     webserver:
       enable_proxy_fix: "True"
-  admin:
-    username: ""
-    password: ""
-    email: ""
+service:
+  port: 80
 authProxy:
-  image: quay.io/mojanalytics/auth-proxy
-  tag: v2.0.1
-  imagePullPolicy: IfNotPresent
-  containerPort: 3000
+  image: "quay.io/mojanalytics/auth-proxy"
+  tag: "v2.0.1"
+  imagePullPolicy: "IfNotPresent"
+  containerPort: "3000"
   resources:
     limits:
       cpu: 100m
@@ -40,7 +38,7 @@ authProxy:
   auth0_domain: ""
   auth0_client_id: ""
   auth0_client_secret: "" # put dummy value here to stop helm lint complaining
-  cookie_maxage: 36000 #10 hours
+  cookie_maxage: 36000
 aws:
   iamRole: ""
   defaultRegion: "eu-west-1"

--- a/charts/airflow-sqlite/values.yaml
+++ b/charts/airflow-sqlite/values.yaml
@@ -1,0 +1,50 @@
+toolsDomain: "tools.EXAMPLE.COM"
+Username: ""
+airflow:
+  secretKey: ""
+  fernetKey: ""
+  image:
+    repository: "quay.io/mojanalytics/airflow"
+    tag: "1.10.2-2"
+    pullPolicy: "IfNotPresent"
+    port: "8080"
+  config:
+    core:
+      parallelism: 1
+    smtp:
+      smtp_host: localhost
+      smtp_starttls: true
+      smtp_ssl: false
+      smtp_user: airflow
+      smtp_password: airflow
+      smtp_port: 25
+      smtp_mail_from: airflow@example.com
+    webserver:
+      enable_proxy_fix: "True"
+  admin:
+    username: ""
+    password: ""
+    email: ""
+authProxy:
+  image: quay.io/mojanalytics/auth-proxy
+  tag: v2.0.1
+  imagePullPolicy: IfNotPresent
+  containerPort: 3000
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 25m
+      memory: 64Mi
+  auth0_domain: ""
+  auth0_client_id: ""
+  auth0_client_secret: "" # put dummy value here to stop helm lint complaining
+  cookie_maxage: 36000 #10 hours
+aws:
+  iamRole: ""
+  defaultRegion: "eu-west-1"
+cookie_secret: ""
+kube2iam:
+  allowedRoles: ".*"
+  serviceAccountName: ""

--- a/charts/cpanel/CHANGELOG.md
+++ b/charts/cpanel/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.1.3] - 2019-02-01
+### Changed
+- AUpdate latest cpanel with tiller 2.13.0
 
 ## [1.1.2] - 2019-02-01
 ### Changed

--- a/charts/cpanel/Chart.yaml
+++ b/charts/cpanel/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Analytics Platform Control Panel API webapp
 name: cpanel
-version: 1.1.2
+version: 1.1.3

--- a/charts/cpanel/values.yaml
+++ b/charts/cpanel/values.yaml
@@ -4,7 +4,7 @@ API:
   Branch: "master"
   Image:
     Repository: quay.io/mojanalytics/control-panel
-    Tag: 0.1.0
+    Tag: v0.13.6
     PullPolicy: IfNotPresent
   Environment:
     DEBUG: "False"

--- a/charts/init-user/CHANGELOG.md
+++ b/charts/init-user/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [0.1.4] - 2018-03-13 
+## Lock down namespace assume role
+- Restrict a users namespace to only assuming the role from their own user
+
+
 ## [0.1.2] - 2018-03-13 
 ## OIDC Username Claim
 - Add idp prefix to username in Clusterrolebinding

--- a/charts/init-user/Chart.yaml
+++ b/charts/init-user/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: init-user
-version: 0.1.3
+version: 0.1.4

--- a/charts/init-user/templates/namespace.yml
+++ b/charts/init-user/templates/namespace.yml
@@ -4,4 +4,4 @@ metadata:
   name: user-{{ .Values.Username }}
   annotations:
     iam.amazonaws.com/allowed-roles: |
-      ["{{ .Values.Env }}_.*"]
+      ["{{ .Values.Env }}_user_{{ .Values.Username }}"]

--- a/charts/jupyter-lab/CHANGELOG.md
+++ b/charts/jupyter-lab/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [0.3.1] - 2019-04-25
+### Changed
+- Set auth-proxy name regex to exact match of username
+
+
 ## [0.3.0] - 2019-04-04
 ### Changed
 - Added `"mojanalytics.xyz/idleable": "true"` label to pods. This will

--- a/charts/jupyter-lab/Chart.yaml
+++ b/charts/jupyter-lab/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: Jupyter Lab with Auth0 authentication proxy
 name: jupyter-lab
-version: 0.3.0
+version: 0.3.1
 appVersion: v0.6.5

--- a/charts/jupyter-lab/templates/deployment.yaml
+++ b/charts/jupyter-lab/templates/deployment.yaml
@@ -64,7 +64,7 @@ spec:
                   name: {{ template "fullname" . }}
                   key: cookie_secret
             - name: NICKNAME_RE
-              value: {{ .Values.Username }}
+              value: "^{{ .Values.Username }}$"
             - name: COOKIE_MAXAGE
               value: {{ .Values.authProxy.cookie_maxage | quote }}
             - name: TUNNEL_ENABLED


### PR DESCRIPTION
Add a helm chart for airflow-sqlite.

This is so the users can test dags running as their own user before merging and releasing them.

This will be run on demand by users via the control panel. The chart will run airflow using sqlite as the database in the users kubernetes namespace.

The users home directory will be mounted and airflow will use `/home/username/airflow/dags` as the dags directory.