### PR TITLE
RStudio 1.10.0: Bumped RStudio to version 1.2

### DIFF
--- a/charts/rstudio/CHANGELOG.md
+++ b/charts/rstudio/CHANGELOG.md
@@ -5,6 +5,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [2.1.0] - 2019-07-08
+### Changed
+Using newer docker image with RStudio 1.2.
+The rest should be the same, same R version, still using conda, etc...
+
+See: https://blog.rstudio.com/2019/04/30/rstudio-1-2-release/
+
+
 ## [2.0.1] - 2019-05-21
 ### Changed
 Bumped `auth-proxy` to version [`v4.0.1`](https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v4.0.1).
@@ -26,22 +34,21 @@ so we don't need to maintain two separate auth proxies.
 ### Changed
 Use `rstudio-auth-proxy` [`v2.0.0`](https://github.com/ministryofjustice/analytics-platform-rstudio-auth-proxy/releases/tag/v2.0.0).
 
-## [1.9.0] - 2019-03-10
 
+## [1.9.0] - 2019-03-10
 ### Changed
 - Version of RStudio image with conda (r3.5.1-py3.7-conda-1)
 
   New image able to recover from bad conda install better
 
-## [1.8.0] - 2019-03-15
 
+## [1.8.0] - 2019-03-15
 ### Changed
 - Added `"mojanalytics.xyz/idleable": "true"` label to pods. This will
   make the "don't idle if CPU usage is above X%" logic work again.
 
 
 ## [1.7.0] - 2019-03-15
-
 ### Changed
 - added `host=` label to everything, this will help simplify the idler
 - don't set unused `TOOLS_DOMAIN` environment variable
@@ -51,7 +58,6 @@ Use `rstudio-auth-proxy` [`v2.0.0`](https://github.com/ministryofjustice/analyti
 
 
 ## [1.6.0] - 2019-02-14
-
 ### Changed
 - Version of RStudio image with conda (r3.5.1-py3.7-conda)
 - it doesn't point at the cran proxy
@@ -61,7 +67,6 @@ Use `rstudio-auth-proxy` [`v2.0.0`](https://github.com/ministryofjustice/analyti
 
 
 ## [1.5.8] - 2018-10-17
-
 ### Changed
 - Version of rstudio image (3.4.2-6), it now points at the cran proxy, has boto3
   installed by default and is able to build udunits2 r package
@@ -69,7 +74,6 @@ Use `rstudio-auth-proxy` [`v2.0.0`](https://github.com/ministryofjustice/analyti
 
 
 ## [1.5.7] - 2018-10-17
-
 ### Changed
 - Don't hardcode target port in `Service`, use provided value
 - Renamed ports in `Deployment` to be more explicit and avoid any possible

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: RStudio with Auth0 authentication proxy
 name: rstudio
-version: 2.0.1
-appVersion: "RStudio: 1.1.463+conda, R: 3.5.1, Python: 3.7 patch: 1"
+version: 2.1.0
+appVersion: "RStudio: 1.2.1335+conda, R: 3.5.1, Python: 3.7.1, patch: 3"

--- a/charts/rstudio/values.yaml
+++ b/charts/rstudio/values.yaml
@@ -30,7 +30,7 @@ rstudio:
   port: "8787"
   image:
     repository: quay.io/mojanalytics/rstudio
-    tag: "1.2.1335-r3.5.1-python3.7.1-conda-2"
+    tag: "1.2.1335-r3.5.1-python3.7.1-conda-3"
     pullPolicy: "IfNotPresent"
     # init option allows you to run an init container that does the setup of the conda environment
     # this is quite slow and if it was run as part of the main container then it would cause problems.

--- a/charts/rstudio/values.yaml
+++ b/charts/rstudio/values.yaml
@@ -30,7 +30,7 @@ rstudio:
   port: "8787"
   image:
     repository: quay.io/mojanalytics/rstudio
-    tag: "r3.5.1-py3.7-conda-1"
+    tag: "1.2.1335-r3.5.1-python3.7.1-conda-2"
     pullPolicy: "IfNotPresent"
     # init option allows you to run an init container that does the setup of the conda environment
     # this is quite slow and if it was run as part of the main container then it would cause problems.


### PR DESCRIPTION
RStudio release notes: https://blog.rstudio.com/2019/04/30/rstudio-1-2-release/
Ticket: https://trello.com/c/rguKYALc/214-try-to-upgrade-rstudio-docker-image-to-use-latest-version