### PR TITLE
bump version to conda-5

### DIFF
--- a/charts/rstudio/CHANGELOG.md
+++ b/charts/rstudio/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.2.3] - 2020-03-20
+### Changed
+Changed tag to 1.2.1335-r3.5.1-python3.7.1-conda-5
+Bumped version
+
 ## [2.2.2] - 2020-03-19
 ### Changed
 Changed tag to 1.2.1335-r3.5.1-python3.7.1-conda-4

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: RStudio with Auth0 authentication proxy
 name: rstudio
-version: 2.2.2
+version: 2.2.3
 appVersion: "RStudio: 1.2.1335+conda, R: 3.5.1, Python: 3.7.1, patch: 3"

--- a/charts/rstudio/values.yaml
+++ b/charts/rstudio/values.yaml
@@ -30,7 +30,7 @@ rstudio:
   port: "8787"
   image:
     repository: quay.io/mojanalytics/rstudio
-    tag: "1.2.1335-r3.5.1-python3.7.1-conda-4"
+    tag: "1.2.1335-r3.5.1-python3.7.1-conda-5"
     pullPolicy: "IfNotPresent"
     # init option allows you to run an init container that does the setup of the conda environment
     # this is quite slow and if it was run as part of the main container then it would cause problems.


### PR DESCRIPTION
Bump version to conda-5 in order to create a new r-studio-server release