### PR TITLE
Add auth.log and syslog.log to Fluentd input

### DIFF
--- a/charts/fluentd/CHANGELOG.md
+++ b/charts/fluentd/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.2.6] - 2019-09-09
+### FluentD Tuning
+- Implemented new sources files for security purposes: `/var/log/auth.log` and `/var/log/syslog`
+- Update `etcd` log formatting to avoid sending the log twice to ES/Kibana
+
 ## [0.2.5] - 2019-09-02
 ### FluentD Selector in Daemonset Spec
 - Add `selector` to `spec` in daemonset as required by `apps/v1` api
@@ -32,7 +37,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Modifying to currently working config set.
   Particularly ensuring we are capturing systemd events from journalD as our current distro is
   debian jessie
-  
+
 - Removing log sources that do not exist on systemd distros i.e.
   `/var/log/kubelet`.  Mentioned path will only exists on sysV init
   distros.
@@ -41,8 +46,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Increasing slow_flush_log_threshold to prevent the corresponding
   threshold exceeded exception
-  
+
 - Increasing buffer chunk and queue limits helps remedy flush failures while
   elasticsearch falls behind during ingestion
-  
+
 - Ensuring this pod can tolerate no-schedule taints on master nodes

--- a/charts/fluentd/Chart.yaml
+++ b/charts/fluentd/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: fluentd
-version: 0.2.5
+version: 0.2.6

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -50,6 +50,28 @@ fluentdconffiles:
   system.input.conf: |-
 
     <source>
+      @id auth.log
+      @type tail
+      path /var/log/auth.log
+      pos_file /var/log/auth.log.pos
+      <parse>
+        @type syslog
+      </parse>
+      tag authlog
+    </source>
+
+    <source>
+      @id syslog.log
+      @type tail
+      path /var/log/syslog
+      pos_file /var/log/syslog.pos
+      <parse>
+        @type syslog
+      </parse>
+      tag syslog
+    </source>
+
+    <source>
       @id docker.log
       @type tail
       format /^time="(?<time>[^)]*)" level=(?<severity>[^ ]*) msg="(?<message>[^"]*)"( err="(?<error>[^"]*)")?( statusCode=($<status_code>\d+))?/
@@ -61,9 +83,11 @@ fluentdconffiles:
     <source>
       @id etcd.log
       @type tail
-      # Not parsing this, because it doesn't have anything particularly useful to
-      # parse out of it (like severities).
-      format none
+      format multiline
+      multiline_flush_interval 5s
+      format_firstline /^\w\d{4}/
+      format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
+      time_format %m%d %H:%M:%S.%N
       path /var/log/etcd.log
       pos_file /var/log/etcd.log.pos
       tag etcd


### PR DESCRIPTION
This modification would allow Fluentd to start shipping the following Audit logs to ES:
`auth.log` and `syslog`