### PR TITLE
Bumped auth-proxy tag in airflow-sqlite/jupyter-lab

### DIFF
--- a/charts/airflow-sqlite/CHANGELOG.md
+++ b/charts/airflow-sqlite/CHANGELOG.md
@@ -5,6 +5,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [0.2.1] - 2019-05-22
+### Changed
+Bumped `auth-proxy` to version [`v4.0.1`](https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v4.0.1).
+
+This version removes support for `NICKNAME_RE` and replaces it with
+a simple equality check with the `USER` environment variable.
+
+
 ## [0.2.0] - 2019-01-01
 ### Changed
 Set all containers to run in a single pod so it can be managed from the control panel.

--- a/charts/airflow-sqlite/Chart.yaml
+++ b/charts/airflow-sqlite/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 description: Airflow with sqlite. Tasks are run as pods
 name: airflow-sqlite
 icon: https://airflow.incubator.apache.org/_images/pin_large.png
-version: 0.2.0
+version: 0.2.1
 appVersion: 1.10.3

--- a/charts/airflow-sqlite/templates/deployment.yml
+++ b/charts/airflow-sqlite/templates/deployment.yml
@@ -86,8 +86,8 @@ spec:
                 secretKeyRef:
                   name: {{ .Release.Name }}
                   key: cookie_secret
-            - name: NICKNAME_RE
-              value: "^{{ .Values.Username }}$"
+            - name: USER
+              value: "{{ .Values.Username }}"
             - name: COOKIE_MAXAGE
               value: {{ .Values.authProxy.cookie_maxage | quote }}
           readinessProbe:

--- a/charts/airflow-sqlite/values.yaml
+++ b/charts/airflow-sqlite/values.yaml
@@ -17,7 +17,7 @@ service:
   port: 80
 authProxy:
   image: "quay.io/mojanalytics/auth-proxy"
-  tag: "v2.1.0"
+  tag: "v4.0.1"
   imagePullPolicy: "IfNotPresent"
   containerPort: "3000"
   resources:

--- a/charts/jupyter-lab/CHANGELOG.md
+++ b/charts/jupyter-lab/CHANGELOG.md
@@ -5,9 +5,18 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [0.4.1] - 2019-05-22
+### Changed
+Bumped `auth-proxy` to version [`v4.0.1`](https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v4.0.1).
+
+This version removes support for `NICKNAME_RE` and replaces it with
+a simple equality check with the `USER` environment variable.
+
+
 ## [0.4.0] - 2019-05-15
 ### Changed
 - `auth-proxy` to version [`v3.1.0`](https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v3.1.0)
+
 
 ## [0.3.2] - 2019-04-26
 ### Changed

--- a/charts/jupyter-lab/Chart.yaml
+++ b/charts/jupyter-lab/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: Jupyter Lab with Auth0 authentication proxy
 name: jupyter-lab
-version: 0.4.0
+version: 0.4.1
 appVersion: v0.6.5

--- a/charts/jupyter-lab/templates/deployment.yaml
+++ b/charts/jupyter-lab/templates/deployment.yaml
@@ -63,8 +63,8 @@ spec:
                 secretKeyRef:
                   name: {{ template "fullname" . }}
                   key: cookie_secret
-            - name: NICKNAME_RE
-              value: "^{{ .Values.Username }}$"
+            - name: USER
+              value: "{{ .Values.Username }}"
             - name: COOKIE_MAXAGE
               value: {{ .Values.authProxy.cookie_maxage | quote }}
             - name: TUNNEL_ENABLED

--- a/charts/jupyter-lab/values.yaml
+++ b/charts/jupyter-lab/values.yaml
@@ -10,7 +10,7 @@ service:
 
 authProxy:
   image: quay.io/mojanalytics/auth-proxy
-  tag: v3.1.0
+  tag: v4.0.1
   imagePullPolicy: IfNotPresent
   containerPort: 3000
   resources:


### PR DESCRIPTION
Bumped `auth-proxy` to version [`v4.0.1`](https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v4.0.1).

This version removes support for `NICKNAME_RE` and replaces it with
a simple equality check with the `USER` environment variable.