### PR TITLE
Webapp: Add security headers by default

### DIFF
--- a/charts/webapp/CHANGELOG.md
+++ b/charts/webapp/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [2.2.0] - 2019-08-27
+### Changed
+Add some security headers by default:
+
+  - X-Content-Type-Options: nosniff
+  - X-Frame-Options: deny
 
 ## [2.1.1] - 2019-08-23
 ### Changed

--- a/charts/webapp/Chart.yaml
+++ b/charts/webapp/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: webapp Helm chart for Kubernetes
 name: webapp
-version: 2.1.1
+version: 2.2.0
 fluentbitVersion: 1.1.1

--- a/charts/webapp/templates/ingress.yaml
+++ b/charts/webapp/templates/ingress.yaml
@@ -10,6 +10,9 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/affinity: "cookie"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "X-Content-Type-Options: nosniff";
+      more_set_headers "X-Frame-Options: deny";
 spec:
   rules:
   - host: {{ template "hostname" . }}


### PR DESCRIPTION
This adds some pretty safe security headers to all responses by default.

This should not be a breaking change unless an app is doing something weird like
embedding itself on another site via an IFRAME

ticket: https://trello.com/c/wpEJaXXt/36-sdt-changes-based-on-zap-result