### PR TITLE
Webapp: Bump auth-proxy version

### DIFF
--- a/charts/webapp/CHANGELOG.md
+++ b/charts/webapp/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [2.1.0] - 2019-07-23
+### Changed
+Bumped `auth-proxy` to version [`v5.0.0`](https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.0.0).
+
 ## [2.0.0] - 2019-05-29
 ### Changed
 Replaced fluentd with [fluent-bit].

--- a/charts/webapp/Chart.yaml
+++ b/charts/webapp/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: webapp Helm chart for Kubernetes
 name: webapp
-version: 2.0.0
+version: 2.1.0
 fluentbitVersion: 1.1.1

--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -20,7 +20,7 @@ AuthProxy:
     Domain: "AUTH0_USER.eu.auth0.com"
   Image:
     Repository: quay.io/mojanalytics/auth-proxy
-    Tag: "v4.0.1"
+    Tag: "v5.0.0"
     PullPolicy: "IfNotPresent"
 AWS:
   IAMRole: ""


### PR DESCRIPTION
Bump auth proxy to v5.0.0 which includes the `/userinfo` endpoint