### PR TITLE
New Environment: Cluster Autoscaler

### DIFF
--- a/charts/cluster-autoscaler/CHANGELOG.md
+++ b/charts/cluster-autoscaler/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.0] - 2019-08-30
+### Changed
+- Changed tag version from `v1.3.5` to `v1.12.3`
+- Increased memory limit from `300mi` to `500mi`
+- Modified `Clusterrole` by adding `apps` apiGroup to read-only on `ReplicaSets` and `DaemonSets`
+- Removed `env` value as instances reside in separate AWS accounts
+
 ## [0.1.3] - 2019-03-13
 ### Changed
 - Increased CPU requests and limits from 100m to 200m and 500m respectively  

--- a/charts/cluster-autoscaler/Chart.yaml
+++ b/charts/cluster-autoscaler/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 1.3.5
+appVersion: 1.12.3
 description: Scales worker nodes within autoscaling groups
 name: cluster-autoscaler
-version: 0.1.3
+version: 1.0.0
 sources:
 - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 - https://github.com/spotinst/kubernetes-autoscaler/tree/master/cluster-autoscaler

--- a/charts/cluster-autoscaler/templates/clusterrole.yaml
+++ b/charts/cluster-autoscaler/templates/clusterrole.yaml
@@ -25,7 +25,7 @@ rules:
 - apiGroups: [""]
   resources: ["pods","services","replicationcontrollers","persistentvolumeclaims","persistentvolumes"]
   verbs: ["watch","list","get"]
-- apiGroups: ["extensions"]
+- apiGroups: ["extensions","apps"]
   resources: ["replicasets","daemonsets"]
   verbs: ["watch","list","get"]
 - apiGroups: ["policy"]

--- a/charts/cluster-autoscaler/templates/deployment.yaml
+++ b/charts/cluster-autoscaler/templates/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: cluster-autoscaler
   annotations:
-    iam.amazonaws.com/role: "{{ .Values.env }}-cluster-autoscaler"
+    iam.amazonaws.com/role: "cluster-autoscaler"
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/charts/cluster-autoscaler/values.yaml
+++ b/charts/cluster-autoscaler/values.yaml
@@ -1,10 +1,8 @@
-env: ""
-
 replicaCount: 1
 
 image:
   repository: k8s.gcr.io/cluster-autoscaler
-  tag: v1.3.5
+  tag: v1.12.3
   pullPolicy: IfNotPresent
 
 autoscalingGroups:
@@ -21,7 +19,7 @@ aws_region: ""
 resources:
   limits:
     cpu: 500m
-    memory: 300Mi
+    memory: 500Mi
   requests:
     cpu: 200m
     memory: 300Mi


### PR DESCRIPTION
[Trello](https://trello.com/c/WpMxBEOb)

- Changed tag version from `v1.3.5` to `v1.12.3`
- Increased memory limit from `300mi` to `500mi`
- Modified `Clusterrole` by adding `apps` apiGroup to read-only on
`ReplicaSets` and `DaemonSets`
- Removed `env` value as instances reside in separate AWS accounts

**Deployed**