### PR TITLE
Remove heapster

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -80,16 +80,6 @@ Exports metrics about the kubernetes nodes.
 $ helm install charts/node-exporter --namespace kube-system --name node-metrics
 ```
 
-
-## heapster
-
-Exports metrics about the kubernetes nodes (used by k8s when describing pods, etc...)
-
-```bash
-$ helm install charts/heapster --namespace kube-system --name heapster
-```
-
-
 ## kube-dashboard
 
 Kubernetes dashboard.


### PR DESCRIPTION
We use metrics-server since Sept 2018
Metrics-server chart install is documented here:
https://github.com/ministryofjustice/analytics-platform-config/blob/master/chart-env-config/alpha/metrics-server.yaml