### PR TITLE
RBAC: Add concourse-deployments ClusterRole

### DIFF
--- a/charts/rbac/CHANGELOG.md
+++ b/charts/rbac/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2019-09-17
+### Added
+- Allow __system:serviceaccount:concourse-main:default__ to have read-only access
+to deployments (get, list, watch) so that concourse can report rollout status
 
 ## [0.3.0] - 2019-04-16
 ### Added

--- a/charts/rbac/Chart.yaml
+++ b/charts/rbac/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: User and Group RBAC resources
 name: rbac
-version: 0.3.0
+version: 0.4.0

--- a/charts/rbac/README.md
+++ b/charts/rbac/README.md
@@ -5,26 +5,27 @@ Chart to deploy user and group [RBAC](https://kubernetes.io/docs/reference/acces
 ### Installing and Upgrading a release
 
 You may need to create these namespaces:
+
 ```
 kubectl create ns airflow
 kubectl create ns apps-prod
 ```
+
 Now install the chart:
+
 ```
 helm upgrade --dry-run --debug --install --namespace default rbac-chart charts/rbac
 ```
 
 **NOTE**: Double-check output and remove `--dry-run` flag to install the chart for real.
 
-
 ## Configuration
 
-| Parameter  | Description      | Default |
-| ---------- | ---------------  | ------- |
-| `team`     | Github team name as it appears in github |   ""  |
-| `namespace` | Kubernetes namespace for namespaced scoped resources i.e. `Role`, `Rolebinding` | "" |
-| `description` | Short description of RBAC resources use | "" |
-
+| Parameter     | Description                                                                     | Default |
+| ------------- | ------------------------------------------------------------------------------- | ------- |
+| `team`        | Github team name as it appears in github                                        | ""      |
+| `namespace`   | Kubernetes namespace for namespaced scoped resources i.e. `Role`, `Rolebinding` | ""      |
+| `description` | Short description of RBAC resources use                                         | ""      |
 
 ## Contributing
 
@@ -32,16 +33,16 @@ helm upgrade --dry-run --debug --install --namespace default rbac-chart charts/r
 - Optionally add a hash/map using the configuration parameters above to `values.yaml`. See [Example](#example)
 - Append details of the resources you added to the [Configured Resources](#configured-resources) table below
 
-Configured Resources
---------------
-| Name/Team       | Type            | github org              | Scope                | Description                     |
-| --------------- | --------------- | ----------              | -----                |  -----------                    |
-| App-Support     | `Group`         | moj-analytical-services | Namespace: apps-prod |  Shiny application support. Read, edit resources except `configmaps` and `secrets`. Delete and exec `pods` |
-| Cluster-Admins  | `Group`         | moj-analytical-services | Cluster Wide         |  Kubernetes Cluster Admins      |
-| Airflow-support | `Group`         | moj-analytical-services | Namespace: airflow   |  Airflow job support. Read, edit resources except `configmaps` and `secrets`. Delete and exec `pods` |
-| generic-support | `Group`         | moj-analytical-services | Cluster Wide         |  Read-only access to non-sensitive resources in all namespaces |
-| kubelet-api     | `User`          | ""                      | Cluster Wide         |  Binding for builtin `kubelet-api` account. Auth between kubelet and API server |
+## Configured Resources
 
+| Name/Team            | Type              | github org              | Scope                | Description                                                                                               |
+| -------------------- | ----------------- | ----------------------- | -------------------- | --------------------------------------------------------------------------------------------------------- |
+| App-Support          | `Group`           | moj-analytical-services | Namespace: apps-prod | Shiny application support. Read, edit resources except `configmaps` and `secrets`. Delete and exec `pods` |
+| Cluster-Admins       | `Group`           | moj-analytical-services | Cluster Wide         | Kubernetes Cluster Admins                                                                                 |
+| Airflow-support      | `Group`           | moj-analytical-services | Namespace: airflow   | Airflow job support. Read, edit resources except `configmaps` and `secrets`. Delete and exec `pods`       |
+| generic-support      | `Group`           | moj-analytical-services | Cluster Wide         | Read-only access to non-sensitive resources in all namespaces                                             |
+| kubelet-api          | `User`            | ""                      | Cluster Wide         | Binding for builtin `kubelet-api` account. Auth between kubelet and API server                            |
+| concourse-deployment | `Service Account` | ""                      | Namespace: apps-prod | Read-only access to deployment status for concourse pipelines                                             |
 
 #### Example
 

--- a/charts/rbac/templates/concourse-deployments.yaml
+++ b/charts/rbac/templates/concourse-deployments.yaml
@@ -1,0 +1,39 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: concourse-deployments
+  labels:
+    chart: {{ template "rbac.chart" . }}
+  namespace: {{ .Values.teams.concourseDeploymentStatus.appsNamespace }}
+  annotations:
+    description: {{ .Values.teams.concourseDeploymentStatus.description | quote }}
+rules:
+  - apiGroups:
+      - "extensions"
+      - "apps"
+    resources:
+      - deployments
+    verbs:
+      - get
+      - watch
+      - list
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: concourse-deployments-binding
+  namespace: {{ .Values.teams.concourseDeploymentStatus.appsNamespace }}
+  labels:
+    chart: {{ template "rbac.chart" . }}
+  annotations:
+    description: {{ .Values.teams.concourseDeploymentStatus.description | quote }}
+roleRef:
+  kind: ClusterRole
+  name: concourse-deployments
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.teams.concourseDeploymentStatus.serviceAccountName }}
+    namespace: {{ .Values.teams.concourseDeploymentStatus.concourseNamespace }}

--- a/charts/rbac/values.yaml
+++ b/charts/rbac/values.yaml
@@ -16,3 +16,9 @@ teams:
   kubeletAPI:
     name: kubelet-api
     description: "Assigns the builtin kubelet-api-admin Clusterrole to the kubelet-api user"
+  concourseDeploymentStatus:
+    name: concourse-deployment
+    appsNamespace: apps-prod
+    concourseNamespace: concourse-main
+    serviceAccountName: default
+    description: "Read-only access to deployment status for concourse"


### PR DESCRIPTION
And bind it to the concourse-main default service account so that concourse can
report on rollout status.

https://trello.com/c/ofx66AHU/315-show-deployment-rollout-status-for-concourse-app-builds