### PR TITLE
network-policies 0.2.0: Restrict traffic to apps' pods

### DIFF
--- a/charts/network-policies/.helmignore
+++ b/charts/network-policies/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/network-policies/CHANGELOG.md
+++ b/charts/network-policies/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+
+## [0.1.0] - 2019-06-07
+### Initial
+Initial release with Network Policies to restrict
+traffic to webapps' pods.
+
+**NOTE**: Due to a limitation in older versions of Calico
+the network policy will allow all traffic from the `default`
+namespace rather than allow only traffic from Ingress controller'
+pods. I've added a temporary (ugly-named by design) flag which
+can be removed once we upgrade Calico (named `TEMPORARYnetworkPoliciesWithNamespaceAndPodSelectorsSupported`)

--- a/charts/network-policies/CHANGELOG.md
+++ b/charts/network-policies/CHANGELOG.md
@@ -5,6 +5,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [0.2.1] - 2019-06-11
+### Changes
+Always restrict traffic to only the Ingress Controller pods rather than all
+the pods in the namespace where Ingress Controller's pods run.
+This was due to a limitation of an older version of Calico and it's not
+necessary anymore now so I've simplified the template.
+
+
 ## [0.2.0] - 2019-06-10
 ### Changes
 Added Helm tests so that we can verify the network policies

--- a/charts/network-policies/CHANGELOG.md
+++ b/charts/network-policies/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [0.2.0] - 2019-06-10
+### Changes
+Added Helm tests so that we can verify the network policies
+are working as expected.
+
+
 ## [0.1.0] - 2019-06-07
 ### Initial
 Initial release with Network Policies to restrict

--- a/charts/network-policies/Chart.yaml
+++ b/charts/network-policies/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Helm chart with NetworkPolicy resources
 name: network-policies
-version: 0.2.0
+version: 0.2.1

--- a/charts/network-policies/Chart.yaml
+++ b/charts/network-policies/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Helm chart with NetworkPolicy resources
 name: network-policies
-version: 0.1.0
+version: 0.2.0

--- a/charts/network-policies/Chart.yaml
+++ b/charts/network-policies/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: Helm chart with NetworkPolicy resources
+name: network-policies
+version: 0.1.0

--- a/charts/network-policies/README.md
+++ b/charts/network-policies/README.md
@@ -40,22 +40,14 @@ not used until we upgrade Calico `v3.1.3` which supports the
 
 ## Tests
 This helm chart comes with some test to verify that the
-network policies are only allowing traffic from the Ingress
-controller's pods:
+network policies are only allowing external traffic from the
+Ingress controller's pods:
 
 ```sh
-$ helm test network-policies
+$ helm test network-policies --cleanup
 
 RUNNING: network-policies-test-traffic-from-pods-in-ns-blocked
 PASSED: network-policies-test-traffic-from-pods-in-ns-blocked
 RUNNING: network-policies-test-traffic-from-ingress-allowed
 PASSED: network-policies-test-traffic-from-ingress-allowed
-```
-
-Caviat: Helm cleanup mechanism is not quite working
-which means you'll have to delete previous run's pods or
-helm test will complain ("pod already exists"):
-
-```
-$ kubectl delete pod -lapp.kubernetes.io/name=network-policies
 ```

