### PR TITLE
Call nbstripout to remove outputs from .ipynb files

### DIFF
--- a/charts/config-user/files/pre-commit
+++ b/charts/config-user/files/pre-commit
@@ -39,6 +39,7 @@ NBS=`git diff-index -z --cached $against --name-only | grep '.ipynb$' | uniq`
 for NB in $NBS ; do
     echo "Removing outputs from $NB"
     nbstripout "$NB"
+    echo "nbstripout has run"
     git add "$NB"
 done
 )

--- a/charts/config-user/files/pre-commit
+++ b/charts/config-user/files/pre-commit
@@ -34,12 +34,13 @@ fi
 (
 IFS='
 '
-NBS=`git diff-index -z --cached $against --name-only | grep '.ipynb$' | uniq`
+NBS=`git diff --cached $against --name-only | grep '.ipynb$' | sort | uniq`
 
 for NB in $NBS ; do
     echo "Removing outputs from $NB"
     nbstripout "$NB"
     echo "nbstripout has run"
+
     git add "$NB"
 done
 )

--- a/charts/config-user/files/pre-commit
+++ b/charts/config-user/files/pre-commit
@@ -20,3 +20,27 @@ if [ "$HAS_ERROR" != "" ]; then
     echo "Can't commit due to oversize files, please unstage before committing." >&2
     exit 1
 fi
+
+
+# add nbstripout to strip output from IPython notebooks 
+if git rev-parse --verify HEAD >/dev/null 2>&1; then
+   against=HEAD
+else
+   # Initial commit: diff against an empty tree object
+   against=4b825dc642cb6eb9a060e54bf8d69288fbee4904
+fi
+
+# Find notebooks to be committed
+(
+IFS='
+'
+NBS=`git diff-index -z --cached $against --name-only | grep '.ipynb$' | uniq`
+
+for NB in $NBS ; do
+    echo "Removing outputs from $NB"
+    nbstripout "$NB"
+    git add "$NB"
+done
+)
+
+exec git diff-index --check --cached $against --

--- a/charts/config-user/files/pre-commit
+++ b/charts/config-user/files/pre-commit
@@ -44,5 +44,3 @@ for NB in $NBS ; do
     git add "$NB"
 done
 )
-
-exec git diff-index --check --cached $against --


### PR DESCRIPTION
For each .ipynb file commited to a git repo. On pre-commit

Call nbstripout (https://github.com/kynan/nbstripout) 
This will remove the outputs from the file 
And then add the file to the repo

This is as part of story (https://trello.com/c/P7BRQJWC/333-strip-out-ipython-notebook-output-using-a-git-hook-for-all-users)

