### PR TITLE
pod-cleaner 0.1.0: Also delete `Pending` pods

### DIFF
--- a/charts/pod-cleaner/CHANGELOG.md
+++ b/charts/pod-cleaner/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-## [0.0.1] - 2019-03-30
+## [0.1.0] - 2019-05-03
+### Added
+Also delete pods in `Pending` phase.
+
+
+## [0.0.1] - 2019-04-30
 ### Added
 Initial release, yay!

--- a/charts/pod-cleaner/Chart.yaml
+++ b/charts/pod-cleaner/Chart.yaml
@@ -1,4 +1,4 @@
 name: pod-cleaner
-description: Delete old completed pods
-version: 0.0.1
-appVersion: 0.0.1
+description: Delete old succeeded/failed/pending pods
+version: 0.1.0
+appVersion: 0.1.0

--- a/charts/pod-cleaner/README.md
+++ b/charts/pod-cleaner/README.md
@@ -1,12 +1,17 @@
 # Pod Cleaner
 
-Deletes old pods in `Succeeded`/`Failed` phase:
+Deletes old pods in `Succeeded`/`Failed`/`Pending` phase:
 
 > Succeeded: All Containers in the Pod have terminated in success, and will not be restarted.
 
 > Failed: All Containers in the Pod have terminated, and at least one Container has terminated in failure. That is, the Container either exited with non-zero status or was terminated by the system.
 
+> Pending: The Pod has been accepted by the Kubernetes system, but one or more of the Container images has not been created.
+
 See kubernetes documentation on [pods phases](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase).
+
+**NOTE**: A pod with status `ErrImagePull` or `ImagePullBackOff` is in
+`Pending` phase.
 
 
 ## Installing the chart
@@ -26,6 +31,7 @@ to delete old pods.
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
 | `deleteFailedAfter` | Number of days after which a pod in `Failed` phase should be deleted | `10` |
+| `deletePendingAfter` | Number of days after which a pod in `Pending` phase should be deleted | `10` |
 | `deleteSucceededAfter` | Number of days after which a pod in `Succeeded` phase should be deleted | `3` |
 | `schedule` | When to run the job that delete the old pods | `"0 5 * * *"` - every day at 5am, see https://kubernetes.io/docs/user-guide/cron-jobs/#schedule |
 
@@ -37,12 +43,11 @@ phase.
 
 
 ## Technical details
-The cron job will start two containers which will run the `pod_cleaner.sh`
-script. One script will delete the old pods in `Succeeded` phase, the other
-will delete the ones in `Failed` phase.
+The cron job will start a container for each of the phases, they'll run
+the `pod_cleaner.sh` script with the right arguments.
 
-The script will get the pods in the specified phase and then use `awk`/`date`
-to determine if the pod is old enough to qualify for deletion.
+This script gets the pods in the specified phase and then use `awk`/`date`
+to determine the pods which are old enough to qualify for deletion.
 
 **NOTE** The script relies on GNU `date` and its `--date` argument to generate
 the date used for the comparison. This means that it would not work on

--- a/charts/pod-cleaner/templates/NOTES.txt
+++ b/charts/pod-cleaner/templates/NOTES.txt
@@ -1,3 +1,4 @@
 All done, cron job is scheduled for "{{ .Values.schedule }}":
 - successful pods will be deleted after {{ .Values.deleteSucceededAfter }} days
 - failed pods will be deleted after {{ .Values.deleteFailedAfter }} days
+- pending pods will be deleted after {{ .Values.deletePendingAfter }} days

--- a/charts/pod-cleaner/templates/cronjob.yaml
+++ b/charts/pod-cleaner/templates/cronjob.yaml
@@ -19,18 +19,6 @@ spec:
         spec:
           serviceAccountName: {{ .Release.Name }}
           containers:
-          - name: succeeded-pods-cleaner
-            image: "{{ .Values.image }}"
-            command:
-            - "scripts/pod_cleaner.sh"
-            env:
-            - name: POD_CLEANER_PHASE
-              value: Succeeded
-            - name: POD_CLEANER_DAYS
-              value: '{{ .Values.deleteSucceededAfter }}'
-            volumeMounts:
-              - name: {{ .Release.Name }}
-                mountPath: "/scripts"
           - name: failed-pods-cleaner
             image: "{{ .Values.image }}"
             command:
@@ -40,6 +28,30 @@ spec:
               value: Failed
             - name: POD_CLEANER_DAYS
               value: '{{ .Values.deleteFailedAfter }}'
+            volumeMounts:
+              - name: {{ .Release.Name }}
+                mountPath: "/scripts"
+          - name: pending-pods-cleaner
+            image: "{{ .Values.image }}"
+            command:
+            - "scripts/pod_cleaner.sh"
+            env:
+            - name: POD_CLEANER_PHASE
+              value: Pending
+            - name: POD_CLEANER_DAYS
+              value: '{{ .Values.deletePendingAfter }}'
+            volumeMounts:
+              - name: {{ .Release.Name }}
+                mountPath: "/scripts"
+          - name: succeeded-pods-cleaner
+            image: "{{ .Values.image }}"
+            command:
+            - "scripts/pod_cleaner.sh"
+            env:
+            - name: POD_CLEANER_PHASE
+              value: Succeeded
+            - name: POD_CLEANER_DAYS
+              value: '{{ .Values.deleteSucceededAfter }}'
             volumeMounts:
               - name: {{ .Release.Name }}
                 mountPath: "/scripts"

--- a/charts/pod-cleaner/values.yaml
+++ b/charts/pod-cleaner/values.yaml
@@ -1,5 +1,6 @@
 # Delete pods after...
 deleteFailedAfter: 10 # days
+deletePendingAfter: 10 # days
 deleteSucceededAfter: 3 # days
 
 # Docker image


### PR DESCRIPTION
When a `Pod` fails to start because for example the image cannot be pulled
the `Pod` will be in `Pending` phase.
It makes sense to delete old pods which are failing to start.