--- a/charts/network-policies/README.md
+++ b/charts/network-policies/README.md
@@ -36,3 +36,26 @@ Listing only the required params here. See `/chart-env-config/` for more details
 **NOTE**: The `ingressController.podsMatchLabels` value is currently
 not used until we upgrade Calico `v3.1.3` which supports the
 [combined use of `namespaceSelector` and `podSelector`](https://github.com/projectcalico/libcalico-go/pull/872).
+
+
+## Tests
+This helm chart comes with some test to verify that the
+network policies are only allowing traffic from the Ingress
+controller's pods:
+
+```sh
+$ helm test network-policies
+
+RUNNING: network-policies-test-traffic-from-pods-in-ns-blocked
+PASSED: network-policies-test-traffic-from-pods-in-ns-blocked
+RUNNING: network-policies-test-traffic-from-ingress-allowed
+PASSED: network-policies-test-traffic-from-ingress-allowed
+```
+
+Caviat: Helm cleanup mechanism is not quite working
+which means you'll have to delete previous run's pods or
+helm test will complain ("pod already exists"):
+
+```
+$ kubectl delete pod -lapp.kubernetes.io/name=network-policies
+```

--- a/charts/network-policies/README.md
+++ b/charts/network-policies/README.md
@@ -1,0 +1,38 @@
+# network-policies Helm Chart
+
+Helm chart to deploy `NetworkPolicy` resources.
+
+At this stage this is mainly to deploy the `NetworkPolicy` that
+block all ingress traffic a part from the one coming from the
+ingress controller.
+
+**NOTE** Your Kubernetes cluster needs to support `NetworkPolicy`
+resources and it needs to use a network plugin which implements
+them, e.g. Calico.
+
+
+## Installing the Chart
+
+To install the chart:
+
+```bash
+$ helm upgrade --install --dry-run --debug network-policies charts/network-policies --namespace default
+```
+
+**NOTE**: Remove `--dry-run` once you're happy with the output.
+
+
+## Configuration
+
+Listing only the required params here. See `/chart-env-config/` for more details.
+
+| Parameter  | Description     | Default |
+| ---------- | --------------- | ------- |
+| `webapps.namespace` | namespace where webapps' pods are running | `"apps-prod"` |
+| `webapps.ports` | array of [ports in NetworkPolicyPort format](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#networkpolicyport-v1-networking-k8s-io) for which we allow ingress traffic | TCP port `3000` only |
+| `ingressController.namespace` | namespace where your Ingress controller's pods run | `"default"` |
+| `ingressController.podsMatchLabels` | map with labels to select your Ingress controller's pods (combined using AND) | only traffic from pods with `app=nginx-ingress` and `component=controller` is allowed |
+
+**NOTE**: The `ingressController.podsMatchLabels` value is currently
+not used until we upgrade Calico `v3.1.3` which supports the
+[combined use of `namespaceSelector` and `podSelector`](https://github.com/projectcalico/libcalico-go/pull/872).

--- a/charts/network-policies/templates/NOTES.txt
+++ b/charts/network-policies/templates/NOTES.txt
@@ -1,0 +1,1 @@
+`NetworkPolicy` resources created.

--- a/charts/network-policies/templates/_helpers.tpl
+++ b/charts/network-policies/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "network-policies.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "network-policies.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "network-policies.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/network-policies/templates/hooks/label-ingress-controller-ns.yaml
+++ b/charts/network-policies/templates/hooks/label-ingress-controller-ns.yaml
@@ -1,0 +1,36 @@
+# This job adds the "name=${NAMESPACE}" label to the
+# namespace where the Ingress controller' pods run.
+#
+# This is required in order for the `NetworkPolicy`
+# to allow traffic from this namespace (as it select
+# namespaces using a label selector)
+#
+# This `Job` runs in the `kube-system` namespace using
+# the `helm` service account (in that namespace).
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: label-ingress-controller-ns
+  namespace: kube-system
+  labels:
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: hook-succeeded
+spec:
+  template:
+    spec:
+      restartPolicy: "Never"
+      serviceAccountName: {{ .Values.tillerServiceAccountName }}
+      containers:
+      - name: label-ingress-controller-ns
+        image: gcr.io/google_containers/hyperkube:v1.11.7
+        imagePullPolicy: "IfNotPresent"
+        command:
+        - kubectl
+        - label
+        - --overwrite
+        - ns
+        - {{ .Values.ingressController.namespace }}
+        - name={{ .Values.ingressController.namespace }}

--- a/charts/network-policies/templates/network-policies.yaml
+++ b/charts/network-policies/templates/network-policies.yaml
@@ -17,16 +17,14 @@ metadata:
 spec:
   podSelector: {}
   policyTypes:
-  - Ingress
+    - Ingress
   ingress:
-  - from:
-    - namespaceSelector:
-        matchLabels:
-          name: {{ .Values.ingressController.namespace }}
-{{- if .Values.TEMPORARYnetworkPoliciesWithNamespaceAndPodSelectorsSupported }}
-      podSelector:
-        matchLabels:
-{{ toYaml .Values.ingressController.podsMatchLabels | indent 10 -}}
-{{- end }}
-    ports:
-{{ toYaml .Values.webapps.ports | indent 6 }}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              name: {{ .Values.ingressController.namespace }}
+          podSelector:
+            matchLabels:
+{{ toYaml .Values.ingressController.podsMatchLabels | indent 14 }}
+      ports:
+{{ toYaml .Values.webapps.ports | indent 8 }}

--- a/charts/network-policies/templates/network-policies.yaml
+++ b/charts/network-policies/templates/network-policies.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-all
+  namespace: {{ .Values.webapps.namespace }}
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ingress-traffic
+  namespace: {{ .Values.webapps.namespace }}
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          name: {{ .Values.ingressController.namespace }}
+{{- if .Values.TEMPORARYnetworkPoliciesWithNamespaceAndPodSelectorsSupported }}
+      podSelector:
+        matchLabels:
+{{ toYaml .Values.ingressController.podsMatchLabels | indent 10 -}}
+{{- end }}
+    ports:
+{{ toYaml .Values.webapps.ports | indent 6 }}

--- a/charts/network-policies/templates/tests-permissions.yaml
+++ b/charts/network-policies/templates/tests-permissions.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: network-policies-tests
+  namespace: {{ .Values.webapps.namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: network-policies-tests
+  namespace: {{ .Values.webapps.namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  name: network-policies-tests
+  kind: Role
+subjects:
+  - apiGroup: ""
+    name: network-policies-tests
+    kind: ServiceAccount
+    namespace: {{ .Values.webapps.namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: network-policies-tests
+  namespace: {{ .Values.webapps.namespace }}
+rules:
+  - apiGroups: ["extensions"]
+    resources: ["ingresses"]
+    verbs: ["list"]
+---

--- a/charts/network-policies/templates/tests/traffic-from-ingress-allowed.yaml
+++ b/charts/network-policies/templates/tests/traffic-from-ingress-allowed.yaml
@@ -1,0 +1,26 @@
+# Gets an Ingress host (the first one, it shouldn't matter)
+# and makes a request to it. This should work as we allow
+# external traffic through the Ingress Controller's pods
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: {{ .Values.webapps.namespace }}
+  name: "{{ include "network-policies.fullname" . }}-test-traffic-from-ingress-allowed"
+  labels:
+    app.kubernetes.io/name: {{ include "network-policies.name" . }}
+    helm.sh/chart: {{ include "network-policies.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    helm.sh/hook: test-success
+    helm.sh/hook-delete-policy: before-hook-creation
+spec:
+  restartPolicy: Never
+  serviceAccount: network-policies-tests
+  containers:
+    - name: test-traffic-from-ingress-allowed
+      image: linkyard/kubectl:1.14.2
+      command:
+        - 'sh'
+        - '-c'
+        - 'curl --connect-timeout 5 https://$(kubectl -n {{ .Values.webapps.namespace }} get ingress -o=json | jq -r .items[0].spec.rules[0].host)'

--- a/charts/network-policies/templates/tests/traffic-from-pods-in-ns-blocked.yaml
+++ b/charts/network-policies/templates/tests/traffic-from-pods-in-ns-blocked.yaml
@@ -1,0 +1,25 @@
+# Gets a Service host (the first one, it shouldn't matter)
+# and makes a request to it. This should not work as we
+# block internal traffic between pods.
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: {{ .Values.webapps.namespace }}
+  name: "{{ include "network-policies.fullname" . }}-test-traffic-from-pods-in-ns-blocked"
+  labels:
+    app.kubernetes.io/name: {{ include "network-policies.name" . }}
+    helm.sh/chart: {{ include "network-policies.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    helm.sh/hook: test-failure
+    helm.sh/hook-delete-policy: before-hook-creation
+spec:
+  restartPolicy: Never
+  containers:
+    - name: test-traffic-from-pods-in-ns-blocked
+      image: busybox
+      command:
+        - 'sh'
+        - '-c'
+        - 'wget --timeout=5 $(env | grep _SERVICE_HOST | grep -v KUBERNETES_SERVICE_HOST | cut -d"=" -f2)'

--- a/charts/network-policies/values.yaml
+++ b/charts/network-policies/values.yaml
@@ -1,0 +1,26 @@
+# Default values for network-policies.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+ingressController:
+  namespace: "default"
+  podsMatchLabels:
+    app: nginx-ingress
+    component: controller
+
+webapps:
+  namespace: "apps-prod"
+  ports:
+    - protocol: TCP
+      port: 3000
+
+# Once calico is upgraded to `v3.1.3`+ in all clusters
+# Remove this option and the `if` statement in the
+# `network-policies.yaml` template.
+#
+# Calico `v3.1.3` supports NetworkPolicies with both
+# `namespaceSelector` and `podSelector`.
+# SEE: https://github.com/projectcalico/libcalico-go/pull/872
+TEMPORARYnetworkPoliciesWithNamespaceAndPodSelectorsSupported: false
+
+tillerServiceAccountName: "tiller" # Called ´helm´ in `dev`

--- a/charts/network-policies/values.yaml
+++ b/charts/network-policies/values.yaml
@@ -14,13 +14,4 @@ webapps:
     - protocol: TCP
       port: 3000
 
-# Once calico is upgraded to `v3.1.3`+ in all clusters
-# Remove this option and the `if` statement in the
-# `network-policies.yaml` template.
-#
-# Calico `v3.1.3` supports NetworkPolicies with both
-# `namespaceSelector` and `podSelector`.
-# SEE: https://github.com/projectcalico/libcalico-go/pull/872
-TEMPORARYnetworkPoliciesWithNamespaceAndPodSelectorsSupported: false
-
 tillerServiceAccountName: "tiller" # Called ´helm´ in `dev`


### PR DESCRIPTION
Initial release of helm chart with `NetworkPolicy` resources.
This currently contains only policies to restrict traffic between
webapps' pods but we may add more network policies later (that's why
in the README the installation command install this helm chart
in `default`).

Once this is installed a pod in the `apps-prod` namespace (configurable)
would not be able to talk with other pods in that namespace.

Only traffic allowed will be traffic from the Ingress controller's pod
in the `default` namespace (again, configurable in case these will
run somewhere).

Part of ticket: https://trello.com/c/z0H0xygD/227-prevents-webapp-to-be-able-to-talk-with-each-other