### PR TITLE
Tools play well with long domains/hosts

### DIFF
--- a/charts/airflow-sqlite/CHANGELOG.md
+++ b/charts/airflow-sqlite/CHANGELOG.md
@@ -5,6 +5,32 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [0.2.4] - 2019-11-01
+### Changed
+Diffent approach to long `host` labels.
+Truncate to 63 chars was not good enough if the 63th
+character happened to be a dot (`.`) because labels
+can't end with a dot.
+
+To maintain compatibility with existing clusters, charts
+and unidler:
+- if the length of `host` label value is <= 63 the value
+  is the full host (as before)
+- if the full host if longer than 63 characters we split
+  by dots and we only use the part of the host before
+  the first dot
+
+Labels changes:
+- Added `unidle-key` label to resources selected by the unidler
+  to be more explicit than just using `host`.
+- `host` label stays there as it's used in old `alpha` by
+  unidler. We'll remove once `alpha` is retired
+- `host` label is only kept for `Ingress`, `Deployment` and
+  `Service` as there are the only `host` labels used by unidler
+  (the rest were just added for consistency for human debugging
+  but could lead to confusion, so removing)
+
+
 ## [0.2.3] - 2019-10-25
 ### Changed
 - Truncate `host` label to make sure it's less than 63

--- a/charts/airflow-sqlite/Chart.yaml
+++ b/charts/airflow-sqlite/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 description: Airflow with sqlite. Tasks are run as pods
 name: airflow-sqlite
 icon: https://airflow.incubator.apache.org/_images/pin_large.png
-version: 0.2.3
+version: 0.2.4
 appVersion: 1.10.3

--- a/charts/airflow-sqlite/templates/_helpers.tpl
+++ b/charts/airflow-sqlite/templates/_helpers.tpl
@@ -22,3 +22,23 @@ e.g. username-airflow.example.com
 {{- define "host" -}}
 {{- (printf "%s-%s.%s" .Values.Username .Chart.Name .Values.toolsDomain) | lower -}}
 {{- end -}}
+
+{{/*
+unidle-key: used by unidler to find airflow-sqlite resources
+
+will be the host if <= 63 characters (no change in old `alpha`
+cluster) or the part before the first dot (".") otherwise
+(to avoid problems with new, long, domain)
+
+examples:
+host="alice-airflow-sqlite.example.com" => returns "alice-airflow-sqlite.example.com"
+host="alice-airflow-sqlite.verylongdomain[...]example.com" => returns "alice-airflow-sqlite"
+*/}}
+{{- define "unidle_key" -}}
+    {{- $label := include "host" . -}}
+    {{- if gt (len $label) 63 -}}
+        {{- $parts := split "." $label -}}
+        {{- $label = $parts._0 -}}
+    {{- end -}}
+    {{- $label | quote -}}
+{{- end -}}

--- a/charts/airflow-sqlite/templates/deployment.yml
+++ b/charts/airflow-sqlite/templates/deployment.yml
@@ -6,7 +6,8 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: {{ .Chart.Name }}
-    host: {{ include "host" . | trunc 63 }}
+    host: {{ include "unidle_key" . }}
+    unidle-key: {{ include "unidle_key" . }}
     component: all
   annotations:
     checksum/config: {{ include (print $.Template.BasePath "/configmap.yml") . | sha256sum }}
@@ -22,7 +23,6 @@ spec:
         app: {{ .Chart.Name }}
         component: all
         airflow-redis-client: "false"
-        host: {{ include "host" . | trunc 63 }}
     spec:
       serviceAccountName: {{ .Release.Name }}
       initContainers:

--- a/charts/airflow-sqlite/templates/ingress.yml
+++ b/charts/airflow-sqlite/templates/ingress.yml
@@ -6,7 +6,8 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: {{ .Chart.Name }}
-    host: {{ include "host" . | trunc 63 }}
+    host: {{ include "unidle_key" . }}
+    unidle-key: {{ include "unidle_key" . }}
   annotations:
     kubernetes.io/ingress.class: "nginx"
 spec:

