### PR TITLE
Initial changes for implementing audit logs s3 changes

### DIFF
--- a/charts/fluentd/CHANGELOG.md
+++ b/charts/fluentd/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.2.6] - 2019-09-09
+### FluentD Tuning
+- Implemented new sources files for security purposes: `/var/log/auth.log` and `/var/log/syslog`
+
 ## [0.2.5] - 2019-09-02
 ### FluentD Selector in Daemonset Spec
 - Add `selector` to `spec` in daemonset as required by `apps/v1` api
@@ -32,7 +36,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Modifying to currently working config set.
   Particularly ensuring we are capturing systemd events from journalD as our current distro is
   debian jessie
-  
+
 - Removing log sources that do not exist on systemd distros i.e.
   `/var/log/kubelet`.  Mentioned path will only exists on sysV init
   distros.
@@ -41,8 +45,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Increasing slow_flush_log_threshold to prevent the corresponding
   threshold exceeded exception
-  
+
 - Increasing buffer chunk and queue limits helps remedy flush failures while
   elasticsearch falls behind during ingestion
-  
+
 - Ensuring this pod can tolerate no-schedule taints on master nodes

--- a/charts/fluentd/Chart.yaml
+++ b/charts/fluentd/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: fluentd
-version: 0.2.5
+version: 0.2.6

--- a/charts/fluentd/templates/daemonset.yaml
+++ b/charts/fluentd/templates/daemonset.yaml
@@ -102,4 +102,3 @@ spec:
       - name: libsystemddir
         hostPath:
           path: /usr/lib64
-

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -2,6 +2,9 @@ image:
   repository: gcr.io/google-containers/fluentd-elasticsearch
   tag: v2.0.4
   pullPolicy: Always
+aws:
+  defaultRegion: "eu-west-1"
+  iamRole: ""
 elasticsearch:
   host: elasticsearch-logging
   port: "9200"
@@ -48,6 +51,28 @@ fluentdconffiles:
     </match>
 
   system.input.conf: |-
+
+    <source>
+      @id auth.log
+      @type tail
+      path /var/log/auth.log
+      pos_file /var/log/auth.log.pos
+      <parse>
+        @type syslog
+      </parse>
+      tag auth
+    </source>
+
+    <source>
+      @id syslog.log
+      @type tail
+      path /var/log/syslog.log
+      pos_file /var/log/syslog.log.pos
+      <parse>
+        @type syslog
+      </parse>
+      tag syslog
+    </source>
 
     <source>
       @id docker.log


### PR DESCRIPTION
This modification would allow Fluentd to start shipping the following Audit logs to ES:
`auth.log` and `syslog.log`