### PR TITLE
Tag r-studio-server with 1.2.1335-r3.5.1-python3.7.1-conda-4

### DIFF
--- a/charts/rstudio/CHANGELOG.md
+++ b/charts/rstudio/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.2.2] - 2020-03-19
+### Changed
+Changed tag to latest
+Bumped version
+
+See:
+- https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.4
+- https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.3
 
 ## [2.2.1] - 2020-01-31
 ### Changed

--- a/charts/rstudio/CHANGELOG.md
+++ b/charts/rstudio/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [2.2.2] - 2020-03-19
 ### Changed
-Changed tag to latest
+Changed tag to 1.2.1335-r3.5.1-python3.7.1-conda-4
 Bumped version
 
 ## [2.2.1] - 2020-01-31

--- a/charts/rstudio/CHANGELOG.md
+++ b/charts/rstudio/CHANGELOG.md
@@ -9,10 +9,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 Changed tag to latest
 Bumped version
 
-See:
-- https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.4
-- https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.3
-
 ## [2.2.1] - 2020-01-31
 ### Changed
 Bumped auth-proxy from `v5.2.1` to `v5.2.4`.

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: RStudio with Auth0 authentication proxy
 name: rstudio
-version: 2.2.1
+version: 2.2.2
 appVersion: "RStudio: 1.2.1335+conda, R: 3.5.1, Python: 3.7.1, patch: 3"

--- a/charts/rstudio/values.yaml
+++ b/charts/rstudio/values.yaml
@@ -30,7 +30,7 @@ rstudio:
   port: "8787"
   image:
     repository: quay.io/mojanalytics/rstudio
-    tag: "add-nbstripout-pkg"
+    tag: "1.2.1335-r3.5.1-python3.7.1-conda-4"
     pullPolicy: "IfNotPresent"
     # init option allows you to run an init container that does the setup of the conda environment
     # this is quite slow and if it was run as part of the main container then it would cause problems.

--- a/charts/rstudio/values.yaml
+++ b/charts/rstudio/values.yaml
@@ -30,7 +30,7 @@ rstudio:
   port: "8787"
   image:
     repository: quay.io/mojanalytics/rstudio
-    tag: "1.2.1335-r3.5.1-python3.7.1-conda-3"
+    tag: "latest"
     pullPolicy: "IfNotPresent"
     # init option allows you to run an init container that does the setup of the conda environment
     # this is quite slow and if it was run as part of the main container then it would cause problems.

--- a/charts/rstudio/values.yaml
+++ b/charts/rstudio/values.yaml
@@ -30,7 +30,7 @@ rstudio:
   port: "8787"
   image:
     repository: quay.io/mojanalytics/rstudio
-    tag: "latest"
+    tag: "add-nbstripout-pkg"
     pullPolicy: "IfNotPresent"
     # init option allows you to run an init container that does the setup of the conda environment
     # this is quite slow and if it was run as part of the main container then it would cause problems.


### PR DESCRIPTION
We need to set the r-studio-tag to a new tag '1.2.1335-r3.5.1-python3.7.1-conda-4'. 

This has been tested and released already on quay