--- a/charts/airflow-sqlite/templates/secrets.yml
+++ b/charts/airflow-sqlite/templates/secrets.yml
@@ -6,7 +6,6 @@ metadata:
   labels:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app: {{ .Release.Name }}
-    host: {{ include "host" . | trunc 63 }}
 type: Opaque
 data:
   auth0_domain: {{ .Values.authProxy.auth0_domain | b64enc | quote }}

--- a/charts/airflow-sqlite/templates/service.yml
+++ b/charts/airflow-sqlite/templates/service.yml
@@ -7,7 +7,8 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: {{ .Release.Name }}
     component: "webserver"
-    host: {{ include "host" . | trunc 63 }}
+    host: {{ include "unidle_key" . }}
+    unidle-key: {{ include "unidle_key" . }}
 spec:
   sessionAffinity: ClientIP
   selector:

--- a/charts/cpanel/CHANGELOG.md
+++ b/charts/cpanel/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [2.3.3] - 2019-11-04
+### Changed
+- Removed unused `host` label.
+
+
 ## [2.3.2] - 2019-10-25
 ### Changed
 - Truncate `host` label to make sure it's less than 63

--- a/charts/cpanel/Chart.yaml
+++ b/charts/cpanel/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Analytics Platform Control Panel API webapp
 name: cpanel
-version: 2.3.2
+version: 2.3.3

--- a/charts/cpanel/templates/cluster-role.yaml
+++ b/charts/cpanel/templates/cluster-role.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: "{{ .Chart.Name }}"
-    host: {{ include "host" . | trunc 63 }}
 rules:
   - apiGroups: [""]
     verbs: ["list"]

--- a/charts/cpanel/templates/deployment.yaml
+++ b/charts/cpanel/templates/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: "{{ .Chart.Name }}"
-    host: {{ include "host" . | trunc 63 }}
 spec:
   replicas: 3
   selector:
@@ -16,7 +15,6 @@ spec:
       labels:
         app: "{{ .Chart.Name }}"
         {{ .Release.Name }}-redis-client: "true"
-        host: {{ include "host" . | trunc 63 }}
       annotations:
         iam.amazonaws.com/role: "{{ .Values.aws.iamRole }}"
     spec:

--- a/charts/cpanel/templates/env-configmap.yaml
+++ b/charts/cpanel/templates/env-configmap.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: "{{ .Chart.Name }}"
-    host: {{ include "host" . | trunc 63 }}
 data:
   {{ range $key, $value := .Values.env -}}
   {{ $key }}: {{ $value | quote }}

--- a/charts/cpanel/templates/ingress.yaml
+++ b/charts/cpanel/templates/ingress.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: "{{ .Chart.Name }}"
-    host: {{ include "host" . | trunc 63 }}
   annotations:
     kubernetes.io/ingress.class: "nginx"
 spec:

--- a/charts/cpanel/templates/job.yaml
+++ b/charts/cpanel/templates/job.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: "{{ .Chart.Name }}"
-    host: {{ include "host" . | trunc 63 }}
   annotations:
     "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-weight": "-5"

--- a/charts/cpanel/templates/rbac-read-ingresses.yaml
+++ b/charts/cpanel/templates/rbac-read-ingresses.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: "{{ .Chart.Name }}"
-    host: {{ include "host" . | trunc 63 }}
 rules:
   - apiGroups: ["extensions"]
     verbs: ["get", "list"]
