### PR TITLE
unidler v4.0.1: Use strategic merge patch instead of JSONPatch

### DIFF
--- a/charts/unidler/CHANGELOG.md
+++ b/charts/unidler/CHANGELOG.md
@@ -5,6 +5,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [v4.0.1] - 2019-03-27
+### Fixed
+Use new version of the unidler which uses strategic merge patch instead of
+JSONPatch.
+
+Strategic merge is more declarative and more robust. When deleting
+a key which is not there it would consider that part of the patch as already
+applied instead of raising an error as in the case of JSONpatch.
+
+- [unidler PR](https://github.com/ministryofjustice/analytics-platform-go-unidler/pull/10)
+- Part of ticket: https://trello.com/c/vr4LPcde/241-investigate-fix-idling-unidling-problems-caused-by-k8s-cluster-upgrade-new-version-of-k8s
+
+
 ## [v4.0.0] - 2019-03-27
 ### Changed
 Bumped unidler to version `v1.0.0`.

--- a/charts/unidler/Chart.yaml
+++ b/charts/unidler/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 description: unidler proxy
 name: unidler
 version: "v4.0.1"
-appVersion: "v1.0.1"
+appVersion: "v1.0.2"

--- a/charts/unidler/Chart.yaml
+++ b/charts/unidler/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: unidler proxy
 name: unidler
-version: "v4.0.0"
-appVersion: "v1.0.0"
+version: "v4.0.1"
+appVersion: "v1.0.1"

--- a/charts/unidler/README.md
+++ b/charts/unidler/README.md
@@ -5,7 +5,7 @@ The unidler is responsible for unidling the RStudio instances (currently).
 ## Installing the chart
 
 ```bash
-$ helm upgrade --install --dry-run unidler charts/unidler --namespace default -f chart-env-config/ENV/unidler.yml
+$ helm upgrade --install --dry-run --debug unidler charts/unidler --namespace default -f chart-env-config/ENV/unidler.yml
 ```
 
 **NOTE**: Remove `--dry-run` and adjust the values file path.

--- a/charts/unidler/values.yaml
+++ b/charts/unidler/values.yaml
@@ -1,7 +1,7 @@
 # Docker image
 image:
   name: quay.io/mojanalytics/go-unidler
-  tag: v1.0.1
+  tag: v1.0.2
   pullPolicy: IfNotPresent
 
 replicaCount: 3

--- a/charts/unidler/values.yaml
+++ b/charts/unidler/values.yaml
@@ -1,7 +1,7 @@
 # Docker image
 image:
   name: quay.io/mojanalytics/go-unidler
-  tag: v1.0.0
+  tag: v1.0.1
   pullPolicy: IfNotPresent
 
 replicaCount: 3


### PR DESCRIPTION
Use new version of the unidler which uses strategic merge patch instead of
JSONPatch.

Strategic merge is more declarative and more robust. When deleting
a key which is not there it would consider that part of the patch as already
applied instead of raising an error as in the case of JSONpatch.

- [unidler PR](https://github.com/ministryofjustice/analytics-platform-go-unidler/pull/10)
- Part of ticket: https://trello.com/c/vr4LPcde/241-investigate-fix-idling-unidling-problems-caused-by-k8s-cluster-upgrade-new-version-of-k8s