### PR TITLE
pod-cleaner 0.0.1: Initial release

### DIFF
--- a/charts/pod-cleaner/.helmignore
+++ b/charts/pod-cleaner/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/pod-cleaner/CHANGELOG.md
+++ b/charts/pod-cleaner/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+
+## [0.0.1] - 2019-03-30
+### Added
+Initial release, yay!

--- a/charts/pod-cleaner/Chart.yaml
+++ b/charts/pod-cleaner/Chart.yaml
@@ -1,0 +1,4 @@
+name: pod-cleaner
+description: Delete old completed pods
+version: 0.0.1
+appVersion: 0.0.1

--- a/charts/pod-cleaner/README.md
+++ b/charts/pod-cleaner/README.md
@@ -1,0 +1,50 @@
+# Pod Cleaner
+
+Deletes old pods in `Succeeded`/`Failed` phase:
+
+> Succeeded: All Containers in the Pod have terminated in success, and will not be restarted.
+
+> Failed: All Containers in the Pod have terminated, and at least one Container has terminated in failure. That is, the Container either exited with non-zero status or was terminated by the system.
+
+See kubernetes documentation on [pods phases](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase).
+
+
+## Installing the chart
+
+```bash
+$ helm upgrade --dry-run --debug --install pod-cleaner charts/pod-cleaner --namespace airflow
+```
+
+Install the helm chart in the namespace where you want the cron job
+to delete old pods.
+
+**NOTE**: Remove `--dry-run` and adjust the values file path.
+
+
+## Configuration
+
+| Parameter | Description | Default |
+| --------- | ----------- | ------- |
+| `deleteFailedAfter` | Number of days after which a pod in `Failed` phase should be deleted | `10` |
+| `deleteSucceededAfter` | Number of days after which a pod in `Succeeded` phase should be deleted | `3` |
+| `schedule` | When to run the job that delete the old pods | `"0 5 * * *"` - every day at 5am, see https://kubernetes.io/docs/user-guide/cron-jobs/#schedule |
+
+
+## Caviats
+Pods which are failing but that have `RestartPolicy=Always` will not be
+deleted because from kubernetes perspective these are still in `Running`
+phase.
+
+
+## Technical details
+The cron job will start two containers which will run the `pod_cleaner.sh`
+script. One script will delete the old pods in `Succeeded` phase, the other
+will delete the ones in `Failed` phase.
+
+The script will get the pods in the specified phase and then use `awk`/`date`
+to determine if the pod is old enough to qualify for deletion.
+
+**NOTE** The script relies on GNU `date` and its `--date` argument to generate
+the date used for the comparison. This means that it would not work on
+distributions which ship with a non-GNU version of `date` out of the box,
+e.g. Alpine (unless you explicitly install GNU date of course).

--- a/charts/pod-cleaner/README.md
+++ b/charts/pod-cleaner/README.md
@@ -30,7 +30,7 @@ to delete old pods.
 | `schedule` | When to run the job that delete the old pods | `"0 5 * * *"` - every day at 5am, see https://kubernetes.io/docs/user-guide/cron-jobs/#schedule |
 
 
-## Caviats
+## Caveats
 Pods which are failing but that have `RestartPolicy=Always` will not be
 deleted because from kubernetes perspective these are still in `Running`
 phase.

--- a/charts/pod-cleaner/files/pod_cleaner.sh
+++ b/charts/pod-cleaner/files/pod_cleaner.sh
@@ -1,0 +1,24 @@
+#! /usr/bin/env bash
+
+set -e
+set -o pipefail
+
+
+if [[ -z "$POD_CLEANER_PHASE" ]]; then
+    echo "Must provide POD_CLEANER_PHASE, see https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase"
+    exit 1
+fi
+
+if [[ -z "$POD_CLEANER_DAYS" ]]; then
+    echo "Must provide POD_CLEANER_DAYS"
+    exit 1
+fi
+
+
+echo "Deleting pods in phase '$POD_CLEANER_PHASE' created more than $POD_CLEANER_DAYS days ago..."
+
+DATE_CMD="date -d'now -$POD_CLEANER_DAYS days' -Is --utc"
+CUTOFF=$(eval $DATE_CMD)
+
+# Delete pods in $POD_CLEANER_PHASE phase created before $CUTOFF
+kubectl get pods --field-selector status.phase==$POD_CLEANER_PHASE -o go-template --template '{{range .items}}{{.metadata.name}} {{.metadata.creationTimestamp}}{{"\n"}}{{end}}' | awk '$2 < "'$CUTOFF'" { print $1 }' | xargs --no-run-if-empty kubectl delete pod

