### PR TITLE
cpanel 2.3.0: CP permissions to read apps ingress

### DIFF
--- a/charts/cpanel/CHANGELOG.md
+++ b/charts/cpanel/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+## [2.3.0] - 2019-09-30
+### Changed
+- Allow CP to read ingresses in apps namespace
+
+
 ## [2.2.0] - 2019-09-09
 ### Changed
 - Added old cpanel frontend hostname to ingress

--- a/charts/cpanel/Chart.yaml
+++ b/charts/cpanel/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Analytics Platform Control Panel API webapp
 name: cpanel
-version: 2.2.0
+version: 2.3.0

--- a/charts/cpanel/templates/rbac-read-ingresses.yaml
+++ b/charts/cpanel/templates/rbac-read-ingresses.yaml
@@ -1,0 +1,34 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: "{{ .Chart.Name }}-read-ingresses"
+  namespace: {{ .Values.appsNamespace }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: "{{ .Chart.Name }}"
+    host: {{ template "host" . }}
+rules:
+  - apiGroups: ["extensions"]
+    verbs: ["get", "list"]
+    resources: ["ingresses"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: "{{ .Chart.Name }}-read-apps-ingresses"
+  namespace: {{ .Values.appsNamespace }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: "{{ .Chart.Name }}"
+    host: {{ template "host" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "{{ .Chart.Name }}-read-ingresses"
+subjects:
+  - apiGroup: ""
+    name: "{{ .Chart.Name }}"
+    kind: ServiceAccount
+    namespace: "{{ .Release.Namespace }}"

--- a/charts/cpanel/values.yaml
+++ b/charts/cpanel/values.yaml
@@ -1,5 +1,6 @@
 servicesDomain: ""
 branch: "master"
+appsNamespace: "apps-prod"
 
 image:
   repository: quay.io/mojanalytics/control-panel


### PR DESCRIPTION
CP use the app ingress to determine the app URL. It seemed like it could
already list/read ingresses but it actually couldn't.

This adds a `Role`/`RoleBinding` that specifically allow the CP to do
that (only in the apps namespace)