### PR TITLE
Bumped auth-proxies to v5.2.1

### DIFF
--- a/charts/airflow-sqlite/CHANGELOG.md
+++ b/charts/airflow-sqlite/CHANGELOG.md
@@ -5,6 +5,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [0.2.2] - 2019-08-23
+### Changed
+Bumped auth-proxy to version v5.2.1.
+This version removes the non-standard `prompt=none`.
+Also note that v5.2.0 introduced support for logic to log into kibana.
+
+This shouldn't be a breaking change.
+
+https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.1
+
+
 ## [0.2.1] - 2019-05-22
 ### Changed
 Bumped `auth-proxy` to version [`v4.0.1`](https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v4.0.1).

--- a/charts/airflow-sqlite/Chart.yaml
+++ b/charts/airflow-sqlite/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 description: Airflow with sqlite. Tasks are run as pods
 name: airflow-sqlite
 icon: https://airflow.incubator.apache.org/_images/pin_large.png
-version: 0.2.1
+version: 0.2.2
 appVersion: 1.10.3

--- a/charts/airflow-sqlite/values.yaml
+++ b/charts/airflow-sqlite/values.yaml
@@ -17,7 +17,7 @@ service:
   port: 80
 authProxy:
   image: "quay.io/mojanalytics/auth-proxy"
-  tag: "v4.0.1"
+  tag: "v5.2.1"
   imagePullPolicy: "IfNotPresent"
   containerPort: "3000"
   resources:

