### PR TITLE
rstudio: Attempt to use generic auth-proxy

### DIFF
--- a/charts/rstudio/CHANGELOG.md
+++ b/charts/rstudio/CHANGELOG.md
@@ -5,6 +5,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [2.0.0] - 2019-05-20
+### Changed
+Using `auth-proxy` [`v4.0.0`](https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v4.0.0)
+instead of the special `rstudio-auth-proxy`.
+
+The logic to add the RStudio secure cookie is now in the `auth-proxy`
+so we don't need to maintain two separate auth proxies.
+
+
 ## [1.10.0] - 2019-05-15
 ### Changed
 Use `rstudio-auth-proxy` [`v2.0.0`](https://github.com/ministryofjustice/analytics-platform-rstudio-auth-proxy/releases/tag/v2.0.0).

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: RStudio with Auth0 authentication proxy
 name: rstudio
-version: 1.10.0
+version: 2.0.0
 appVersion: "RStudio: 1.1.463+conda, R: 3.5.1, Python: 3.7 patch: 1"

--- a/charts/rstudio/README.md
+++ b/charts/rstudio/README.md
@@ -6,7 +6,7 @@
 To install/upgrade an rstudio instance for the user specified in the username variable (Github username):
 
 ```bash
-$ helm upgrade --dry-run --debug --install USERNAME-rstudio --namespace user-USERNAME --set username=USERNAME charts/rstudio -f chart-env-config/ENV/rstudio.yml
+$ helm upgrade --dry-run --debug --install USERNAME-rstudio --namespace user-USERNAME --set username=USERNAME --set aws.iamRole=ENV_user_USERNAME charts/rstudio -f chart-env-config/ENV/rstudio.yml
 ```
 
 The instance will be available in <https://USERNAME-rstudio.tools.ENV.mojanalytics.xyz>.

--- a/charts/rstudio/templates/deployment.yml
+++ b/charts/rstudio/templates/deployment.yml
@@ -80,8 +80,15 @@ spec:
                 secretKeyRef:
                   name: {{ template "fullname" . }}
                   key: cookie_secret
-            - name: NICKNAME_RE
-              value: "^{{ .Values.username }}$"
+            - name: USER
+              value: "{{ .Values.username }}"
+            - name: RSTUDIO_ADD_SECURE_COOKIE
+              value: "true"
+            - name: RSTUDIO_SECURE_COOKIE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "fullname" . }}
+                  key: secure_cookie_key
             - name: COOKIE_MAXAGE
               value: "{{ .Values.authProxy.cookieMaxAge }}"
           readinessProbe:

--- a/charts/rstudio/templates/deployment.yml
+++ b/charts/rstudio/templates/deployment.yml
@@ -53,67 +53,49 @@ spec:
             - name: proxy
               containerPort: {{ .Values.authProxy.express.port }}
           env:
-            - name: USER
-              value: {{ .Values.username }}
-            - name: APP_PROTOCOL
-              value: {{ .Values.authProxy.appProtocol }}
-            - name: APP_HOST
-              valueFrom:
-                secretKeyRef:
-                  name: {{ template "fullname" . }}
-                  key: app_host
-            - name: AUTH0_CLIENT_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: {{ template "fullname" . }}
-                  key: client_secret
-            - name: AUTH0_CLIENT_ID
-              valueFrom:
-                secretKeyRef:
-                  name: {{ template "fullname" . }}
-                  key: client_id
+            - name: TARGET_URL
+              value: http://localhost:{{ .Values.rstudio.port }}
             - name: AUTH0_DOMAIN
               valueFrom:
                 secretKeyRef:
                   name: {{ template "fullname" . }}
                   key: domain
+            - name: AUTH0_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "fullname" . }}
+                  key: client_id
             - name: AUTH0_CALLBACK_URL
               valueFrom:
                 secretKeyRef:
                   name: {{ template "fullname" . }}
                   key: callback_url
+            - name: AUTH0_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "fullname" . }}
+                  key: client_secret
             - name: COOKIE_SECRET
               valueFrom:
                 secretKeyRef:
                   name: {{ template "fullname" . }}
                   key: cookie_secret
-            - name: SECURE_COOKIE_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ template "fullname" . }}
-                  key: secure_cookie_key
+            - name: NICKNAME_RE
+              value: "^{{ .Values.username }}$"
             - name: COOKIE_MAXAGE
               value: "{{ .Values.authProxy.cookieMaxAge }}"
-            - name: PROXY_TARGET_HOST
-              value: localhost
-            - name: PROXY_TARGET_PORT
-              value: "{{ .Values.rstudio.port }}"
-            - name: EXPRESS_HOST
-              value: {{ .Values.authProxy.express.host }}
-            - name: EXPRESS_PORT
-              value: "{{ .Values.authProxy.express.port }}"
           readinessProbe:
             httpGet:
               path: /healthz
               port: proxy
-            initialDelaySeconds: 5
-            periodSeconds: 2
+            initialDelaySeconds: 15
+            periodSeconds: 10
           livenessProbe:
             httpGet:
               path: /healthz
               port: proxy
-            initialDelaySeconds: 10
-            periodSeconds: 2
+            initialDelaySeconds: 20
+            periodSeconds: 10
           resources:
 {{ toYaml .Values.authProxy.resources | indent 12 }}
 

--- a/charts/rstudio/values.yaml
+++ b/charts/rstudio/values.yaml
@@ -15,8 +15,8 @@ authProxy:
     host: "0.0.0.0"
     port: 3000
   image:
-    repository: quay.io/mojanalytics/rstudio-auth-proxy
-    tag: "v2.0.0"
+    repository: quay.io/mojanalytics/auth-proxy
+    tag: "v2.1.0"
     pullPolicy: "IfNotPresent"
   resources:
     limits:

--- a/charts/rstudio/values.yaml
+++ b/charts/rstudio/values.yaml
@@ -16,7 +16,7 @@ authProxy:
     port: 3000
   image:
     repository: quay.io/mojanalytics/auth-proxy
-    tag: "v2.1.0"
+    tag: "v4.0.0"
     pullPolicy: "IfNotPresent"
   resources:
     limits:


### PR DESCRIPTION
RStudio is the only application not using our [generic auth-proxy].

RStudio was using a special proxy which set an authentication header.
This commit attempts to disable the RStudio authentication.
By doing so we can use the plain auth proxy instead.

NOTE: The configuration for the proxy was copied and tweaked from the
jupyter-lab helm chart.

[generic auth-proxy]: https://github.com/ministryofjustice/analytics-platform-auth-proxy

Ticket: https://trello.com/c/5twZHrb4/215-try-to-replace-custom-rstudio-auth-proxy-with-our-usual-generic-one

**TODO**
- [x] Once we're happy with the [`auth-proxy` changes](https://github.com/ministryofjustice/analytics-platform-auth-proxy/pull/122), tag the release as `v4.0.0`.