### PR TITLE
webapp 2.3.7: Revert "webapp 2.3.5: removed unused `host` labels"

### DIFF
--- a/charts/webapp/CHANGELOG.md
+++ b/charts/webapp/CHANGELOG.md
@@ -5,6 +5,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [2.3.7] - 2020-01-06
+### Changed
+Reverted removal of `host` label.
+
+It's not only used by the [*restarter* service](https://github.com/ministryofjustice/analytics-platform-restarter) but
+it's also causing some webapp deployments to fail because
+of a new constraint on labels in `apps/v1` which means
+they can't change
+
+SEE: [kubernetes issue on GitHub](https://github.com/kubernetes/kubernetes/issues/26202)
+
 
 ## [2.3.6] - 2019-11-20
 ### Changed

--- a/charts/webapp/Chart.yaml
+++ b/charts/webapp/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: webapp Helm chart for Kubernetes
 name: webapp
-version: 2.3.6
+version: 2.3.7
 fluentbitVersion: 1.1.1

--- a/charts/webapp/templates/deployment.yaml
+++ b/charts/webapp/templates/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     repo: "{{ .Values.WebApp.GithubRepo }}"
     app: {{ template "fullname" . }}
+    host: {{ include "hostname" . | trunc 63 }}
 spec:
   selector:
     matchLabels:
@@ -15,6 +16,7 @@ spec:
     metadata:
       labels:
         app: {{ template "fullname" . }}
+        host: {{ include "hostname" . | trunc 63 }}
       annotations:
         checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
         iam.amazonaws.com/role: {{ .Values.AWS.IAMRole }}

--- a/charts/webapp/templates/fluent-bit-configmap.yml
+++ b/charts/webapp/templates/fluent-bit-configmap.yml
@@ -6,6 +6,7 @@ metadata:
     app: {{ template "fullname" . }}
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
+    host: {{ include "hostname" . | trunc 63 }}
   name: "{{ template "fullname" . }}-fluent-bit"
 data:
   source_tag: "{{ template "fullname" . }}"

--- a/charts/webapp/templates/ingress.yaml
+++ b/charts/webapp/templates/ingress.yaml
@@ -6,6 +6,7 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     app: {{ template "fullname" . }}
     repo: {{ .Values.WebApp.GithubRepo }}
+    host: {{ include "hostname" . | trunc 63 }}
   annotations:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/affinity: "cookie"

--- a/charts/webapp/templates/secrets.yaml
+++ b/charts/webapp/templates/secrets.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: {{ template "fullname" . }}
+    host: {{ include "hostname" . | trunc 63 }}
 type: Opaque
 data:
   client_secret: {{ .Values.AuthProxy.Auth0.ClientSecret | b64enc | quote }}
@@ -26,6 +27,7 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: {{ template "fullname" . }}
+    host: {{ include "hostname" . | trunc 63 }}
 type: Opaque
 data:
   {{ range $key, $value := .Values.secretEnv -}}

--- a/charts/webapp/templates/service-account.yaml
+++ b/charts/webapp/templates/service-account.yaml
@@ -6,3 +6,4 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     repo: "{{ .Values.WebApp.GithubRepo }}"
     app: {{ template "fullname" . }}
+    host: {{ include "hostname" . | trunc 63 }}

--- a/charts/webapp/templates/service.yaml
+++ b/charts/webapp/templates/service.yaml
@@ -6,6 +6,7 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     repo: "{{ .Values.WebApp.GithubRepo }}"
     app: {{ template "fullname" . }}
+    host: {{ include "hostname" . | trunc 63 }}
 spec:
   sessionAffinity: ClientIP
   ports:


### PR DESCRIPTION
This reverts commit 04cd02233449af29700e126090732fe186f75f38 (so basically I'm adding back `host` label for webapps)

The `host` label is not only used by the [*restarter* service](https://github.com/ministryofjustice/analytics-platform-restarter) but
it's also causing some webapp deployments to fail because
of a new constraint on labels in `apps/v1` which means
they can't change

SEE: [kubernetes issue on GitHub](https://github.com/kubernetes/kubernetes/issues/26202)

Ticket: https://trello.com/c/drbbqgjC