### PR TITLE
webapp 1.4.1: Use auth-proxy `v4.0.1`

### DIFF
--- a/charts/webapp/CHANGELOG.md
+++ b/charts/webapp/CHANGELOG.md
@@ -4,14 +4,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.4.1] - 2019-05-21
+### Changed
+Bumped `auth-proxy` to version [`v4.0.1`](https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v4.0.1).
+
+This version of the proxy reads the `X-Forwarded-For` header
+but fixes the problem for websockets not able to read the headers.
+
+
 ## [1.4.0] - 2019-05-15
 ### Changed
 - `auth-proxy` to version [`v3.1.0`](https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v3.1.0)
 
+
 ## [1.3.26] - 2019-05-13
 ### FluentD update repository
-- Changed image repo from `gcr.io/google-containers/fluentd-elasticsearch` to `gcr.io/fluentd-elasticsearch/fluentd` 
-- Changed __fluentd__ image tag from `v2.4.0` to `v2.5.0` 
+- Changed image repo from `gcr.io/google-containers/fluentd-elasticsearch` to `gcr.io/fluentd-elasticsearch/fluentd`
+- Changed __fluentd__ image tag from `v2.4.0` to `v2.5.0`
 
 ## [1.3.25] - 2019-04-26
 ### Changed

--- a/charts/webapp/Chart.yaml
+++ b/charts/webapp/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 description: webapp Helm chart for Kubernetes
 name: webapp
 fluentdVersion: 1.4.0
-version: 1.4.0
+version: 1.4.1

--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -20,7 +20,7 @@ AuthProxy:
     Domain: "AUTH0_USER.eu.auth0.com"
   Image:
     Repository: quay.io/mojanalytics/auth-proxy
-    Tag: "v3.1.0"
+    Tag: "v4.0.1"
     PullPolicy: "IfNotPresent"
 AWS:
   IAMRole: ""


### PR DESCRIPTION
Reverted use of `X-Forwarded-For` (but working for websockets)