### PR TITLE
rstudio 2.0.1: Bumped auth-proxy image tag

### DIFF
--- a/charts/rstudio/CHANGELOG.md
+++ b/charts/rstudio/CHANGELOG.md
@@ -5,6 +5,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [2.0.1] - 2019-05-21
+### Changed
+Bumped `auth-proxy` to version [`v4.0.1`](https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v4.0.1).
+
+This version of the proxy reads the `X-Forwarded-For` header
+but fixes the problem for websockets not able to read the headers.
+
+
 ## [2.0.0] - 2019-05-20
 ### Changed
 Using `auth-proxy` [`v4.0.0`](https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v4.0.0)

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: RStudio with Auth0 authentication proxy
 name: rstudio
-version: 2.0.0
+version: 2.0.1
 appVersion: "RStudio: 1.1.463+conda, R: 3.5.1, Python: 3.7 patch: 1"

--- a/charts/rstudio/values.yaml
+++ b/charts/rstudio/values.yaml
@@ -16,7 +16,7 @@ authProxy:
     port: 3000
   image:
     repository: quay.io/mojanalytics/auth-proxy
-    tag: "v4.0.0"
+    tag: "v4.0.1"
     pullPolicy: "IfNotPresent"
   resources:
     limits:


### PR DESCRIPTION
Bumped `auth-proxy` to version [`v4.0.1`](https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v4.0.1).

 This version of the proxy reads the `X-Forwarded-For` header
but fixes the problem for websockets not able to read the headers.
