### PR TITLE
High Priority Workloads 2

### DIFF
--- a/charts/priority-classes/Chart.yaml
+++ b/charts/priority-classes/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Pod Priority Classes
 name: priority-classes
-version: 0.1.1
+version: 0.1.2
 sources:
   - https://github.com/ministryofjustice/analytics-platform-helm-charts
   - https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption

--- a/charts/priority-classes/templates/system-priority-class.yaml
+++ b/charts/priority-classes/templates/system-priority-class.yaml
@@ -1,5 +1,5 @@
 {{ range .Values.priority_classes }}
-apiVersion: scheduling.k8s.io/v1
+apiVersion: scheduling.k8s.io/v1beta1
 kind: PriorityClass
 metadata:
   name: {{ .name }}

--- a/charts/priority-classes/values.yaml
+++ b/charts/priority-classes/values.yaml
@@ -1,7 +1,4 @@
 priority_classes:
-  - name: system
-    priority_value: 1000000000
-    description: "Reserved for high priority system pods/daemonsets"
   - name: rstudio
     priority_value: 10000000
     description: "10 million"


### PR DESCRIPTION
[Trello](https://trello.com/c/sMRJcSXN)

Relates to [PR](https://github.com/ministryofjustice/analytics-platform-helm-charts/pull/389)

Our deployments of k8s are both too old and new:
- Old because they do not have stable `v1` in `scheduling.k8s.io` yet
- New because `PriorityClass` is enabled by default and the __system__ `PriorityClass` is deployed as a default to same value this chart used to set.

**Deployed to all envs**