### PR TITLE
User Read ClusterRole

### DIFF
--- a/charts/init-user/CHANGELOG.md
+++ b/charts/init-user/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.1.6] - 2019-09-10
+## User Read Rolebinding
+- Add a `RoleBinding` in user namespaces for __user-read__ `ClusterRole` and team.
 
 ## [0.1.5] - 2019-08-19 
 ## User Support role

--- a/charts/init-user/Chart.yaml
+++ b/charts/init-user/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: init-user
-version: 0.1.5
+version: 0.1.6

--- a/charts/init-user/templates/role-binding.yml
+++ b/charts/init-user/templates/role-binding.yml
@@ -27,3 +27,19 @@ subjects:
   - apiGroup: rbac.authorization.k8s.io
     kind: Group
     name: user-support
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: user-read
+  namespace: user-{{ .Values.Username }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: user-read
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: user-read

--- a/charts/rbac/CHANGELOG.md
+++ b/charts/rbac/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Allow __system:serviceaccount:concourse-main:default__ to have read-only access
 to deployments (get, list, watch) so that concourse can report rollout status
 
+## [0.4.0] - 2019-09-10
+### Added
+- Added __user-read__ `ClusterRole` with intent to be used primarily by the [__init-user__](../init-user) helm chart
+and/or any other entity that can make use of it. i.e. `ServiceAccount` binding.
+- __user-read__ `ClusterRole` scoped to read `ingresses`, `services`, `deployments`, `pods` and `configmaps`
+
 ## [0.3.0] - 2019-04-16
 ### Added
 - Allow __generic-support__ users to list namespaces. This is to make their

--- a/charts/rbac/templates/user-namespaces.yaml
+++ b/charts/rbac/templates/user-namespaces.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.teams.userRead.name }}
+  labels:
+    chart: {{ template "rbac.chart" . }}
+  annotations:
+    moj-analytical-services/teams: {{ .Values.teams.userRead.name }}
+    description: {{ .Values.teams.userRead.description }}
+rules:
+ - apiGroups: [""]
+   resources: ["pods"]
+   verbs: ["get", "list", "watch"]
+ - apiGroups: ["extensions", "apps"]
+   resources: ["deployments"]
+   verbs: ["get", "list", "watch"]
+ - apiGroups: ["", "extensions", "networking.k8s.io"]
+   resources: ["services", "ingresses", "configmaps"]
+   verbs: ["get", "list", "watch"]

--- a/charts/rbac/values.yaml
+++ b/charts/rbac/values.yaml
@@ -22,3 +22,6 @@ teams:
     concourseNamespace: concourse-main
     serviceAccountName: default
     description: "Read-only access to deployment status for concourse"
+  userRead:
+    name: user-read
+    description: "Read, list, watch etc... on ingresses, services, deployments, pods and configmaps"


### PR DESCRIPTION
Conversation earlier prompted the need for a read-only role on user
namespaces.

- Added __user-read__ `ClusterRole` with intent to be used primarily by the [__init-user__](../init-user) helm chart
and/or any other entity that can make use of it. i.e. `ServiceAccount` binding.
- __user-read__ `ClusterRole` scoped to read `ingresses`, `services`, `deployments`, `pods` and `configmaps`