### PR TITLE
set git global templates

### DIFF
--- a/charts/config-user/Chart.yaml
+++ b/charts/config-user/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Configure the user (e.g. git setup, etc...)
 name: config-user
-version: 0.2.1
+version: 0.2.2

--- a/charts/config-user/files/git-config.sh
+++ b/charts/config-user/files/git-config.sh
@@ -56,4 +56,5 @@ git config -f $GIT_CONFIG user.email $EMAIL
 git config -f $GIT_CONFIG user.name "${FULLNAME}"
 git config -f $GIT_CONFIG core.excludesfile $GIT_IGNORE
 git config -f $GIT_CONFIG init.templatedir $GIT_TEMPLATES
+git config --global init.templatedir $GIT_TEMPLATES
 chown 1001:staff $GIT_CONFIG


### PR DESCRIPTION
We need to set the global git templates directory 
This will automatically copy all templates from .git-templates into per project .git

 