### PR TITLE
Support ip range for Alan Turing Institute

### DIFF
--- a/charts/concourse-org-pipeline/CHANGELOG.md
+++ b/charts/concourse-org-pipeline/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.2.5] - 2019-09-03
+### Added
+Placeholder secret `alanTuringInstitute` to `ipRanges` to support
+ip whitelisting for them
+
 ## [0.2.4] - 2019-07-12
 ### Changed
 Add parameter IAM role secrets

--- a/charts/concourse-org-pipeline/Chart.yaml
+++ b/charts/concourse-org-pipeline/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Concourse pipeline for creating deployment pipelines for Github org repos
 name: concourse-org-pipeline
-version: 0.2.4
+version: 0.2.5

--- a/charts/concourse-org-pipeline/templates/secrets.yaml
+++ b/charts/concourse-org-pipeline/templates/secrets.yaml
@@ -29,6 +29,7 @@ data:
   ip-digital: {{ .Values.ipRanges.mojDigitalWifiAndVpn | b64enc | quote }}
   ip-dom1: {{ .Values.ipRanges.dom1 | b64enc | quote }}
   ip-quantum: {{ .Values.ipRanges.quantum | b64enc | quote }}
+  ip-turing: {{ .Values.ipRanges.alanTuringInstitute | b64enc | quote}}
   kubernetes-api-url: {{ .Values.kubernetes.apiUrl | b64enc | quote }}
   kubernetes-ca-cert: {{ .Values.kubernetes.caCert | b64enc | quote }}
   kubernetes-token: {{ .Values.kubernetes.token | b64enc | quote }}

--- a/charts/concourse-org-pipeline/values.yaml
+++ b/charts/concourse-org-pipeline/values.yaml
@@ -53,6 +53,8 @@ ipRanges:
   wifi102pf: ""
   dom1: ""
   quantum: ""
+  mojDigitalWifiAndVpn: ""
+  alanTuringInstitute: ""
 
 kubernetes:
   apiUrl: ""


### PR DESCRIPTION
This allows us to deploy apps that are only accessible by someone working at the
Turing Institute

https://trello.com/c/YswsWozF/295-add-ip-for-turing-institute