### PR TITLE
Set git global

### DIFF
--- a/charts/config-user/CHANGELOG.md
+++ b/charts/config-user/CHANGELOG.md
@@ -1,0 +1,4 @@
+## [0.2.6] - 2020-03-13
+### Added
+- Chown for staff on `GIT_TEMPLATES` folder to copy hooks to project .git/hooks
+- `CHANGELOG.md`

--- a/charts/config-user/Chart.yaml
+++ b/charts/config-user/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Configure the user (e.g. git setup, etc...)
 name: config-user
-version: 0.2.5
+version: 0.2.6

--- a/charts/config-user/files/git-config.sh
+++ b/charts/config-user/files/git-config.sh
@@ -58,4 +58,4 @@ git config -f $GIT_CONFIG core.excludesfile $GIT_IGNORE
 git config -f $GIT_CONFIG init.templatedir $GIT_TEMPLATES
 
 chown 1001:staff $GIT_CONFIG
-chmod 1001:staff $GIT_TEMPLATES
+chown 1001:staff $GIT_TEMPLATES

--- a/charts/config-user/files/git-config.sh
+++ b/charts/config-user/files/git-config.sh
@@ -56,8 +56,6 @@ git config -f $GIT_CONFIG user.email $EMAIL
 git config -f $GIT_CONFIG user.name "${FULLNAME}"
 git config -f $GIT_CONFIG core.excludesfile $GIT_IGNORE
 git config -f $GIT_CONFIG init.templatedir $GIT_TEMPLATES
-chown 1001:staff $GIT_CONFIG
 
-# set global git template config for jupyter user and git user (rstudio)
-git config --global init.templatedir '/home/jovyan/.git-templates'
-git config --global init.templatedir $GIT_TEMPLATES
+chown 1001:staff $GIT_CONFIG
+chmod 1001:staff $GIT_TEMPLATES

--- a/charts/config-user/files/git-config.sh
+++ b/charts/config-user/files/git-config.sh
@@ -58,14 +58,6 @@ git config -f $GIT_CONFIG core.excludesfile $GIT_IGNORE
 git config -f $GIT_CONFIG init.templatedir $GIT_TEMPLATES
 chown 1001:staff $GIT_CONFIG
 
-# set jupyter (jovyan) user or git user
-if grep -q jovyan /etc/passwd; then
-  USER="jovyan"
-elif grep -q "$USERNAME" /etc/passwd; then
-  USER=$USERNAME
-fi
-
-# set global templates either with the jupyter or git user
-if [ $USER ]; then
-  sudo -u $USER git config --global init.templatedir '~/.git-templates'
-fi
+# set global git template config for jupyter user and git user (rstudio)
+git config --global init.templatedir '/home/jovyan/.git-templates'
+git config --global init.templatedir $GIT_TEMPLATES


### PR DESCRIPTION
The issue is that .git-templates was set to root and the hooks folder wasn't getting copied.

We need to chown to 1001:staff to .git-templates