### PR TITLE
unidler v4.0.2: play well with long host labels

### DIFF
--- a/charts/unidler/CHANGELOG.md
+++ b/charts/unidler/CHANGELOG.md
@@ -5,6 +5,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [v4.0.2] - 2019-10-29
+### Changed
+Works with `host` labels truncated at 63 chars (k8s limit).
+
+This is to be sure the unidler searches for the same label value when
+unidling things in the new clusters (whose hosts are very long).
+
+**NOTE** It shouldn't make any difference on existing clusters as these
+labels don't exceed this limit. On new clusters should work as before.
+
+- [unidler PR](https://github.com/ministryofjustice/analytics-platform-go-unidler/pull/12)
+- Part of ticket: https://trello.com/c/kVT0QFqe
+
+
 ## [v4.0.1] - 2019-03-27
 ### Fixed
 Use new version of the unidler which uses strategic merge patch instead of

--- a/charts/unidler/Chart.yaml
+++ b/charts/unidler/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: unidler proxy
 name: unidler
-version: "v4.0.1"
-appVersion: "v1.0.2"
+version: "v4.0.2"
+appVersion: "v1.0.3"

--- a/charts/unidler/values.yaml
+++ b/charts/unidler/values.yaml
@@ -1,7 +1,7 @@
 # Docker image
 image:
   name: quay.io/mojanalytics/go-unidler
-  tag: v1.0.2
+  tag: v1.0.3
   pullPolicy: IfNotPresent
 
 replicaCount: 3


### PR DESCRIPTION
New version of unidler truncate `host` to 63 characters to be sure it's
looking for the correct label values (as these can't be more than 63
characters and new version of tools truncate these)

See:
- [unidler PR](https://github.com/ministryofjustice/analytics-platform-go-unidler/pull/12)
- Part of ticket: https://trello.com/c/kVT0QFqe