### PR TITLE
Update URL for crown logo on auth proxy login page

### DIFF
--- a/charts/webapp/CHANGELOG.md
+++ b/charts/webapp/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 
+## [2.3.6] - 2019-11-20
+### Changed
+Update URL for crown logo
+
+
 ## [2.3.5] - 2019-11-04
 ### Changed
 Removed unused `host` label

--- a/charts/webapp/Chart.yaml
+++ b/charts/webapp/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: webapp Helm chart for Kubernetes
 name: webapp
-version: 2.3.5
+version: 2.3.6
 fluentbitVersion: 1.1.1

--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -21,7 +21,7 @@ AuthProxy:
     Domain: "AUTH0_USER.eu.auth0.com"
   Image:
     Repository: quay.io/mojanalytics/auth-proxy
-    Tag: "v5.2.1"
+    Tag: "v5.2.2"
     PullPolicy: "IfNotPresent"
 AWS:
   IAMRole: ""


### PR DESCRIPTION
See https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.2 which contains https://github.com/ministryofjustice/analytics-platform-auth-proxy/pull/166