--- a/charts/jupyter-lab/CHANGELOG.md
+++ b/charts/jupyter-lab/CHANGELOG.md
@@ -5,6 +5,18 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+
+## [0.4.3] - 2019-08-23
+### Changed
+Bumped auth-proxy to version v5.2.1.
+This version removes the non-standard `prompt=none`.
+Also note that v5.2.0 introduced support for logic to log into kibana.
+
+This shouldn't be a breaking change.
+
+https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.1
+
+
 ## [0.4.2] - 2019-06-05
 ### Changed
 Bumped `quay.io/mojanalytics/datascience-notebook` to version [`v0.6.7`](https://github.com/ministryofjustice/analytics-platform-jupyter-notebook/releases/tag/v0.6.7).

--- a/charts/jupyter-lab/Chart.yaml
+++ b/charts/jupyter-lab/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: Jupyter Lab with Auth0 authentication proxy
 name: jupyter-lab
-version: 0.4.2
+version: 0.4.3
 appVersion: v0.6.7

--- a/charts/jupyter-lab/values.yaml
+++ b/charts/jupyter-lab/values.yaml
@@ -10,7 +10,7 @@ service:
 
 authProxy:
   image: quay.io/mojanalytics/auth-proxy
-  tag: v4.0.1
+  tag: v5.2.1
   imagePullPolicy: IfNotPresent
   containerPort: 3000
   resources:

--- a/charts/kubernetes-dashboard/CHANGELOG.md
+++ b/charts/kubernetes-dashboard/CHANGELOG.md
@@ -5,11 +5,23 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [2.0.1] - 2019-08-23
+### Changed
+Bumped auth-proxy to version `v5.2.1`.
+This version removes the non-standard `prompt=none`.
+Also note that `v5.2.0` introduced support for logic to log into kibana.
+
+This shouldn't be a breaking change.
+
+https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.1
+
+
 ## [2.0.0] - 2019-01-15
 ### Changed
 - Added Auth Proxy to Kubernetes-Dashboard
 - Modified Kubernetes-Dashboard image tag from  `v1.8.3` to `v1.10.1`
-- Switch Kubernetes-Dashboard to insecure backend 
+- Switch Kubernetes-Dashboard to insecure backend
+
 
 ## [1.0.0] - 2018-09-27
 ### Changed

--- a/charts/kubernetes-dashboard/Chart.yaml
+++ b/charts/kubernetes-dashboard/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Kubernetes Dashboard with OIDC auth
 name: kubernetes-dashboard
-version: 2.0.0
+version: 2.0.1

--- a/charts/kubernetes-dashboard/README.md
+++ b/charts/kubernetes-dashboard/README.md
@@ -2,21 +2,18 @@
 
 Chart representation of [kubernetes-dashboard](https://raw.githubusercontent.com/kubernetes/dashboard/master/src/deploy/recommended/kubernetes-dashboard.yaml) with read only by default
 
-## Installing the Chart
+## Install/Upgrade the Chart
 
 ```bash
-$ helm install --name=kubernetes-dashboard analytics-platform-helm-charts/charts/kubernetes-dashboard --namespace=kube-system -f analytics-platform-config/chart-env-config/{ENV}/kube-dashboard.yml
+$ helm upgrade --dry-run --install --debug kubernetes-dashboard --namespace=kube-system charts/kubernetes-dashboard -f analytics-platform-config/chart-env-config/{ENV}/kubernetes-dashboard.yml
 ```
+
 
 **NOTE**: Change the environment config file to deploy in a different environment
           (the URL will change accordingly)
 
+**NOTE**: Remove `-dry-run` once you're happy with the output.
 
-## Upgrade the Chart
-
-```bash
-$ helm upgrade kubernetes-dashboard analytics-platform-helm-charts/charts/kubernetes-dashboard -f analytics-platform-config/chart-env-config/{ENV}/kube-dashboard.yml
-```
 
 ## Delete the Chart
 

--- a/charts/kubernetes-dashboard/templates/deployment.yaml
+++ b/charts/kubernetes-dashboard/templates/deployment.yaml
@@ -26,6 +26,8 @@ spec:
         env:
           - name: TARGET_URL
             value: http://localhost:{{ .Values.dashboard.port }}
+          - name: USER
+            value: ""
           - name: AUTH0_DOMAIN
             valueFrom:
               secretKeyRef:

--- a/charts/kubernetes-dashboard/values.yaml
+++ b/charts/kubernetes-dashboard/values.yaml
@@ -8,7 +8,7 @@ dashboard:
 
 authProxy:
   image: quay.io/mojanalytics/auth-proxy
-  tag: v0.1.6
+  tag: v5.2.1
   imagePullPolicy: IfNotPresent
   containerPort: 3000
   resources:

--- a/charts/prometheus-resources/CHANGELOG.md
+++ b/charts/prometheus-resources/CHANGELOG.md
@@ -4,16 +4,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+## [0.1.2] - 2019-08-23
+### Changed
+Bumped auth-proxy to version `v5.2.1`.
+This version removes the non-standard `prompt=none`.
+Also note that `v5.2.0` introduced support for logic to log into kibana.
+
+This shouldn't be a breaking change.
+
+https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.1
+
+
 ## [0.1.1] - 2019-03-18
 ### Upstream Chart Migration/Initial Commit
 - Removed duplicate alerting rules
-- Modified custom alerts to display message field like operator alerts 
+- Modified custom alerts to display message field like operator alerts
+
 
 ## [0.1.0] - 2019-02-05
 ### Upstream Chart Migration/Initial Commit
 - Initial commit
 - Migrated our deployment from [CoreOS's deprecated chart](https://github.com/coreos/prometheus-operator/tree/master/helm) to [Helm stable repo chart](https://github.com/helm/charts/tree/master/stable/prometheus-operator)
 - Secured [Prometheus](https://prometheus.services.dev.mojanalytics.xyz) and [AlertManager](https://alertmanager.services.dev.mojanalytics.xyz) front-ends with [auth-proxy](https://github.com/ministryofjustice/analytics-platform-auth-proxy)
-- Migrated Dashboard templates to Grafana 5.4.x spec  
+- Migrated Dashboard templates to Grafana 5.4.x spec
 - Migrated Rules, Alerts and Dashboards from previous deployment
 - Added `PodSecurityPolicy` in preparation for [Trello](https://trello.com/c/0mfKXhjp)

--- a/charts/prometheus-resources/Chart.yaml
+++ b/charts/prometheus-resources/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "1.0"
 description: Deploys resources related to the [Prometheus-Operator](https://github.com/helm/charts/tree/master/stable/prometheus-operator) helm chart
 name: prometheus-resources
-version: 0.1.1
+version: 0.1.2
 engine: gotpl

--- a/charts/prometheus-resources/templates/deployment.yaml
+++ b/charts/prometheus-resources/templates/deployment.yaml
@@ -37,6 +37,8 @@ spec:
           env:
             - name: TARGET_URL
               value: http://{{ $.Release.Name }}-{{ .name }}.{{ $.Release.Namespace }}.svc.cluster.local
+            - name: USER
+              value: ""
             - name: AUTH0_DOMAIN
               valueFrom:
                 secretKeyRef:

--- a/charts/prometheus-resources/values.yaml
+++ b/charts/prometheus-resources/values.yaml
@@ -5,7 +5,7 @@ ingressClass: nginx
 authProxy:
   name: auth-proxy
   image: quay.io/mojanalytics/auth-proxy
-  tag: v0.1.6
+  tag: v5.2.1
   imagePullPolicy: IfNotPresent
   containerPort: 3000
   resources:

--- a/charts/rstudio/CHANGELOG.md
+++ b/charts/rstudio/CHANGELOG.md
@@ -5,6 +5,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [2.1.1] - 2019-08-23
+### Changed
+Bumped auth-proxy to version v5.2.1.
+This version removes the non-standard `prompt=none`.
+Also note that v5.2.0 introduced support for logic to log into kibana.
+
+This shouldn't be a breaking change.
+
+https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.1
+
+
 ## [2.1.0] - 2019-07-08
 ### Changed
 Using newer docker image with RStudio 1.2.

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: RStudio with Auth0 authentication proxy
 name: rstudio
-version: 2.1.0
+version: 2.1.1
 appVersion: "RStudio: 1.2.1335+conda, R: 3.5.1, Python: 3.7.1, patch: 3"

--- a/charts/rstudio/values.yaml
+++ b/charts/rstudio/values.yaml
@@ -16,7 +16,7 @@ authProxy:
     port: 3000
   image:
     repository: quay.io/mojanalytics/auth-proxy
-    tag: "v4.0.1"
+    tag: "v5.2.1"
     pullPolicy: "IfNotPresent"
   resources:
     limits:

--- a/charts/webapp/CHANGELOG.md
+++ b/charts/webapp/CHANGELOG.md
@@ -5,6 +5,18 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+
+## [2.1.1] - 2019-08-23
+### Changed
+Bumped auth-proxy to version v5.2.1.
+This version removes the non-standard `prompt=none`.
+Also note that v5.2.0 introduced support for logic to log into kibana.
+
+This shouldn't be a breaking change.
+
+https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.1
+
+
 ## [2.1.0] - 2019-07-23
 ### Changed
 Bumped `auth-proxy` to version [`v5.0.0`](https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.0.0).

--- a/charts/webapp/Chart.yaml
+++ b/charts/webapp/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: webapp Helm chart for Kubernetes
 name: webapp
-version: 2.1.0
+version: 2.1.1
 fluentbitVersion: 1.1.1

--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -20,7 +20,7 @@ AuthProxy:
     Domain: "AUTH0_USER.eu.auth0.com"
   Image:
     Repository: quay.io/mojanalytics/auth-proxy
-    Tag: "v5.1.0"
+    Tag: "v5.2.1"
     PullPolicy: "IfNotPresent"
 AWS:
   IAMRole: ""


### PR DESCRIPTION
This version of [`auth-proxy`](https://github.com/ministryofjustice/analytics-platform-auth-proxy) removes the non-standard `prompt=none`.
Also note that v5.2.0 introduced support for logic to log into kibana.

Charts updated:
- airflow-sqlite
- jupyter-lab
- rstudio
- webapp

**NOTE**: `kubernetes-dashboard` and `prometheus-resources` use an older
version of the proxy - we should probably update those as well:
- [X] update `kubernetes-dashboard`
- [x] update `prometheus-resources`

See auth-proxy releases for more details:
- https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.1
- https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.0