### PR TITLE
Truncate `host` labels to work for new domain

### DIFF
--- a/charts/airflow-sqlite/CHANGELOG.md
+++ b/charts/airflow-sqlite/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [0.2.3] - 2019-10-25
+### Changed
+- Truncate `host` label to make sure it's less than 63
+  characters once we move to new domain.
+
+
 ## [0.2.2] - 2019-08-23
 ### Changed
 Bumped auth-proxy to version v5.2.1.

--- a/charts/airflow-sqlite/Chart.yaml
+++ b/charts/airflow-sqlite/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 description: Airflow with sqlite. Tasks are run as pods
 name: airflow-sqlite
 icon: https://airflow.incubator.apache.org/_images/pin_large.png
-version: 0.2.2
+version: 0.2.3
 appVersion: 1.10.3

--- a/charts/airflow-sqlite/templates/deployment.yml
+++ b/charts/airflow-sqlite/templates/deployment.yml
@@ -6,7 +6,7 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: {{ .Chart.Name }}
-    host: {{ template "host" . }}
+    host: {{ include "host" . | trunc 63 }}
     component: all
   annotations:
     checksum/config: {{ include (print $.Template.BasePath "/configmap.yml") . | sha256sum }}
@@ -22,6 +22,7 @@ spec:
         app: {{ .Chart.Name }}
         component: all
         airflow-redis-client: "false"
+        host: {{ include "host" . | trunc 63 }}
     spec:
       serviceAccountName: {{ .Release.Name }}
       initContainers:

--- a/charts/airflow-sqlite/templates/ingress.yml
+++ b/charts/airflow-sqlite/templates/ingress.yml
@@ -6,7 +6,7 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: {{ .Chart.Name }}
-    host: {{ template "host" . }}
+    host: {{ include "host" . | trunc 63 }}
   annotations:
     kubernetes.io/ingress.class: "nginx"
 spec:

--- a/charts/airflow-sqlite/templates/secrets.yml
+++ b/charts/airflow-sqlite/templates/secrets.yml
@@ -6,7 +6,7 @@ metadata:
   labels:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app: {{ .Release.Name }}
-    host: {{ template "host" . }}
+    host: {{ include "host" . | trunc 63 }}
 type: Opaque
 data:
   auth0_domain: {{ .Values.authProxy.auth0_domain | b64enc | quote }}

--- a/charts/airflow-sqlite/templates/service.yml
+++ b/charts/airflow-sqlite/templates/service.yml
@@ -7,6 +7,7 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: {{ .Release.Name }}
     component: "webserver"
+    host: {{ include "host" . | trunc 63 }}
 spec:
   sessionAffinity: ClientIP
   selector:

--- a/charts/cpanel/CHANGELOG.md
+++ b/charts/cpanel/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [2.3.2] - 2019-10-25
+### Changed
+- Truncate `host` label to make sure it's less than 63
+  characters once we move to new domain.
+
+
 ## [2.3.1] - 2019-10-04
 ### Removed
 - Removed legacy `ENABLE_K8S_RBAC` flag. This is always `True` both in `dev`

--- a/charts/cpanel/Chart.yaml
+++ b/charts/cpanel/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Analytics Platform Control Panel API webapp
 name: cpanel
-version: 2.3.1
+version: 2.3.2

--- a/charts/cpanel/templates/_helpers.tpl
+++ b/charts/cpanel/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 Control Panel hostname
 */}}
 {{- define "host" -}}
