### PR TITLE
Bump Webapp chart: v5.1.0

### DIFF
--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -20,7 +20,7 @@ AuthProxy:
     Domain: "AUTH0_USER.eu.auth0.com"
   Image:
     Repository: quay.io/mojanalytics/auth-proxy
-    Tag: "v5.0.1"
+    Tag: "v5.1.0"
     PullPolicy: "IfNotPresent"
 AWS:
   IAMRole: ""


### PR DESCRIPTION
This changes the response code the auth-proxy sends back when user is not in the
ip_whitelist from 500 to 403