### PR TITLE
Upgrade ca new env

### DIFF
--- a/charts/cluster-autoscaler/CHANGELOG.md
+++ b/charts/cluster-autoscaler/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.1.4] - 2019-10-21
+### Changed
+- Updated clusterrole api-group for replicasets
+- Upgraded cluster autoscaler to lockstep with k8s version in __OLD__ environment from `1.3.5` to `1.12.8`
+
 ## [0.1.3] - 2019-03-13
 ### Changed
 - Increased CPU requests and limits from 100m to 200m and 500m respectively  

--- a/charts/cluster-autoscaler/CHANGELOG.md
+++ b/charts/cluster-autoscaler/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.1.5] - 2019-10-21
+### Changed
+- Upgraded cluster autoscaler to lockstep with k8s version in new environment from `1.12.8` to `1.13.8`
+
 ## [0.1.4] - 2019-10-21
 ### Changed
 - Updated clusterrole api-group for replicasets

--- a/charts/cluster-autoscaler/Chart.yaml
+++ b/charts/cluster-autoscaler/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 1.12.8
+appVersion: 1.13.8
 description: Scales worker nodes within autoscaling groups
 name: cluster-autoscaler
-version: 0.1.4
+version: 0.1.5
 sources:
 - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 - https://github.com/spotinst/kubernetes-autoscaler/tree/master/cluster-autoscaler

--- a/charts/cluster-autoscaler/Chart.yaml
+++ b/charts/cluster-autoscaler/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 1.3.5
+appVersion: 1.12.8
 description: Scales worker nodes within autoscaling groups
 name: cluster-autoscaler
-version: 0.1.3
+version: 0.1.4
 sources:
 - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 - https://github.com/spotinst/kubernetes-autoscaler/tree/master/cluster-autoscaler

--- a/charts/cluster-autoscaler/templates/clusterrole.yaml
+++ b/charts/cluster-autoscaler/templates/clusterrole.yaml
@@ -25,7 +25,7 @@ rules:
 - apiGroups: [""]
   resources: ["pods","services","replicationcontrollers","persistentvolumeclaims","persistentvolumes"]
   verbs: ["watch","list","get"]
-- apiGroups: ["extensions"]
+- apiGroups: ["extensions", "apps"]
   resources: ["replicasets","daemonsets"]
   verbs: ["watch","list","get"]
 - apiGroups: ["policy"]

--- a/charts/cluster-autoscaler/values.yaml
+++ b/charts/cluster-autoscaler/values.yaml
@@ -4,7 +4,7 @@ replicaCount: 1
 
 image:
   repository: k8s.gcr.io/cluster-autoscaler
-  tag: v1.12.8
+  tag: v1.13.8
   pullPolicy: IfNotPresent
 
 autoscalingGroups:

--- a/charts/cluster-autoscaler/values.yaml
+++ b/charts/cluster-autoscaler/values.yaml
@@ -4,7 +4,7 @@ replicaCount: 1
 
 image:
   repository: k8s.gcr.io/cluster-autoscaler
-  tag: v1.3.5
+  tag: v1.12.8
   pullPolicy: IfNotPresent
 
 autoscalingGroups:


### PR DESCRIPTION
Upgraded cluster autoscaler to lockstep with k8s version in new environment from `1.12.8` to `1.13.8`