### PR TITLE
Webapp: Bump auth proxy version to v5.0.1

### DIFF
--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -20,7 +20,7 @@ AuthProxy:
     Domain: "AUTH0_USER.eu.auth0.com"
   Image:
     Repository: quay.io/mojanalytics/auth-proxy
-    Tag: "v5.0.0"
+    Tag: "v5.0.1"
     PullPolicy: "IfNotPresent"
 AWS:
   IAMRole: ""


### PR DESCRIPTION
This new auth proxy version makes sure the `secure` flag is sent with the
`connect.sid` cookie.