### PR TITLE
Rstudio: Add `spec.selector.matchLabels` to deployment

### DIFF
--- a/charts/rstudio/CHANGELOG.md
+++ b/charts/rstudio/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.1.3] - 2019-10-23
+### Added
+Added `spec.selector.matchLabels` to deployment spec
 
 ## [2.1.2] - 2019-10-21
 ### Added

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: RStudio with Auth0 authentication proxy
 name: rstudio
-version: 2.1.2
+version: 2.1.3
 appVersion: "RStudio: 1.2.1335+conda, R: 3.5.1, Python: 3.7.1, patch: 3"

--- a/charts/rstudio/templates/deployment.yml
+++ b/charts/rstudio/templates/deployment.yml
@@ -151,3 +151,6 @@ spec:
         - name: home
           persistentVolumeClaim:
             claimName: nfs-home
+  selector:
+    matchLabels:
+      app: "{{ .Chart.Name }}"


### PR DESCRIPTION
Unfortunately apps/v1's Deployments now needs spec.selector.matchLabels in order to work.
How did it even work before?

bug fix: https://trello.com/c/HfICQ15Y/386-add-matchselector-to-tools-charts