### PR TITLE
Bumped auth-proxy to `v5.2.4`

### DIFF
--- a/charts/airflow-sqlite/CHANGELOG.md
+++ b/charts/airflow-sqlite/CHANGELOG.md
@@ -5,6 +5,19 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [0.3.1] - 2020-01-31
+### Changed
+Bumped auth-proxy from `v5.2.1` to `v5.2.4`.
+
+This version updates some of the dependencies, [including
+`handlebars` `4.7.2`](https://github.com/ministryofjustice/analytics-platform-auth-proxy/pull/214)
+which fixes a security vulnerability.
+
+See:
+- https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.4
+- https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.3
+
+
 ## [0.3.0] - 2020-01-21
 ### Changed
 Give containers fixed cpu and memory to guarantee QoS

--- a/charts/airflow-sqlite/Chart.yaml
+++ b/charts/airflow-sqlite/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 description: Airflow with sqlite. Tasks are run as pods
 name: airflow-sqlite
 icon: https://airflow.incubator.apache.org/_images/pin_large.png
-version: 0.3.0
+version: 0.3.1
 appVersion: 1.10.6-1

--- a/charts/airflow-sqlite/values.yaml
+++ b/charts/airflow-sqlite/values.yaml
@@ -24,7 +24,7 @@ service:
   port: 80
 authProxy:
   image: "quay.io/mojanalytics/auth-proxy"
-  tag: "v5.2.1"
+  tag: "v5.2.4"
   imagePullPolicy: "IfNotPresent"
   containerPort: "3000"
   resources:

--- a/charts/jupyter-lab/CHANGELOG.md
+++ b/charts/jupyter-lab/CHANGELOG.md
@@ -5,6 +5,19 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [0.5.1] - 2020-01-31
+### Changed
+Bumped auth-proxy from `v5.2.1` to `v5.2.4`.
+
+This version updates some of the dependencies, [including
+`handlebars` `4.7.2`](https://github.com/ministryofjustice/analytics-platform-auth-proxy/pull/214)
+which fixes a security vulnerability.
+
+See:
+- https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.4
+- https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.3
+
+
 ## [0.5.0] - 2020-01-21
 ### Changed
 Give containers fixed cpu and memory to guarantee QoS

--- a/charts/jupyter-lab/Chart.yaml
+++ b/charts/jupyter-lab/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: Jupyter Lab with Auth0 authentication proxy
 name: jupyter-lab
-version: 0.5.0
+version: 0.5.1
 appVersion: v0.6.7

--- a/charts/jupyter-lab/values.yaml
+++ b/charts/jupyter-lab/values.yaml
@@ -10,7 +10,7 @@ service:
 
 authProxy:
   image: quay.io/mojanalytics/auth-proxy
-  tag: v5.2.1
+  tag: v5.2.4
   imagePullPolicy: IfNotPresent
   containerPort: 3000
   resources:

--- a/charts/kibana-auth-proxy/CHANGELOG.md
+++ b/charts/kibana-auth-proxy/CHANGELOG.md
@@ -5,6 +5,19 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [2.1.1] - 2020-01-31
+### Changed
+Bumped auth-proxy from `v5.2.1` to `v5.2.4`.
+
+This version updates some of the dependencies, [including
+`handlebars` `4.7.2`](https://github.com/ministryofjustice/analytics-platform-auth-proxy/pull/214)
+which fixes a security vulnerability.
+
+See:
+- https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.4
+- https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.3
+
+
 ## [2.1.0] - 2019-08-22
 ### Changed
 - Replaced `kibana-auth-proxy` with `auth-proxy` - the latest

--- a/charts/kibana-auth-proxy/Chart.yaml
+++ b/charts/kibana-auth-proxy/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Auth proxy in front of Kibana
 name: kibana-auth-proxy
-version: 2.1.0
+version: 2.1.1

--- a/charts/kibana-auth-proxy/values.yaml
+++ b/charts/kibana-auth-proxy/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 image:
   repository: quay.io/mojanalytics/auth-proxy
-  tag: "v5.2.1"
+  tag: "v5.2.4"
   pullPolicy: IfNotPresent
 service:
   type: ClusterIP

--- a/charts/kubernetes-dashboard/CHANGELOG.md
+++ b/charts/kubernetes-dashboard/CHANGELOG.md
@@ -5,6 +5,19 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [2.0.2] - 2020-01-31
+### Changed
+Bumped auth-proxy from `v5.2.1` to `v5.2.4`.
+
+This version updates some of the dependencies, [including
+`handlebars` `4.7.2`](https://github.com/ministryofjustice/analytics-platform-auth-proxy/pull/214)
+which fixes a security vulnerability.
+
+See:
+- https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.4
+- https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.3
+
+
 ## [2.0.1] - 2019-08-23
 ### Changed
 Bumped auth-proxy to version `v5.2.1`.

--- a/charts/kubernetes-dashboard/Chart.yaml
+++ b/charts/kubernetes-dashboard/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Kubernetes Dashboard with OIDC auth
 name: kubernetes-dashboard
-version: 2.0.1
+version: 2.0.2

--- a/charts/kubernetes-dashboard/values.yaml
+++ b/charts/kubernetes-dashboard/values.yaml
@@ -8,7 +8,7 @@ dashboard:
 
 authProxy:
   image: quay.io/mojanalytics/auth-proxy
-  tag: v5.2.1
+  tag: v5.2.4
   imagePullPolicy: IfNotPresent
   containerPort: 3000
   resources:

--- a/charts/prometheus-resources/CHANGELOG.md
+++ b/charts/prometheus-resources/CHANGELOG.md
@@ -5,6 +5,19 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [0.1.3] - 2020-12-31
+### Changed
+Bumped auth-proxy from `v5.2.1` to `v5.2.4`.
+
+This version updates some of the dependencies, [including
+`handlebars` `4.7.2`](https://github.com/ministryofjustice/analytics-platform-auth-proxy/pull/214)
+which fixes a security vulnerability.
+
+See:
+- https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.4
+- https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.3
+
+
 ## [0.1.2] - 2019-08-23
 ### Changed
 Bumped auth-proxy to version `v5.2.1`.

--- a/charts/prometheus-resources/Chart.yaml
+++ b/charts/prometheus-resources/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "1.0"
 description: Deploys resources related to the [Prometheus-Operator](https://github.com/helm/charts/tree/master/stable/prometheus-operator) helm chart
 name: prometheus-resources
-version: 0.1.2
+version: 0.1.3
 engine: gotpl

--- a/charts/prometheus-resources/values.yaml
+++ b/charts/prometheus-resources/values.yaml
@@ -5,7 +5,7 @@ ingressClass: nginx
 authProxy:
   name: auth-proxy
   image: quay.io/mojanalytics/auth-proxy
-  tag: v5.2.1
+  tag: v5.2.4
   imagePullPolicy: IfNotPresent
   containerPort: 3000
   resources:

--- a/charts/rstudio/CHANGELOG.md
+++ b/charts/rstudio/CHANGELOG.md
@@ -5,6 +5,19 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [2.2.1] - 2020-01-31
+### Changed
+Bumped auth-proxy from `v5.2.1` to `v5.2.4`.
+
+This version updates some of the dependencies, [including
+`handlebars` `4.7.2`](https://github.com/ministryofjustice/analytics-platform-auth-proxy/pull/214)
+which fixes a security vulnerability.
+
+See:
+- https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.4
+- https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.3
+
+
 ## [2.2.0] - 2020-01-21
 ### Changed
 Give containers fixed cpu and memory to guarantee QoS

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: RStudio with Auth0 authentication proxy
 name: rstudio
-version: 2.2.0
+version: 2.2.1
 appVersion: "RStudio: 1.2.1335+conda, R: 3.5.1, Python: 3.7.1, patch: 3"

--- a/charts/rstudio/values.yaml
+++ b/charts/rstudio/values.yaml
@@ -16,7 +16,7 @@ authProxy:
     port: 3000
   image:
     repository: quay.io/mojanalytics/auth-proxy
-    tag: "v5.2.1"
+    tag: "v5.2.4"
     pullPolicy: "IfNotPresent"
   resources:
     limits:

--- a/charts/webapp/CHANGELOG.md
+++ b/charts/webapp/CHANGELOG.md
@@ -5,6 +5,19 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [2.3.8] - 2020-01-31
+### Changed
+Bumped auth-proxy from `v5.2.2` to `v5.2.4`.
+
+This version updates some of the dependencies, [including
+`handlebars` `4.7.2`](https://github.com/ministryofjustice/analytics-platform-auth-proxy/pull/214)
+which fixes a security vulnerability.
+
+See:
+- https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.4
+- https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.3
+
+
 ## [2.3.7] - 2020-01-06
 ### Changed
 Reverted removal of `host` label.

--- a/charts/webapp/Chart.yaml
+++ b/charts/webapp/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: webapp Helm chart for Kubernetes
 name: webapp
-version: 2.3.7
+version: 2.3.8
 fluentbitVersion: 1.1.1

--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -21,7 +21,7 @@ AuthProxy:
     Domain: "AUTH0_USER.eu.auth0.com"
   Image:
     Repository: quay.io/mojanalytics/auth-proxy
-    Tag: "v5.2.2"
+    Tag: "v5.2.4"
     PullPolicy: "IfNotPresent"
 AWS:
   IAMRole: ""


### PR DESCRIPTION
This version updates some of the dependencies, [including `handlebars` `4.7.2`](https://github.com/ministryofjustice/analytics-platform-auth-proxy/pull/214)
which fixes a security vulnerability.

See:
- https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.4
- https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.3

Updated helm charts:
- webapp
- rstudio
- jupyter-lab
- airflow-sqlite
- kibana-auth-proxy
- kubernetes-dashboard
- prometheus-resources

Part of ticket: https://trello.com/c/wUaYAyYZ