-"controlpanel.{{ .Values.servicesDomain }}"
+{{- printf "controlpanel.%s" .Values.servicesDomain -}}
 {{- end -}}
 
 {{/*

--- a/charts/cpanel/templates/cluster-role.yaml
+++ b/charts/cpanel/templates/cluster-role.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: "{{ .Chart.Name }}"
-    host: {{ template "host" . }}
+    host: {{ include "host" . | trunc 63 }}
 rules:
   - apiGroups: [""]
     verbs: ["list"]

--- a/charts/cpanel/templates/deployment.yaml
+++ b/charts/cpanel/templates/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: "{{ .Chart.Name }}"
-    host: {{ template "host" . }}
+    host: {{ include "host" . | trunc 63 }}
 spec:
   replicas: 3
   selector:
@@ -16,6 +16,7 @@ spec:
       labels:
         app: "{{ .Chart.Name }}"
         {{ .Release.Name }}-redis-client: "true"
+        host: {{ include "host" . | trunc 63 }}
       annotations:
         iam.amazonaws.com/role: "{{ .Values.aws.iamRole }}"
     spec:

--- a/charts/cpanel/templates/env-configmap.yaml
+++ b/charts/cpanel/templates/env-configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: "{{ .Chart.Name }}"
-    host: {{ template "host" . }}
+    host: {{ include "host" . | trunc 63 }}
 data:
   {{ range $key, $value := .Values.env -}}
   {{ $key }}: {{ $value | quote }}

--- a/charts/cpanel/templates/ingress.yaml
+++ b/charts/cpanel/templates/ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: "{{ .Chart.Name }}"
-    host: {{ template "host" . }}
+    host: {{ include "host" . | trunc 63 }}
   annotations:
     kubernetes.io/ingress.class: "nginx"
 spec:

--- a/charts/cpanel/templates/job.yaml
+++ b/charts/cpanel/templates/job.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: "{{ .Chart.Name }}"
-    host: {{ template "host" . }}
+    host: {{ include "host" . | trunc 63 }}
   annotations:
     "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-weight": "-5"

--- a/charts/cpanel/templates/rbac-read-ingresses.yaml
+++ b/charts/cpanel/templates/rbac-read-ingresses.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: "{{ .Chart.Name }}"
-    host: {{ template "host" . }}
+    host: {{ include "host" . | trunc 63 }}
 rules:
   - apiGroups: ["extensions"]
     verbs: ["get", "list"]
@@ -22,7 +22,7 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: "{{ .Chart.Name }}"
-    host: {{ template "host" . }}
+    host: {{ include "host" . | trunc 63 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/cpanel/templates/role-binding.yaml
+++ b/charts/cpanel/templates/role-binding.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: "{{ .Chart.Name }}"
-    host: {{ template "host" . }}
+    host: {{ include "host" . | trunc 63 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   name: "{{ .Chart.Name }}"

--- a/charts/cpanel/templates/secrets.yaml
+++ b/charts/cpanel/templates/secrets.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: "{{ .Chart.Name }}"
-    host: {{ template "host" . }}
+    host: {{ include "host" . | trunc 63 }}
 type: Opaque
 data:
   postgres-password: {{ .Values.postgresql.postgresPassword | b64enc | quote }}
@@ -17,7 +17,7 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: "{{ .Chart.Name }}"
-    host: {{ template "host" . }}
+    host: {{ include "host" . | trunc 63 }}
 type: Opaque
 data:
   DB_HOST: {{ include "postgresHost" . | b64enc | quote }}
@@ -32,7 +32,7 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: "{{ .Chart.Name }}"
-    host: {{ template "host" . }}
+    host: {{ include "host" . | trunc 63 }}
 type: Opaque
 data:
   {{ range $key, $value := .Values.secretEnv -}}

--- a/charts/cpanel/templates/service-account.yaml
+++ b/charts/cpanel/templates/service-account.yaml
@@ -6,4 +6,4 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: "{{ .Chart.Name }}"
-    host: {{ template "host" . }}
+    host: {{ include "host" . | trunc 63 }}

--- a/charts/cpanel/templates/service.yaml
+++ b/charts/cpanel/templates/service.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: "{{ .Chart.Name }}"
-    host: {{ template "host" . }}
+    host: {{ include "host" . | trunc 63 }}
 spec:
   ports:
   - port: 80

--- a/charts/jupyter-lab/CHANGELOG.md
+++ b/charts/jupyter-lab/CHANGELOG.md
@@ -5,10 +5,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [0.4.5] - 2019-10-25
+### Changed
+- Truncate `host` label to make sure it's less than 63
+  characters once we move to new domain.
+
+
 ## [0.4.4] - 2019-10-21
 ### Added
 Added `priorityClassName` to pod spec
 Updated `Deployment` APIGroup
+
 
 ## [0.4.3] - 2019-08-23
 ### Changed

--- a/charts/jupyter-lab/Chart.yaml
+++ b/charts/jupyter-lab/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: Jupyter Lab with Auth0 authentication proxy
 name: jupyter-lab
-version: 0.4.4
+version: 0.4.5
 appVersion: v0.6.7

--- a/charts/jupyter-lab/templates/configmap-bash-profile.yaml
+++ b/charts/jupyter-lab/templates/configmap-bash-profile.yaml
@@ -6,6 +6,6 @@ metadata:
   labels:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app: {{ .Chart.Name }}
-    host: {{ template "host" . }}
+    host: {{ include "host" . | trunc 63 }}
 data:
 {{ (.Files.Glob "files/*").AsConfig | indent 2 }} # Flatten script into yaml map

--- a/charts/jupyter-lab/templates/deployment.yaml
+++ b/charts/jupyter-lab/templates/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app: {{ .Chart.Name }}
-    host: {{ template "host" . }}
+    host: {{ include "host" . | trunc 63 }}
     "mojanalytics.xyz/idleable": "true"
 spec:
   selector:
@@ -22,7 +22,7 @@ spec:
     metadata:
       labels:
         app: {{ .Chart.Name }}
-        host: {{ template "host" . }}
+        host: {{ include "host" . | trunc 63 }}
         "mojanalytics.xyz/idleable": "true"
       annotations:
         iam.amazonaws.com/role: {{ .Values.aws.iamRole }}

--- a/charts/jupyter-lab/templates/ingress.yaml
+++ b/charts/jupyter-lab/templates/ingress.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app: {{ .Chart.Name }}
-    host: {{ template "host" . }}
+    host: {{ include "host" . | trunc 63 }}
   annotations:
     kubernetes.io/ingress.class: "nginx"
 spec:

--- a/charts/jupyter-lab/templates/job-bash-profile.yaml
+++ b/charts/jupyter-lab/templates/job-bash-profile.yaml
@@ -6,14 +6,14 @@ metadata:
   labels:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app: {{ .Chart.Name }}
-    host: {{ template "host" . }}
+    host: {{ include "host" . | trunc 63 }}
 spec:
   template:
     metadata:
       name: {{ template "fullname" . }}-job
       labels:
         chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-        host: {{ template "host" . }}
+        host: {{ include "host" . | trunc 63 }}
         # NOTE: DO NOT add `app` label here as it's used by the service
         #       to direct traffic to the jupyter pod and we don't want the
         #       Job's pod to receive that traffic.

--- a/charts/jupyter-lab/templates/secrets.yaml
+++ b/charts/jupyter-lab/templates/secrets.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app: {{ .Chart.Name }}
-    host: {{ template "host" . }}
+    host: {{ include "host" . | trunc 63 }}
 type: Opaque
 data:
   auth0_domain: {{ .Values.authProxy.auth0_domain | b64enc | quote }}

--- a/charts/jupyter-lab/templates/service.yaml
+++ b/charts/jupyter-lab/templates/service.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app: {{ .Chart.Name }}
-    host: {{ template "host" . }}
+    host: {{ include "host" . | trunc 63 }}
 spec:
   ports:
     - name: http

--- a/charts/rstudio/CHANGELOG.md
+++ b/charts/rstudio/CHANGELOG.md
@@ -4,15 +4,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+## [2.1.4] - 2019-10-25
+### Changed
+- Truncate `host` label to make sure it's less than 63
+  characters once we move to new domain.
+- Added labels to `ServiceAccount` for consistency
+
+
 ## [2.1.3] - 2019-10-23
 ### Added
 Added `spec.selector.matchLabels` to deployment spec
+
 
 ## [2.1.2] - 2019-10-21
 ### Added
 Added `priorityClassName` to pod spec
 Updated `Deployment` APIGroup
-Increased requested memory from `5GI` to `8GI` 
+Increased requested memory from `5GI` to `8GI`
+
 
 ## [2.1.1] - 2019-08-23
 ### Changed

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: RStudio with Auth0 authentication proxy
 name: rstudio
-version: 2.1.3
+version: 2.1.4
 appVersion: "RStudio: 1.2.1335+conda, R: 3.5.1, Python: 3.7.1, patch: 3"

--- a/charts/rstudio/templates/deployment.yml
+++ b/charts/rstudio/templates/deployment.yml
@@ -5,7 +5,7 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: "{{ .Chart.Name }}"
-    host: "{{ template "host" .}}"
+    host: "{{ include "host" . | trunc 63 }}"
     "mojanalytics.xyz/idleable": "true"
 spec:
   replicas: 1
@@ -18,7 +18,7 @@ spec:
     metadata:
       labels:
         app: "{{ .Chart.Name }}"
-        host: "{{ template "host" .}}"
+        host: "{{ include "host" . | trunc 63 }}"
         "mojanalytics.xyz/idleable": "true"
       annotations:
         iam.amazonaws.com/role: {{ .Values.aws.iamRole }}

--- a/charts/rstudio/templates/ingress.yml
+++ b/charts/rstudio/templates/ingress.yml
@@ -5,7 +5,7 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: "{{ .Chart.Name }}"
-    host: "{{ template "host" .}}"
+    host: "{{ include "host" . | trunc 63 }}"
   annotations:
     kubernetes.io/ingress.class: "nginx"
 spec:

--- a/charts/rstudio/templates/secrets.yml
+++ b/charts/rstudio/templates/secrets.yml
@@ -5,7 +5,7 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: "{{ .Chart.Name }}"
-    host: "{{ template "host" .}}"
+    host: "{{ include "host" . | trunc 63 }}"
 type: Opaque
 data:
   client_secret: {{ .Values.authProxy.auth0.clientSecret | b64enc | quote }}

--- a/charts/rstudio/templates/service-account.yaml
+++ b/charts/rstudio/templates/service-account.yaml
@@ -3,3 +3,7 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.username }}-rstudio
   namespace: {{ .Release.Namespace }}
+  labels:
+    app: "{{ .Chart.Name }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    host: "{{ include "host" . | trunc 63 }}"

--- a/charts/rstudio/templates/service.yml
+++ b/charts/rstudio/templates/service.yml
@@ -5,7 +5,7 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: "{{ .Chart.Name }}"
-    host: "{{ template "host" .}}"
+    host: "{{ include "host" . | trunc 63 }}"
 spec:
   sessionAffinity: ClientIP
   selector:

--- a/charts/webapp/CHANGELOG.md
+++ b/charts/webapp/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+## [2.3.4] - 2019-10-25
+### Changed
+- Truncate `host` label to make sure it's less than 63
+  characters once we move to new domain.
+- Use `hostname` helper in NOTES.txt
+
+
 ## [2.3.3] - 2019-10-23
 ### Added
 Added `Values.secretEnv.` to values.yaml and added secret that can be overridden by thh helm values override. This is to set dynamic env vars from AWS Parameters when deploying.

--- a/charts/webapp/Chart.yaml
+++ b/charts/webapp/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: webapp Helm chart for Kubernetes
 name: webapp
-version: 2.3.3
+version: 2.3.4
 fluentbitVersion: 1.1.1

--- a/charts/webapp/templates/NOTES.txt
+++ b/charts/webapp/templates/NOTES.txt
@@ -1,1 +1,1 @@
-Your webapp will be available shortly at {{ .Values.WebApp.Name }}.{{ .Values.WebApp.BaseHost }}
+Your webapp will be available shortly at https://{{ template "hostname" . }}

--- a/charts/webapp/templates/deployment.yaml
+++ b/charts/webapp/templates/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     repo: "{{ .Values.WebApp.GithubRepo }}"
     app: {{ template "fullname" . }}
-    host: {{ template "hostname" . }}
+    host: {{ include "hostname" . | trunc 63 }}
 spec:
   selector:
     matchLabels:
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         app: {{ template "fullname" . }}
-        host: {{ template "hostname" . }}
+        host: {{ include "hostname" . | trunc 63 }}
       annotations:
         checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
         iam.amazonaws.com/role: {{ .Values.AWS.IAMRole }}

--- a/charts/webapp/templates/fluent-bit-configmap.yml
+++ b/charts/webapp/templates/fluent-bit-configmap.yml
@@ -6,7 +6,7 @@ metadata:
     app: {{ template "fullname" . }}
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
-    host: {{ template "hostname" . }}
+    host: {{ include "hostname" . | trunc 63 }}
   name: "{{ template "fullname" . }}-fluent-bit"
 data:
   source_tag: "{{ template "fullname" . }}"

--- a/charts/webapp/templates/ingress.yaml
+++ b/charts/webapp/templates/ingress.yaml
@@ -6,7 +6,7 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     app: {{ template "fullname" . }}
     repo: {{ .Values.WebApp.GithubRepo }}
-    host: {{ template "hostname" . }}
+    host: {{ include "hostname" . | trunc 63 }}
   annotations:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/affinity: "cookie"

--- a/charts/webapp/templates/secrets.yaml
+++ b/charts/webapp/templates/secrets.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: {{ template "fullname" . }}
-    host: {{ template "hostname" . }}
+    host: {{ include "hostname" . | trunc 63 }}
 type: Opaque
 data:
   client_secret: {{ .Values.AuthProxy.Auth0.ClientSecret | b64enc | quote }}
@@ -27,7 +27,7 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: {{ template "fullname" . }}
-    host: {{ template "hostname" . }}
+    host: {{ include "hostname" . | trunc 63 }}
 type: Opaque
 data:
   {{ range $key, $value := .Values.secretEnv -}}

--- a/charts/webapp/templates/service-account.yaml
+++ b/charts/webapp/templates/service-account.yaml
@@ -6,4 +6,4 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     repo: "{{ .Values.WebApp.GithubRepo }}"
     app: {{ template "fullname" . }}
-    host: {{ template "hostname" . }}
+    host: {{ include "hostname" . | trunc 63 }}

--- a/charts/webapp/templates/service.yaml
+++ b/charts/webapp/templates/service.yaml
@@ -6,7 +6,7 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     repo: "{{ .Values.WebApp.GithubRepo }}"
     app: {{ template "fullname" . }}
-    host: {{ template "hostname" . }}
+    host: {{ include "hostname" . | trunc 63 }}
 spec:
   sessionAffinity: ClientIP
   ports:


### PR DESCRIPTION
kubernetes labels (among other things) have a 63 characters
limitation.

Charts updated:
- airflow-sqlite
- cpanel
- jupyter-lab
- rstudio
- webapp

Part of ticket: https://trello.com/c/kVT0QFqe