### PR TITLE
FluentD Update Repository

### DIFF
--- a/charts/webapp/CHANGELOG.md
+++ b/charts/webapp/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.3.26] - 2019-05-13
+### FluentD update repository
+- Changed image repo from `gcr.io/google-containers/fluentd-elasticsearch` to `gcr.io/fluentd-elasticsearch/fluentd` 
+- Changed __fluentd__ image tag from `v2.4.0` to `v2.5.0` 
 
 ## [1.3.25] - 2019-04-26
 ### Changed

--- a/charts/webapp/Chart.yaml
+++ b/charts/webapp/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: webapp Helm chart for Kubernetes
 name: webapp
-fluentdVersion: 2.5.0
-version: 1.3.25
+fluentdVersion: 1.4.0
+version: 1.3.26

--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -25,9 +25,10 @@ AuthProxy:
 AWS:
   IAMRole: ""
 Fluentd:
+  # https://github.com/kubernetes/kubernetes/blob/master/cluster/addons/fluentd-elasticsearch/fluentd-es-image/
   Image:
-    Repository: gcr.io/google-containers/fluentd-elasticsearch
-    Tag: v2.4.0
+    Repository: gcr.io/fluentd-elasticsearch/fluentd
+    Tag: v2.5.0
     PullPolicy: "IfNotPresent"
 Elasticsearch:
   Scheme: "http"


### PR DESCRIPTION
`gcr.io/google-containers/fluentd-elasticsearch` has been deprecated in
favour of `gcr.io/fluentd-elasticsearch/fluentd`.

Application versions remain unchanged

- Changed image repo from `gcr.io/google-containers/fluentd-elasticsearch` to `gcr.io/fluentd-elasticsearch/fluentd`
- Changed __fluentd__ image tag from `v2.4.0` to `v2.5.0`