### PR TITLE
Pass Slack API token to CPanel migrations job

### DIFF
--- a/charts/cpanel/CHANGELOG.md
+++ b/charts/cpanel/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [2.4.2] - 2019-11-13
+### Changed
+- Pass Slack API token to migrations job to fix error
+
 ## [2.4.1] - 2019-11-07
 ### Changed
 - **Deprecated** `secretEnv.AWS_ACCOUNT_ID`. Remove once `alpha` CP start to

--- a/charts/cpanel/Chart.yaml
+++ b/charts/cpanel/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Analytics Platform Control Panel API webapp
 name: cpanel
-version: 2.4.1
+version: 2.4.2

--- a/charts/cpanel/templates/job.yaml
+++ b/charts/cpanel/templates/job.yaml
@@ -26,5 +26,7 @@ spec:
           envFrom:
             - secretRef:
                 name: "{{ .Chart.Name }}-db-env"
+            - secretRef:
+                name: "{{ .Chart.Name }}-env-secrets"
       restartPolicy: OnFailure
   backoffLimit: 5


### PR DESCRIPTION
Deployment is failing due to the migrations job requiring the SLACK_API_TOKEN environment variable.