### PR TITLE
Upgrade Cert Manager

### DIFF
--- a/charts/cert-manager-resources/CHANGELOG.md
+++ b/charts/cert-manager-resources/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.0] - 2019-10-31
+## Changed
+- Updated Cert Manager from `v0.5.0` to `v0.11.0`. See [Trello](https://trello.com/c/vK2e5D58)
+- Modified __README.md__ to reflect new deployment steps
+- Modified `Certificate` to updated Cert Manager version spec
+- Modified `ClusterIssuer` to updated Cert Manager version spec
+
 ## [0.1.0] - 2018-08-09
 ## Changed
 - Initial chart development
- 

--- a/charts/cert-manager-resources/Chart.yaml
+++ b/charts/cert-manager-resources/Chart.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 description: A Helm chart to provision certificates using cert-manager
 name: cert-manager-resources
-version: 0.1.0
+version: 1.0.0
+appVersion: 0.11.0
 sources:
   - https://github.com/jetstack/cert-manager

--- a/charts/cert-manager-resources/templates/certificate.yaml
+++ b/charts/cert-manager-resources/templates/certificate.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   name: {{ .Release.Name }}
@@ -12,11 +12,7 @@ spec:
     name: {{ .Release.Name }}
     kind: ClusterIssuer
   commonName: '{{ .Values.cert.commonname }}'
+  duration: 2160h # 90 days
+  renewBefore: 360h # 15 days
   dnsNames:
 {{ toYaml .Values.cert.dnsnames | indent 4 }}
-  acme:
-    config:
-      - dns01:
-          provider: {{ .Values.issuer.dns01.provider.name }}
-        domains:
-{{ toYaml .Values.cert.acme.config.domains | indent 10 }}

--- a/charts/cert-manager-resources/templates/cluster-issuer.yaml
+++ b/charts/cert-manager-resources/templates/cluster-issuer.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: ClusterIssuer
 metadata:
   name: {{ .Release.Name }}
@@ -12,11 +12,11 @@ spec:
     # Name of a secret used to store the ACME account private key
     privateKeySecretRef:
       name: {{ .Release.Name }}
-    # ACME DNS-01 provider configurations
-    dns01:
-      # Here we define a list of DNS-01 providers that can solve DNS challenges
-      providers:
-        - name: {{ .Values.issuer.dns01.provider.name }}
+    solvers:
+      - selector:
+          dnsZones:
+            - {{ .Values.issuer.acme.solvers.dnsZone | quote }}
+        dns01:
           route53:
-            region: {{ .Values.issuer.dns01.provider.route53.region }}
-            hostedZoneID: {{ .Values.issuer.dns01.provider.route53.hostedzoneid }}
+            region: {{ .Values.issuer.acme.dns01.route53 }}
+            role: {{ .Values.issuer.acme.dns01.route53.role }}

--- a/charts/cert-manager-resources/values.yaml
+++ b/charts/cert-manager-resources/values.yaml
@@ -1,19 +1,15 @@
 issuer:
   acme:
-    server: https://acme-v02.api.letsencrypt.org/directory
+    server: https://acme-staging-v02.api.letsencrypt.org/directory # use staging for testing purposes
     email: ""
-
-  dns01:
-    provider:
-      name: route53
+    solvers:
+      dnsZone: ""
+    dns01:
       route53:
         region: eu-west-1
         hostedzoneid: ""
+        role: ""
 
 cert:
   commonname: ""
   dnsnames: []
-
-  acme:
-    config:
-      domains: []


### PR DESCRIPTION
[Trello](https://trello.com/c/vK2e5D58)

Our current version of Cert Manager will be blocked by LetsEncrypt as of
1 Nov 2019.

Deploying Latest version of Cert Manager as of now (__31\10\2019__):
`0.11.0`