### PR TITLE
buckets-archiver 0.0.1: Initial release

### DIFF
--- a/charts/buckets-archiver/CHANGELOG.md
+++ b/charts/buckets-archiver/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+
+## [0.0.1] - 2020-02-26
+### Added
+- Initial release
+
+Ticket: https://trello.com/c/6VdNPbzz

--- a/charts/buckets-archiver/Chart.yaml
+++ b/charts/buckets-archiver/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+name: buckets-archiver
+description: Archives S3 buckets tagged 'to-archive'
+version: 0.0.1
+appVersion: v0.0.1

--- a/charts/buckets-archiver/README.md
+++ b/charts/buckets-archiver/README.md
@@ -1,0 +1,35 @@
+# buckets-archiver
+
+CronJob which archives S3 buckets tagged with `to-archive=true` tag.
+
+The data in the S3 bucket to archive is moved to `${archiveBucket}/${BUCKET_NAME}/`
+before the S3 bucket is actually deleted.
+
+The CronJob's schedule is determined by the `schedule` value (see below).
+
+See: https://github.com/ministryofjustice/analytics-platform-buckets-archiver
+
+
+## Installing/upgrading the Chart
+
+
+```bash
+$ helm upgrade --dry-run --debug --install buckets-archiver charts/buckets-archiver --namespace default  -f chart-env-config/ENV/buckets-archiver.yml
+```
+
+**NOTE**: Remove `--dry-run` to actually install/upgrade once you're
+happy with the output.
+
+
+## Configuration
+
+| Parameter       | Description                                                                                 | Default                    |
+| --------------- | ------------------------------------------------------------------------------------------- | -------------------------- |
+| `env`           | environment to restrict archiving to (e.g. `dev`)                                           | `""`                       |
+| `archiveBucket` | S3 bucket where the archived data will go (e.g. `dev-archived-buckets-data`)                | `""`                       |
+| `iamRole`       | IAM role assumed by the buckets-archiver. See [buckets-archiver's permissions] for details. | `""`                       |
+| `schedule`      | Cron format string defining time and frequency of runs                                      | `"*/5 * * * *"` (every 5m) |
+
+
+
+[buckets-archiver's permissions]: https://github.com/ministryofjustice/analytics-platform-buckets-archiver#permissions

--- a/charts/buckets-archiver/templates/clusterrole.yaml
+++ b/charts/buckets-archiver/templates/clusterrole.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app: {{ .Release.Name }}
+# buckets-archiver doesn't need any k8s permissions
+rules: []

--- a/charts/buckets-archiver/templates/clusterrolebinding.yaml
+++ b/charts/buckets-archiver/templates/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app: {{ .Release.Name }}
+subjects:
+  - kind: ServiceAccount
+    namespace: {{ .Release.Namespace }}
+    name: {{ .Release.Name }}
+    apiGroup: ""
+roleRef:
+  kind: ClusterRole
+  namespace: {{ .Release.Namespace }}
+  name: {{ .Release.Name }}
+  apiGroup: ""

--- a/charts/buckets-archiver/templates/cronjob.yaml
+++ b/charts/buckets-archiver/templates/cronjob.yaml
@@ -1,0 +1,35 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app: {{ .Release.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    type: cron
+spec:
+  schedule: "{{ .Values.schedule }}"
+  concurrencyPolicy: {{ .Values.concurrencyPolicy }}
+  failedJobsHistoryLimit: {{ .Values.failedJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          annotations:
+            iam.amazonaws.com/role: {{ .Values.iamRole }}
+          labels:
+            app: {{ .Release.Name }}
+        spec:
+          serviceAccountName: {{ .Release.Name }}
+          containers:
+            - name: {{ .Release.Name }}
+              image: "{{ .Values.image }}"
+              args:
+                - "archive"
+              env:
+                - name: ENV
+                  value: "{{ .Values.env }}"
+                - name: ARCHIVE_BUCKET
+                  value: "{{ .Values.archiveBucket }}"
+                - name: AWS_DEFAULT_REGION
+                  value: "{{ .Values.awsDefaultRegion }}"
+          restartPolicy: Never

--- a/charts/buckets-archiver/templates/serviceaccount.yaml
+++ b/charts/buckets-archiver/templates/serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app: {{ .Release.Name }}

--- a/charts/buckets-archiver/values.yaml
+++ b/charts/buckets-archiver/values.yaml
@@ -1,0 +1,28 @@
+# environment to target, e.g. "dev"
+env: ""
+
+# S3 Bucket where archived data will be moved to
+archiveBucket: ""
+
+# IAM role assumed by the buckets-archiver
+iamRole: ""
+
+# Docker image version
+image: quay.io/mojanalytics/buckets-archiver:v0.0.1
+
+# Schedule when to run
+#   min    hour   day    month (Sun-Sat)
+# "(0-59) (0-23) (1-31) (1-12) (0-6)"
+# See https://kubernetes.io/docs/user-guide/cron-jobs/#schedule
+schedule: "*/5 * * * *" # every 5 minutes
+
+# Concurrency Policy
+# Allow|Forbid|Replace
+# See https://kubernetes.io/docs/user-guide/cron-jobs/#concurrency_policy
+concurrencyPolicy: Forbid
+
+# The number of failed finished jobs to retain.
+failedJobsHistoryLimit: 5
+
+# AWS default region
+awsDefaultRegion: "eu-west-1"


### PR DESCRIPTION
### What
CronJob which archives S3 buckets (tagged `to-archive=true`) by moving
their data to an `archiveBucket` (e.g. `dev-archived-buckets-data`)
before deleting them.

### buckets-archiver code
`buckets-archiver` code in this repo: https://github.com/ministryofjustice/analytics-platform-buckets-archiver - please have a look as well, sorry for the lack of PR as it was a new repo.

### Bucket/Permissions in Terraform
The S3 bucket and the permissions for the `buckets-archiver` are created in Terraform. See PR: https://github.com/ministryofjustice/analytics-platform-ops/pull/311


### Part of ticket
https://trello.com/c/6VdNPbzz

### Related PR:
https://github.com/ministryofjustice/analytics-platform-config/pull/190 👉 