### PR TITLE
set git-template path to ~/.git-templates

### DIFF
--- a/charts/config-user/Chart.yaml
+++ b/charts/config-user/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Configure the user (e.g. git setup, etc...)
 name: config-user
-version: 0.2.2
+version: 0.2.3

--- a/charts/config-user/files/git-config.sh
+++ b/charts/config-user/files/git-config.sh
@@ -56,5 +56,5 @@ git config -f $GIT_CONFIG user.email $EMAIL
 git config -f $GIT_CONFIG user.name "${FULLNAME}"
 git config -f $GIT_CONFIG core.excludesfile $GIT_IGNORE
 git config -f $GIT_CONFIG init.templatedir $GIT_TEMPLATES
-git config --global init.templatedir $GIT_TEMPLATES
-chown 1001:staff $GIT_CONFIG
+git config --global init.templatedir '~/.git-templates'
+chown 1001:staff $GIT_CONFIG  

--- a/charts/config-user/files/git-config.sh
+++ b/charts/config-user/files/git-config.sh
@@ -57,4 +57,4 @@ git config -f $GIT_CONFIG user.name "${FULLNAME}"
 git config -f $GIT_CONFIG core.excludesfile $GIT_IGNORE
 git config -f $GIT_CONFIG init.templatedir $GIT_TEMPLATES
 git config --global init.templatedir '~/.git-templates'
-chown 1001:staff $GIT_CONFIG  
+chown 1001:staff $GIT_CONFIG


### PR DESCRIPTION
Set global git template path to ~/.git-templates and not USER_HOME (dhirajnarwanimoj).
The reason is that jupyter runs another user (jovyan) and we need to change the ~/.git-templates of that user