@@ -22,7 +21,6 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: "{{ .Chart.Name }}"
-    host: {{ include "host" . | trunc 63 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/cpanel/templates/role-binding.yaml
+++ b/charts/cpanel/templates/role-binding.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: "{{ .Chart.Name }}"
-    host: {{ include "host" . | trunc 63 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   name: "{{ .Chart.Name }}"

--- a/charts/cpanel/templates/secrets.yaml
+++ b/charts/cpanel/templates/secrets.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: "{{ .Chart.Name }}"
-    host: {{ include "host" . | trunc 63 }}
 type: Opaque
 data:
   postgres-password: {{ .Values.postgresql.postgresPassword | b64enc | quote }}
@@ -17,7 +16,6 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: "{{ .Chart.Name }}"
-    host: {{ include "host" . | trunc 63 }}
 type: Opaque
 data:
   DB_HOST: {{ include "postgresHost" . | b64enc | quote }}
@@ -32,7 +30,6 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: "{{ .Chart.Name }}"
-    host: {{ include "host" . | trunc 63 }}
 type: Opaque
 data:
   {{ range $key, $value := .Values.secretEnv -}}

--- a/charts/cpanel/templates/service-account.yaml
+++ b/charts/cpanel/templates/service-account.yaml
@@ -6,4 +6,3 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: "{{ .Chart.Name }}"
-    host: {{ include "host" . | trunc 63 }}

--- a/charts/cpanel/templates/service.yaml
+++ b/charts/cpanel/templates/service.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: "{{ .Chart.Name }}"
-    host: {{ include "host" . | trunc 63 }}
 spec:
   ports:
   - port: 80

--- a/charts/jupyter-lab/CHANGELOG.md
+++ b/charts/jupyter-lab/CHANGELOG.md
@@ -5,6 +5,32 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [0.4.6] - 2019-11-04
+### Changed
+Diffent approach to long `host` labels.
+Truncate to 63 chars was not good enough if the 63th
+character happened to be a dot (`.`) because labels
+can't end with a dot.
+
+To maintain compatibility with existing clusters, charts
+and unidler:
+- if the length of `host` label value is <= 63 the value
+  is the full host (as before)
+- if the full host if longer than 63 characters we split
+  by dots and we only use the part of the host before
+  the first dot
+
+Labels changes:
+- Added `unidle-key` label to resources selected by the unidler
+  to be more explicit than just using `host`.
+- `host` label stays there as it's used in old `alpha` by
+  unidler. We'll remove once `alpha` is retired
+- `host` label is only kept for `Ingress`, `Deployment` and
+  `Service` as there are the only `host` labels used by unidler
+  (the rest were just added for consistency for human debugging
+  but could lead to confusion, so removing)
+
+
 ## [0.4.5] - 2019-10-25
 ### Changed
 - Truncate `host` label to make sure it's less than 63

--- a/charts/jupyter-lab/Chart.yaml
+++ b/charts/jupyter-lab/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: Jupyter Lab with Auth0 authentication proxy
 name: jupyter-lab
-version: 0.4.5
+version: 0.4.6
 appVersion: v0.6.7

--- a/charts/jupyter-lab/templates/_helpers.tpl
+++ b/charts/jupyter-lab/templates/_helpers.tpl
@@ -16,3 +16,24 @@ e.g. username-jupyter-lab.example.com
 {{- define "host" -}}
 {{- (printf "%s-jupyter-lab.%s" .Values.Username .Values.toolsDomain) | lower -}}
 {{- end -}}
+
+
+{{/*
+unidle-key: used by unidler to find RStudio resources
+
+will be the host if <= 63 characters (no change in old `alpha`
+cluster) or the part before the first dot (".") otherwise
+(to avoid problems with new, long, domain)
+
+examples:
+host="alice-jupyter-lab.example.com" => returns "alice-jupyter-lab.example.com"
+host="alice-jupyter-lab.verylongdomain[...]example.com" => returns "alice-jupyter-lab"
+*/}}
+{{- define "unidle_key" -}}
+    {{- $label := include "host" . -}}
+    {{- if gt (len $label) 63 -}}
+        {{- $parts := split "." $label -}}
+        {{- $label = $parts._0 -}}
+    {{- end -}}
+    {{- $label | quote -}}
+{{- end -}}

--- a/charts/jupyter-lab/templates/configmap-bash-profile.yaml
+++ b/charts/jupyter-lab/templates/configmap-bash-profile.yaml
@@ -6,6 +6,5 @@ metadata:
   labels:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app: {{ .Chart.Name }}
-    host: {{ include "host" . | trunc 63 }}
 data:
 {{ (.Files.Glob "files/*").AsConfig | indent 2 }} # Flatten script into yaml map

--- a/charts/jupyter-lab/templates/deployment.yaml
+++ b/charts/jupyter-lab/templates/deployment.yaml
@@ -6,7 +6,8 @@ metadata:
   labels:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app: {{ .Chart.Name }}
-    host: {{ include "host" . | trunc 63 }}
+    host: {{ include "unidle_key" . }}
+    unidle-key: {{ include "unidle_key" . }}
     "mojanalytics.xyz/idleable": "true"
 spec:
   selector:
@@ -22,7 +23,6 @@ spec:
     metadata:
       labels:
         app: {{ .Chart.Name }}
-        host: {{ include "host" . | trunc 63 }}
         "mojanalytics.xyz/idleable": "true"
       annotations:
         iam.amazonaws.com/role: {{ .Values.aws.iamRole }}

--- a/charts/jupyter-lab/templates/ingress.yaml
+++ b/charts/jupyter-lab/templates/ingress.yaml
@@ -6,7 +6,8 @@ metadata:
   labels:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app: {{ .Chart.Name }}
-    host: {{ include "host" . | trunc 63 }}
+    host: {{ include "unidle_key" . }}
+    unidle-key: {{ include "unidle_key" . }}
   annotations:
     kubernetes.io/ingress.class: "nginx"
 spec:

--- a/charts/jupyter-lab/templates/job-bash-profile.yaml
+++ b/charts/jupyter-lab/templates/job-bash-profile.yaml
@@ -6,14 +6,12 @@ metadata:
   labels:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app: {{ .Chart.Name }}
-    host: {{ include "host" . | trunc 63 }}
 spec:
   template:
     metadata:
       name: {{ template "fullname" . }}-job
       labels:
         chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-        host: {{ include "host" . | trunc 63 }}
         # NOTE: DO NOT add `app` label here as it's used by the service
         #       to direct traffic to the jupyter pod and we don't want the
         #       Job's pod to receive that traffic.

--- a/charts/jupyter-lab/templates/secrets.yaml
+++ b/charts/jupyter-lab/templates/secrets.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app: {{ .Chart.Name }}
-    host: {{ include "host" . | trunc 63 }}
 type: Opaque
 data:
   auth0_domain: {{ .Values.authProxy.auth0_domain | b64enc | quote }}

--- a/charts/jupyter-lab/templates/service.yaml
+++ b/charts/jupyter-lab/templates/service.yaml
@@ -6,7 +6,8 @@ metadata:
   labels:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app: {{ .Chart.Name }}
-    host: {{ include "host" . | trunc 63 }}
+    host: {{ include "unidle_key" . }}
+    unidle-key: {{ include "unidle_key" . }}
 spec:
   ports:
     - name: http

--- a/charts/rstudio/CHANGELOG.md
+++ b/charts/rstudio/CHANGELOG.md
@@ -5,6 +5,32 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [2.1.5] - 2019-10-30
+### Changed
+Diffent approach to long `host` labels.
+Truncate to 63 chars was not good enough if the 63th
+character happened to be a dot (`.`) because labels
+can't end with a dot.
+
+To maintain compatibility with existing clusters, charts
+and unidler:
+- if the length of `host` label value is <= 63 the value
+  is the full host (as before)
+- if the full host if longer than 63 characters we split
+  by dots and we only use the part of the host before
+  the first dot
+
+Labels changes:
+- Added `unidle-key` label to resources selected by the unidler
+  to be more explicit than just using `host`.
+- `host` label stays there as it's used in old `alpha` by
+  unidler. We'll remove once `alpha` is retired
+- `host` label is only kept for `Ingress`, `Deployment` and
+  `Service` as there are the only `host` labels used by unidler
+  (the rest were just added for consistency for human debugging
+  but could lead to confusion, so removing)
+
+
 ## [2.1.4] - 2019-10-25
 ### Changed
 - Truncate `host` label to make sure it's less than 63

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: RStudio with Auth0 authentication proxy
 name: rstudio
-version: 2.1.4
+version: 2.1.5
 appVersion: "RStudio: 1.2.1335+conda, R: 3.5.1, Python: 3.7.1, patch: 3"

--- a/charts/rstudio/templates/_helpers.tpl
+++ b/charts/rstudio/templates/_helpers.tpl
@@ -16,3 +16,24 @@ e.g. username-rstudio.example.com
 {{- define "host" -}}
 {{- (printf "%s-rstudio.%s" .Values.username .Values.toolsDomain) | lower -}}
 {{- end -}}
+
+
+{{/*
+unidle-key: used by unidler to find RStudio resources
+
+will be the host if <= 63 characters (no change in old `alpha`
+cluster) or the part before the first dot (".") otherwise
+(to avoid problems with new, long, domain)
+
+examples:
+host="alice-rstudio.example.com" => returns "alice-rstudio.example.com"
+host="alice-rstudio.verylongdomain[...]example.com" => returns "alice-rstudio"
+*/}}
+{{- define "unidle_key" -}}
+    {{- $label := include "host" . -}}
+    {{- if gt (len $label) 63 -}}
+        {{- $parts := split "." $label -}}
+        {{- $label = $parts._0 -}}
+    {{- end -}}
+    {{- $label | quote -}}
+{{- end -}}

--- a/charts/rstudio/templates/deployment.yml
+++ b/charts/rstudio/templates/deployment.yml
@@ -5,7 +5,8 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: "{{ .Chart.Name }}"
-    host: "{{ include "host" . | trunc 63 }}"
+    host: {{ template "unidle_key" . }}
+    unidler-key: {{ template "unidle_key" . }}
     "mojanalytics.xyz/idleable": "true"
 spec:
   replicas: 1
@@ -18,7 +19,6 @@ spec:
     metadata:
       labels:
         app: "{{ .Chart.Name }}"
-        host: "{{ include "host" . | trunc 63 }}"
         "mojanalytics.xyz/idleable": "true"
       annotations:
         iam.amazonaws.com/role: {{ .Values.aws.iamRole }}

--- a/charts/rstudio/templates/ingress.yml
+++ b/charts/rstudio/templates/ingress.yml
@@ -5,7 +5,8 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: "{{ .Chart.Name }}"
-    host: "{{ include "host" . | trunc 63 }}"
+    host: {{ template "unidle_key" . }}
+    unidle-key: {{ template "unidle_key" . }}
   annotations:
     kubernetes.io/ingress.class: "nginx"
 spec:

--- a/charts/rstudio/templates/secrets.yml
+++ b/charts/rstudio/templates/secrets.yml
@@ -5,7 +5,6 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: "{{ .Chart.Name }}"
-    host: "{{ include "host" . | trunc 63 }}"
 type: Opaque
 data:
   client_secret: {{ .Values.authProxy.auth0.clientSecret | b64enc | quote }}

--- a/charts/rstudio/templates/service-account.yaml
+++ b/charts/rstudio/templates/service-account.yaml
@@ -6,4 +6,3 @@ metadata:
   labels:
     app: "{{ .Chart.Name }}"
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    host: "{{ include "host" . | trunc 63 }}"

--- a/charts/rstudio/templates/service.yml
+++ b/charts/rstudio/templates/service.yml
@@ -5,7 +5,8 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: "{{ .Chart.Name }}"
-    host: "{{ include "host" . | trunc 63 }}"
+    host: {{ template "unidle_key" . }}
+    unidle-key: {{ template "unidle_key" . }}
 spec:
   sessionAffinity: ClientIP
   selector:

--- a/charts/webapp/CHANGELOG.md
+++ b/charts/webapp/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+
+## [2.3.5] - 2019-11-04
+### Changed
+Removed unused `host` label
+
+
 ## [2.3.4] - 2019-10-25
 ### Changed
 - Truncate `host` label to make sure it's less than 63

--- a/charts/webapp/Chart.yaml
+++ b/charts/webapp/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: webapp Helm chart for Kubernetes
 name: webapp
-version: 2.3.4
+version: 2.3.5
 fluentbitVersion: 1.1.1

--- a/charts/webapp/templates/deployment.yaml
+++ b/charts/webapp/templates/deployment.yaml
@@ -6,7 +6,6 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     repo: "{{ .Values.WebApp.GithubRepo }}"
     app: {{ template "fullname" . }}
-    host: {{ include "hostname" . | trunc 63 }}
 spec:
   selector:
     matchLabels:
@@ -16,7 +15,6 @@ spec:
     metadata:
       labels:
         app: {{ template "fullname" . }}
-        host: {{ include "hostname" . | trunc 63 }}
       annotations:
         checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
         iam.amazonaws.com/role: {{ .Values.AWS.IAMRole }}

--- a/charts/webapp/templates/fluent-bit-configmap.yml
+++ b/charts/webapp/templates/fluent-bit-configmap.yml
@@ -6,7 +6,6 @@ metadata:
     app: {{ template "fullname" . }}
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
-    host: {{ include "hostname" . | trunc 63 }}
   name: "{{ template "fullname" . }}-fluent-bit"
 data:
   source_tag: "{{ template "fullname" . }}"

--- a/charts/webapp/templates/ingress.yaml
+++ b/charts/webapp/templates/ingress.yaml
@@ -6,7 +6,6 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     app: {{ template "fullname" . }}
     repo: {{ .Values.WebApp.GithubRepo }}
-    host: {{ include "hostname" . | trunc 63 }}
   annotations:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/affinity: "cookie"

--- a/charts/webapp/templates/secrets.yaml
+++ b/charts/webapp/templates/secrets.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: {{ template "fullname" . }}
-    host: {{ include "hostname" . | trunc 63 }}
 type: Opaque
 data:
   client_secret: {{ .Values.AuthProxy.Auth0.ClientSecret | b64enc | quote }}
@@ -27,7 +26,6 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: {{ template "fullname" . }}
-    host: {{ include "hostname" . | trunc 63 }}
 type: Opaque
 data:
   {{ range $key, $value := .Values.secretEnv -}}

--- a/charts/webapp/templates/service-account.yaml
+++ b/charts/webapp/templates/service-account.yaml
@@ -6,4 +6,3 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     repo: "{{ .Values.WebApp.GithubRepo }}"
     app: {{ template "fullname" . }}
-    host: {{ include "hostname" . | trunc 63 }}

--- a/charts/webapp/templates/service.yaml
+++ b/charts/webapp/templates/service.yaml
@@ -6,7 +6,6 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     repo: "{{ .Values.WebApp.GithubRepo }}"
     app: {{ template "fullname" . }}
-    host: {{ include "hostname" . | trunc 63 }}
 spec:
   sessionAffinity: ClientIP
   ports:


### PR DESCRIPTION
Label values can't be longer than 63 chars but also can't end with
a dot (`.`) so truncate to 63 chars can lead to invalid labels.

To maintain compatibility with existing clusters, chart and unidler:
- we use full host if its lenght is max 63 chars (as before)
- we only use the part of the host before the first dot (`.`) otherwise

Updated charts:
- airflow-sqlite
- jupyter-lab
- rstudio

Charts where "host" label was not used and it is not removed:
- cpanel
- webapp