### PR TITLE
pod-cleaner 0.1.1: Fixed Docker permission problem

### DIFF
--- a/charts/pod-cleaner/CHANGELOG.md
+++ b/charts/pod-cleaner/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [0.1.1] - 2019-07-02
+### Fixed
+Fixed Docker permission error while executing `pod_cleaner.sh` script.
+Possibly caused by some change in Kubernetes.
+
+
 ## [0.1.0] - 2019-05-03
 ### Added
 Also delete pods in `Pending` phase.

--- a/charts/pod-cleaner/Chart.yaml
+++ b/charts/pod-cleaner/Chart.yaml
@@ -1,4 +1,3 @@
 name: pod-cleaner
 description: Delete old succeeded/failed/pending pods
-version: 0.1.0
-appVersion: 0.1.0
+version: 0.1.1

--- a/charts/pod-cleaner/templates/cronjob.yaml
+++ b/charts/pod-cleaner/templates/cronjob.yaml
@@ -60,4 +60,4 @@ spec:
           - name: {{ .Release.Name }}
             configMap:
               name: {{ .Release.Name }}
-              defaultMode: 500
+              defaultMode: 0555 # a+rx


### PR DESCRIPTION
Probably caused by k8s cluster upgrade

Ticket: https://trello.com/c/J5jgkueM/244-fix-pod-cleaner-permission-problem