--- a/charts/pod-cleaner/templates/NOTES.txt
+++ b/charts/pod-cleaner/templates/NOTES.txt
@@ -1,0 +1,3 @@
+All done, cron job is scheduled for "{{ .Values.schedule }}":
+- successful pods will be deleted after {{ .Values.deleteSucceededAfter }} days
+- failed pods will be deleted after {{ .Values.deleteFailedAfter }} days

--- a/charts/pod-cleaner/templates/_helpers.tpl
+++ b/charts/pod-cleaner/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "pod-cleaner.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "pod-cleaner.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "pod-cleaner.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/pod-cleaner/templates/configmap.yaml
+++ b/charts/pod-cleaner/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app: {{ .Release.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+data:
+{{ (.Files.Glob "files/*").AsConfig | indent 2 }}

--- a/charts/pod-cleaner/templates/cronjob.yaml
+++ b/charts/pod-cleaner/templates/cronjob.yaml
@@ -1,0 +1,51 @@
+apiVersion: batch/v2alpha1
+kind: CronJob
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app: {{ .Release.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    type: cron
+spec:
+  schedule: "{{ .Values.schedule }}"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: {{ .Release.Name }}
+            chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        spec:
+          serviceAccountName: {{ .Release.Name }}
+          containers:
+          - name: succeeded-pods-cleaner
+            image: "{{ .Values.image }}"
+            command:
+            - "scripts/pod_cleaner.sh"
+            env:
+            - name: POD_CLEANER_PHASE
+              value: Succeeded
+            - name: POD_CLEANER_DAYS
+              value: '{{ .Values.deleteSucceededAfter }}'
+            volumeMounts:
+              - name: {{ .Release.Name }}
+                mountPath: "/scripts"
+          - name: failed-pods-cleaner
+            image: "{{ .Values.image }}"
+            command:
+            - "scripts/pod_cleaner.sh"
+            env:
+            - name: POD_CLEANER_PHASE
+              value: Failed
+            - name: POD_CLEANER_DAYS
+              value: '{{ .Values.deleteFailedAfter }}'
+            volumeMounts:
+              - name: {{ .Release.Name }}
+                mountPath: "/scripts"
+          restartPolicy: Never
+          volumes:
+          - name: {{ .Release.Name }}
+            configMap:
+              name: {{ .Release.Name }}
+              defaultMode: 500

--- a/charts/pod-cleaner/templates/role.yaml
+++ b/charts/pod-cleaner/templates/role.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - "pods"
+    verbs:
+      - "list"
+      - "delete"

--- a/charts/pod-cleaner/templates/rolebinding.yaml
+++ b/charts/pod-cleaner/templates/rolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  name: {{ .Release.Name }}
+  kind: Role
+subjects:
+  - apiGroup: ""
+    name: {{ .Release.Name }}
+    kind: ServiceAccount
+    namespace: {{ .Release.Namespace }}

--- a/charts/pod-cleaner/templates/serviceaccount.yaml
+++ b/charts/pod-cleaner/templates/serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app: {{ .Release.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/charts/pod-cleaner/values.yaml
+++ b/charts/pod-cleaner/values.yaml
@@ -1,0 +1,12 @@
+# Delete pods after...
+deleteFailedAfter: 10 # days
+deleteSucceededAfter: 3 # days
+
+# Docker image
+image: "bitnami/kubectl:1.14.1"
+
+# Schedule when to run
+#   min    hour   day    month (Sun-Sat)
+# "(0-59) (0-23) (1-31) (1-12) (0-6)"
+# See https://kubernetes.io/docs/user-guide/cron-jobs/#schedule
+schedule: "0 5 * * *"


### PR DESCRIPTION
CronJob which deletes old pods in "Succeeded" and "Failed" phase after a
certain number of days.

See kubernetes documentation on phases: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase

Ticket: https://trello.com/c/i1Nxclu3/197-airflow-remove-superseded-pods