### PR TITLE
restarter v0.0.1: Initial release

### DIFF
--- a/charts/restarter/CHANGELOG.md
+++ b/charts/restarter/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+
+## [v0.0.1] - 2019-07-26
+### Added
+- Initial release

--- a/charts/restarter/Chart.yaml
+++ b/charts/restarter/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+description: internal API to restart apps
+name: restarter
+version: "v0.0.1"
+appVersion: "v0.0.1"

--- a/charts/restarter/README.md
+++ b/charts/restarter/README.md
@@ -1,0 +1,13 @@
+# Restarter Helm Chart
+
+API to restart applications within a certain namespace (given their host).
+
+See deployed API: https://github.com/ministryofjustice/analytics-platform-restarter
+
+## Installing the chart
+
+```bash
+$ helm upgrade --install --dry-run --debug restarter charts/restarter --namespace apps-prod
+```
+
+**NOTE**: Remove `--dry-run` and adjust the values file path.

--- a/charts/restarter/templates/NOTES.txt
+++ b/charts/restarter/templates/NOTES.txt
@@ -1,0 +1,1 @@
+The internal API will be available at {{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local

--- a/charts/restarter/templates/deployment.yaml
+++ b/charts/restarter/templates/deployment.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: {{ .Release.Name }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}
+    spec:
+      serviceAccountName: {{ .Release.Name }}
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.name }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        env:
+          - name: NAMESPACE
+            value: "{{ .Release.Namespace }}"
+          - name: PORT
+            value: "{{ .Values.service.internalPort }}"
+        ports:
+          - name: http
+            containerPort: {{ .Values.service.internalPort }}
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: http
+          initialDelaySeconds: 1
+          periodSeconds: 5
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: http
+          initialDelaySeconds: 1
+          periodSeconds: 10

--- a/charts/restarter/templates/networkpolicy.yaml
+++ b/charts/restarter/templates/networkpolicy.yaml
@@ -1,0 +1,11 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-traffic-to-restarter
+  namespace: {{ .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ .Release.Name }}
+  ingress:
+  - {}

--- a/charts/restarter/templates/role.yaml
+++ b/charts/restarter/templates/role.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["list", "patch"]

--- a/charts/restarter/templates/rolebinding.yaml
+++ b/charts/restarter/templates/rolebinding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}
+    apiGroup: ""
+roleRef:
+  kind: Role
+  name: {{ .Release.Name }}
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/restarter/templates/service.yaml
+++ b/charts/restarter/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: {{ .Release.Name }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - name: http
+    port: {{ .Values.service.externalPort }}
+    targetPort: {{ .Values.service.internalPort }}
+  selector:
+    app: {{ .Release.Name }}

--- a/charts/restarter/templates/serviceaccount.yaml
+++ b/charts/restarter/templates/serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}

--- a/charts/restarter/values.yaml
+++ b/charts/restarter/values.yaml
@@ -1,0 +1,12 @@
+# Docker image
+image:
+  name: quay.io/mojanalytics/restarter
+  tag: v0.0.1
+  pullPolicy: IfNotPresent
+
+replicaCount: 3
+
+service:
+  externalPort: 80
+  internalPort: 8080
+  type: ClusterIP


### PR DESCRIPTION
Internal API to restart applications in a given
namespace.

This API doesn't have an Ingress resource so it's
only accessible from within the k8s cluster (at `${RELEASE_NAME}.${NAMESPACE}.svc.cluster.local`).

Furthermore, the service account for this API is only able to list and
patch Deployments within the namespace where the chart/API is been
released to.

Part of ticket: https://trello.com/c/zb9HsZca/254-investigate-ways-to-trigger-apps-restart-when-data-changes