### PR TITLE
rbac 0.3.0: `generic-support` users can read namespaces and pods logs

### DIFF
--- a/charts/rbac/CHANGELOG.md
+++ b/charts/rbac/CHANGELOG.md
@@ -4,17 +4,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+## [0.3.0] - 2019-04-16
+### Added
+- Allow __generic-support__ users to list namespaces. This is to make their
+  life easier as they'll find the right namespace without necessarily go
+  through the Control Panel. They can already read and list pods so this doesn't
+  give support people much more power. [Trello](https://trello.com/c/meCj3EJ6).
+- Allow __generic-support__ users to read pods logs
+
+
 ## [0.2.0] - 2018-01-24
 ### Added
 - Created `ClusterRoleBinding` for __generic-support__ users. [Trello](https://trello.com/c/LsQcIL12)
+
 
 ## [0.1.2] - 2018-12-18
 ### Added
 - Created `ClusterRoleBinding` for __kubelet-api__ user. [Trello](https://trello.com/c/YNDTzEIx)
 
+
 ## [0.1.1] - 2018-08-06
 ### Added
 - Created `Rolebinding` for airflow support that binds to __app-support__ `Clusterrole`. [Trello](https://trello.com/c/Tq1xQCf3)
+
 
 ## [0.1.0] - 2018-07-23
 ### Initial Commit

--- a/charts/rbac/Chart.yaml
+++ b/charts/rbac/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: User and Group RBAC resources
 name: rbac
-version: 0.2.0
+version: 0.3.0

--- a/charts/rbac/templates/generic-support.yaml
+++ b/charts/rbac/templates/generic-support.yaml
@@ -16,9 +16,10 @@ rules:
       - "services"
       - "deployments"
       - "pods"
-      # - "pods/log"
+      - "pods/log"
       - "cronjobs"
       - "jobs"
+      - "namespaces"
     verbs: ["get", "list", "watch"]
 
 ---


### PR DESCRIPTION
- Allow __generic-support__ users to list namespaces. This is to make their
  life easier as they'll find the right namespace without necessarily go
  through the Control Panel. They can already read and list pods so this doesn't
  give support people much more power.
- Allow __generic-support__ users to read pods logs

Ticket: https://trello.com/c/meCj3EJ6