### PR TITLE
idler 2.1.0: Run idler every Wednesday by default

### DIFF
--- a/charts/idler/CHANGELOG.md
+++ b/charts/idler/CHANGELOG.md
@@ -5,6 +5,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [2.1.0] - 2019-11-13
+### Changed
+- Updated default schedule to run idler every Tuesday at 22:00 instead
+  of running it every night. This is to reduce users' waiting time in the
+  morning
+
+Ticket: https://trello.com/c/6yyF8WFV
+
+
 ## [2.0.1] - 2019-06-24
 ### Fixed
 - Fixed idling problems caused by some k8s resouces in an inconsistent state.

--- a/charts/idler/Chart.yaml
+++ b/charts/idler/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: idler cronjob
 name: idler
-version: 2.0.1
+version: 2.1.0
 appVersion: v1.0.1

--- a/charts/idler/README.md
+++ b/charts/idler/README.md
@@ -25,4 +25,4 @@ happy with the output.
 | `cpuActivityThreshold` | Percentage of CPU usage to consider an "active" deployment which should not be idled | `10` |
 | `labelSelector` | Kubernetes label selector for deployments to consider for idling | `mojanalytics.xyz/idleable=true` |
 | `logLevel` | Log level. See [Python 3 log levels](https://docs.python.org/3/library/logging.html#levels) for valid values | `DEBUG` |
-| `schedule` | Cron format string defining time and frequency of runs | `0 22 * * *` (every day at 22:00) |
+| `schedule` | Cron format string defining time and frequency of runs | `0 22 * * 2` (every Tuesday at 22:00) |

--- a/charts/idler/values.yaml
+++ b/charts/idler/values.yaml
@@ -5,7 +5,7 @@ image: quay.io/mojanalytics/idler:v1.0.1
 #   min    hour   day    month (Sun-Sat)
 # "(0-59) (0-23) (1-31) (1-12) (0-6)"
 # See https://kubernetes.io/docs/user-guide/cron-jobs/#schedule
-schedule: "0 22 * * *"
+schedule: "0 22 * * 2"
 
 # Concurrency Policy
 # Allow|Forbid|Replace


### PR DESCRIPTION
This is to reduce users' waiting time in the morning.

I've updated the default `schedule` as we currently we don't have config
files for this helm chart and it makes sense to keep installation of
this chart simple rather then require a config file.

Ticket: https://trello.com/c/6yyF8WFV