### PR TITLE
cpanel 2.3.1: Removed legacy `ENABLE_K8S_RBAC` flag

### DIFF
--- a/charts/cpanel/CHANGELOG.md
+++ b/charts/cpanel/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [2.3.1] - 2019-10-04
+### Removed
+- Removed legacy `ENABLE_K8S_RBAC` flag. This is always `True` both in `dev`
+  and `alpha` - no reason to keep it around
+
+
 ## [2.3.0] - 2019-09-30
 ### Changed
 - Allow CP to read ingresses in apps namespace

--- a/charts/cpanel/Chart.yaml
+++ b/charts/cpanel/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Analytics Platform Control Panel API webapp
 name: cpanel
-version: 2.3.0
+version: 2.3.1

--- a/charts/cpanel/values.yaml
+++ b/charts/cpanel/values.yaml
@@ -10,7 +10,6 @@ image:
 env:
   DEBUG: "False"
   ELASTICSEARCH_PORT: ""
-  ENABLE_K8S_RBAC: "False"
   ENV: ""
   K8S_WORKER_ROLE_NAME: ""
   LOGS_BUCKET_NAME: ""


### PR DESCRIPTION
⚠️ : Wait for [Control Panel PR](https://github.com/ministryofjustice/analytics-platform-control-panel/pull/759) to be merged before this is merged as this flag use to default to False


Part of ticket: https://trello.com/c/OXWwaZua