### PR TITLE
`auth-proxy` don't run as root

### DIFF
--- a/charts/airflow-sqlite/CHANGELOG.md
+++ b/charts/airflow-sqlite/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+## [0.0.2] - 2019-04-26
+### Changed
+`auth-proxy` don't run as root anymore.
+
+
 ## [0.0.1] - 2019-04-04
 ### Added
 First attempt at self service Airflow running on Sqlite with no Redis

--- a/charts/airflow-sqlite/Chart.yaml
+++ b/charts/airflow-sqlite/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 description: Airflow with sqlite. Tasks are run as pods
 name: airflow-sqlite
 icon: https://airflow.incubator.apache.org/_images/pin_large.png
-version: 0.0.1
+version: 0.0.2
 appVersion: 1.10.2

--- a/charts/airflow-sqlite/values.yaml
+++ b/charts/airflow-sqlite/values.yaml
@@ -25,7 +25,7 @@ service:
   port: 80
 authProxy:
   image: "quay.io/mojanalytics/auth-proxy"
-  tag: "v2.0.1"
+  tag: "v2.1.0"
   imagePullPolicy: "IfNotPresent"
   containerPort: "3000"
   resources:

--- a/charts/jupyter-lab/CHANGELOG.md
+++ b/charts/jupyter-lab/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [0.3.2] - 2019-04-26
+### Changed
+- `auth-proxy` container don't run as root user
+
+
 ## [0.3.1] - 2019-04-25
 ### Changed
 - Set auth-proxy name regex to exact match of username

--- a/charts/jupyter-lab/Chart.yaml
+++ b/charts/jupyter-lab/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: Jupyter Lab with Auth0 authentication proxy
 name: jupyter-lab
-version: 0.3.1
+version: 0.3.2
 appVersion: v0.6.5

--- a/charts/jupyter-lab/values.yaml
+++ b/charts/jupyter-lab/values.yaml
@@ -10,7 +10,7 @@ service:
 
 authProxy:
   image: quay.io/mojanalytics/auth-proxy
-  tag: v2.0.1
+  tag: v2.1.0
   imagePullPolicy: IfNotPresent
   containerPort: 3000
   resources:

--- a/charts/webapp/CHANGELOG.md
+++ b/charts/webapp/CHANGELOG.md
@@ -4,20 +4,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+## [1.3.25] - 2019-04-26
+### Changed
+- `auth-proxy` container don't run as `root` (bumped
+  image tag `v0.1.9` => `v2.1.0`)
+
+
 ## [1.3.24] - 2019-04-02
 ### FluentD Upgrade cipher version
 - Add `ssl_version TLSv1_2` to output configuration
 
+
 ## [1.3.23] - 2019-03-28
 ### FluentD Upgrade
-- Set `target_type_key` to `true` in output configuration 
+- Set `target_type_key` to `true` in output configuration
 - Set `log_es_400_reason` to `true` in output configuration
 - Removed record transformer `types` key because it's not needed
 - Changed FluentD image tag from `v2.0.4` to `v2.4.0`
 
+
 ## [1.3.22] - 2019-03-14
 ### FluentD Resources
-- Increased cpu shares for fluentd. Requests and limits from 200m to 500m and 500m to 1 core respectively 
+- Increased cpu shares for fluentd. Requests and limits from 200m to 500m and 500m to 1 core respectively
+
 
 ## [1.3.21] - 2019-03-08
 ### FluentD Resources

--- a/charts/webapp/Chart.yaml
+++ b/charts/webapp/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 description: webapp Helm chart for Kubernetes
 name: webapp
 fluentdVersion: 2.5.0
-version: 1.3.24
+version: 1.3.25

--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -20,7 +20,7 @@ AuthProxy:
     Domain: "AUTH0_USER.eu.auth0.com"
   Image:
     Repository: quay.io/mojanalytics/auth-proxy
-    Tag: "v0.1.9"
+    Tag: "v2.1.0"
     PullPolicy: "IfNotPresent"
 AWS:
   IAMRole: ""


### PR DESCRIPTION
Bumped `auth-proxy` image tag to [`v2.1.0`](https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v2.1.0) in the following helm charts:
- `charts/airflow-sqlite`
- `jupyter-lab`
- `webapp`

The proxy doesn't run as `root` anymore.