### PR TITLE
unidler v4.0.3: Uses unidler `v1.0.4` (support for `unidle-key`)

### DIFF
--- a/charts/unidler/CHANGELOG.md
+++ b/charts/unidler/CHANGELOG.md
@@ -5,6 +5,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [v4.0.3] - 2019-11-04
+### Changed
+- uses [unidler v1.0.4](https://github.com/ministryofjustice/analytics-platform-go-unidler/releases/tag/v1.0.4)
+- this version calculate "unidle key" slightly differently
+  to avoid problems with new long domain: it only uses
+  the part of the host before the first dot (".") when
+  the host is longer than 63 character
+- its behaviour doesn't change for old clusters/domain
+  as hosts are shorter then 63 chars (to not break
+  compatibility)
+- it also has `UNIDLE_KEY_LABEL` (defaults to `host`)
+  which can be used in new clusters to look for resources
+  by using the `unidle-key` label (instead of the old
+  `host` label which we'll remove once `alpha` cluster
+  is retired)
+
+- [unidler PR](https://github.com/ministryofjustice/analytics-platform-go-unidler/pull/14)
+- Part of ticket: https://trello.com/c/kVT0QFqe
+
+
 ## [v4.0.2] - 2019-10-29
 ### Changed
 Works with `host` labels truncated at 63 chars (k8s limit).

--- a/charts/unidler/Chart.yaml
+++ b/charts/unidler/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: unidler proxy
 name: unidler
-version: "v4.0.2"
-appVersion: "v1.0.3"
+version: "v4.0.3"
+appVersion: "v1.0.4"

--- a/charts/unidler/README.md
+++ b/charts/unidler/README.md
@@ -9,3 +9,12 @@ $ helm upgrade --install --dry-run --debug unidler charts/unidler --namespace de
 ```
 
 **NOTE**: Remove `--dry-run` and adjust the values file path.
+
+
+## Configuration
+The `unidleKeyLabel` value can be used to specify which label will be used
+by the unidler to find the tool's resources to update when unidling.
+
+This defaults to `"host"` for retro-compatibility with `dev`/`alpha` clusters.
+
+For new clusters set to `unidle-key`.

--- a/charts/unidler/templates/deployment.yaml
+++ b/charts/unidler/templates/deployment.yaml
@@ -17,6 +17,9 @@ spec:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.name }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        env:
+        - name: UNIDLE_KEY_LABEL
+          value: "{{ .Values.unidleKeyLabel }}"
         ports:
         - name: http
           containerPort: {{ .Values.service.internalPort }}

--- a/charts/unidler/values.yaml
+++ b/charts/unidler/values.yaml
@@ -1,8 +1,10 @@
 # Docker image
 image:
   name: quay.io/mojanalytics/go-unidler
-  tag: v1.0.3
+  tag: v1.0.4
   pullPolicy: IfNotPresent
+
+unidleKeyLabel: "host"
 
 replicaCount: 3
 


### PR DESCRIPTION
Fix for long "host" label and added `unidleKeyLabel` value to support
`UNIDLE_KEY_LABEL` configuration (unidler will stop using `host` label
in new clusters and start using `unidle-key` label)

Part of ticket: https://trello.com/c/kVT0QFqe