### PR TITLE
Webapp: Bump Auth Proxy Version

### DIFF
--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -20,7 +20,7 @@ AuthProxy:
     Domain: "AUTH0_USER.eu.auth0.com"
   Image:
     Repository: quay.io/mojanalytics/auth-proxy
-    Tag: "v2.1.0"
+    Tag: "v2.2.0"
     PullPolicy: "IfNotPresent"
 AWS:
   IAMRole: ""


### PR DESCRIPTION
New auth proxy version can now tell the webapp the email address of the logged
in user via the `USER_EMAIL` header.

This header will not be set unless authentication is enabled