### PR TITLE
Add old cpfrontend host to ingress

### DIFF
--- a/charts/cpanel/CHANGELOG.md
+++ b/charts/cpanel/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.2.0] - 2019-09-09
+### Changed
+- Added old cpanel frontend hostname to ingress
+
+
 ## [2.1.3] - 2019-08-29
 ### Added
 - Added `secretEnv.SECRET_KEY` value

--- a/charts/cpanel/Chart.yaml
+++ b/charts/cpanel/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Analytics Platform Control Panel API webapp
 name: cpanel
-version: 2.1.3
+version: 2.2.0

--- a/charts/cpanel/templates/_helpers.tpl
+++ b/charts/cpanel/templates/_helpers.tpl
@@ -15,7 +15,7 @@ Old Control Panel API hostname
 {{/*
 Old Control Panel Frontend hostname
 */}}
-{{- define "hostname" -}}
+{{- define "old_cpfrontend_host" -}}
 "cpanel{{- if .Values.branch -}}-{{ .Values.branch }}{{- end -}}.{{ .Values.servicesDomain }}"
 {{- end -}}
 

--- a/charts/cpanel/templates/_helpers.tpl
+++ b/charts/cpanel/templates/_helpers.tpl
@@ -13,6 +13,13 @@ Old Control Panel API hostname
 {{- end -}}
 
 {{/*
+Old Control Panel Frontend hostname
+*/}}
+{{- define "hostname" -}}
+"cpanel{{- if .Values.branch -}}-{{ .Values.branch }}{{- end -}}.{{ .Values.servicesDomain }}"
+{{- end -}}
+
+{{/*
 Postgres release
 */}}
 {{- define "postgresRelease" -}}

--- a/charts/cpanel/templates/ingress.yaml
+++ b/charts/cpanel/templates/ingress.yaml
@@ -22,6 +22,12 @@ spec:
       - backend:
           serviceName: "{{ .Chart.Name }}"
           servicePort: 80
+  - host: {{ template "old_cpfrontend_host" . }}
+    http:
+      paths:
+      - backend:
+          serviceName: "{{ .Chart.Name }}"
+          servicePort: 80
   tls:
   - hosts:
     - {{ template "host" . }}


### PR DESCRIPTION
This will make the new Control Panel receive requests to `https://cpanel-master.services...`

I'm assuming the way to actually remove the old frontend is to just `helm delete` it, but let me know if you have a nicer way