### PR TITLE
Bump Auth Proxies for Jupyter / Rstudio / Webapp charts

### DIFF
--- a/charts/jupyter-lab/CHANGELOG.md
+++ b/charts/jupyter-lab/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [0.4.0] - 2019-05-15
+### Changed
+- `auth-proxy` to version [`v3.1.0`](https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v3.1.0)
+
 ## [0.3.2] - 2019-04-26
 ### Changed
 - `auth-proxy` container don't run as root user

--- a/charts/jupyter-lab/Chart.yaml
+++ b/charts/jupyter-lab/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: Jupyter Lab with Auth0 authentication proxy
 name: jupyter-lab
-version: 0.3.2
+version: 0.4.0
 appVersion: v0.6.5

--- a/charts/jupyter-lab/values.yaml
+++ b/charts/jupyter-lab/values.yaml
@@ -10,7 +10,7 @@ service:
 
 authProxy:
   image: quay.io/mojanalytics/auth-proxy
-  tag: v2.1.0
+  tag: v3.1.0
   imagePullPolicy: IfNotPresent
   containerPort: 3000
   resources:

--- a/charts/rstudio/CHANGELOG.md
+++ b/charts/rstudio/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [1.10.0] - 2019-05-15
+### Changed
+Use `rstudio-auth-proxy` [`v2.0.0`](https://github.com/ministryofjustice/analytics-platform-rstudio-auth-proxy/releases/tag/v2.0.0).
+
 ## [1.9.0] - 2019-03-10
 
 ### Changed

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: RStudio with Auth0 authentication proxy
 name: rstudio
-version: 1.9.0
+version: 1.10.0
 appVersion: "RStudio: 1.1.463+conda, R: 3.5.1, Python: 3.7 patch: 1"

--- a/charts/rstudio/values.yaml
+++ b/charts/rstudio/values.yaml
@@ -16,7 +16,7 @@ authProxy:
     port: 3000
   image:
     repository: quay.io/mojanalytics/rstudio-auth-proxy
-    tag: "v1.4.3"
+    tag: "v2.0.0"
     pullPolicy: "IfNotPresent"
   resources:
     limits:

--- a/charts/webapp/CHANGELOG.md
+++ b/charts/webapp/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - 2019-05-15
+### Changed
+- `auth-proxy` to version [`v3.1.0`](https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v3.1.0)
+
 ## [1.3.26] - 2019-05-13
 ### FluentD update repository
 - Changed image repo from `gcr.io/google-containers/fluentd-elasticsearch` to `gcr.io/fluentd-elasticsearch/fluentd` 

--- a/charts/webapp/Chart.yaml
+++ b/charts/webapp/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 description: webapp Helm chart for Kubernetes
 name: webapp
 fluentdVersion: 1.4.0
-version: 1.3.26
+version: 1.4.0

--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -20,7 +20,7 @@ AuthProxy:
     Domain: "AUTH0_USER.eu.auth0.com"
   Image:
     Repository: quay.io/mojanalytics/auth-proxy
-    Tag: "v2.2.0"
+    Tag: "v3.1.0"
     PullPolicy: "IfNotPresent"
 AWS:
   IAMRole: ""


### PR DESCRIPTION
This commit updates the Jupyter / Rstudio / Webapp charts to use the latest
versions of the proxy they use.
In Rstudio's case this is v2.0.0 of rstudio-auth-proxy, and for the others it is
`v3.0.0` of the generic auth proxy