### PR TITLE
Adding exclusions to nfs backup

### DIFF
--- a/charts/nfs-backup/Chart.yaml
+++ b/charts/nfs-backup/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: nfs-backup
-version: 0.2.0
+version: 0.2.1

--- a/charts/nfs-backup/README.md
+++ b/charts/nfs-backup/README.md
@@ -8,7 +8,7 @@ This will install a CronJob object to periodically back up user NFS home directo
 To install:
 
 ```bash
-$ helm install charts/nfs-backup -f chart-env-config/ENV/nfs-backup.yml
+$ helm upgrade nfs-backup charts/nfs-backup -f chart-env-config/ENV/nfs-backup.yml --install
 ```
 
 The job's status can be viewed with `kubectl get cronjobs`

--- a/charts/nfs-backup/templates/configmap.yml
+++ b/charts/nfs-backup/templates/configmap.yml
@@ -18,4 +18,14 @@ data:
     \/id_rsa$
     \/\.bash_history$
     \/core$
+    \/\.conda\/
+    \/miniconda3-r\/
+    \/\.local\/
+    \/Git_Repos\/
+    \/SAT+Shapes\/
+    \/py-safety\/
+    \/\.virtualenvs\/
+    \/comparisons\/
+    \/Python\/
+    \/node_modules\/
   s3_backup_bucket_name: "{{ .Values.AWS.S3.BucketName }}"


### PR DESCRIPTION
The below directories seem to be the usual culprits that cause the nfs
backup job to either stall or fail entirely.

I don't think there is much value in backing these directories to `s3` but please shout
if you disagree.

```
.conda
miniconda3-r
.local
Git_Repos
SAT+Shapes
py-safety
.virtualenvs
comparisons
Python
```

Already deployed `(31/07/2019)`

Will check later or tomorrow to see if it had the desired effect.