### PR TITLE
kibana-auth-proxy 2.1.0: Use auth-proxy as a proxy

### DIFF
--- a/charts/kibana-auth-proxy/CHANGELOG.md
+++ b/charts/kibana-auth-proxy/CHANGELOG.md
@@ -5,9 +5,20 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [2.1.0] - 2019-08-22
+### Changed
+- Replaced `kibana-auth-proxy` with `auth-proxy` - the latest
+version has the logic that used to be part of kibana-auth-proxy.
+This means we now have only one auth-proxy to maintain insteadto of
+several ones.
+
+- Added `host` label to deployment/pod.
+
+
 ## [2.0.1] - 2019-07-04
 ### Changed
 Patched security vulnerabilities in dependencies
+
 
 ## [2.0.0] - 2018-09-27
 ### Changed

--- a/charts/kibana-auth-proxy/Chart.yaml
+++ b/charts/kibana-auth-proxy/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
-description: A Helm chart for Kubernetes
+description: Auth proxy in front of Kibana
 name: kibana-auth-proxy
-version: 2.0.1
+version: 2.1.0

--- a/charts/kibana-auth-proxy/README.md
+++ b/charts/kibana-auth-proxy/README.md
@@ -10,7 +10,7 @@ Authentication layer in front of kibana.
 To install the chart:
 
 ```bash
-helm upgrade --dry-run --install cluster-logviewer mojanalytics/kibana-auth-proxy \
+helm upgrade --dry-run --debug --install cluster-logviewer mojanalytics/kibana-auth-proxy \
   --namespace kube-system \
   -f chart-env-config/ENV/kibana-auth-proxy.yml
 ```

--- a/charts/kibana-auth-proxy/templates/deployment.yaml
+++ b/charts/kibana-auth-proxy/templates/deployment.yaml
@@ -1,16 +1,18 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     app: {{ template "fullname" . }}
+    host: {{ .Values.ingress.host }}
 spec:
   replicas: {{ .Values.replicaCount }}
   template:
     metadata:
       labels:
         app: {{ template "fullname" . }}
+        host: {{ .Values.ingress.host }}
       annotations:
         checksum/config: {{ include (print $.Chart.Name "/templates/secrets.yaml") . | sha256sum }}
     spec:
@@ -55,11 +57,13 @@ spec:
               secretKeyRef:
                 name: {{ template "fullname" . }}
                 key: cookie_secret
-          - name: KIBANA_URL
+          - name: TARGET_URL
             valueFrom:
               secretKeyRef:
                 name: {{ template "fullname" . }}
                 key: kibana_url
+          - name: KIBANA_ADD_BASIC_AUTH
+            value: "true"
           - name: KIBANA_ADMIN_USERNAME
             valueFrom:
               secretKeyRef:

--- a/charts/kibana-auth-proxy/values.yaml
+++ b/charts/kibana-auth-proxy/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 image:
-  repository: quay.io/mojanalytics/kibana-auth-proxy
-  tag: "v1.1.3"
+  repository: quay.io/mojanalytics/auth-proxy
+  tag: "v5.2.1"
   pullPolicy: IfNotPresent
 service:
   type: ClusterIP


### PR DESCRIPTION
This means we don't have to maintain several auth proxies anymore
as we now use `auth-proxy` as auth proxy for all apps.

Part of ticket: https://trello.com/c/zxHetcOl/262-get-rid-of-kibana-auth-proxy