### PR TITLE
add -R flag

### DIFF
--- a/charts/config-user/CHANGELOG.md
+++ b/charts/config-user/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.2.9] - 2020-03-23
+### Changed
+- Add -R to $GIT_TEMPLATES to set hooks as executables
+
 ## [0.2.8] - 2020-03-18
 ### Changed
 - Add full path to nbstripout (~/.local/bin/nbstripout)

--- a/charts/config-user/Chart.yaml
+++ b/charts/config-user/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Configure the user (e.g. git setup, etc...)
 name: config-user
-version: 0.2.8
+version: 0.2.9

--- a/charts/config-user/files/git-config.sh
+++ b/charts/config-user/files/git-config.sh
@@ -58,4 +58,4 @@ git config -f $GIT_CONFIG core.excludesfile $GIT_IGNORE
 git config -f $GIT_CONFIG init.templatedir '~/.git-templates'
 
 chown 1001:staff $GIT_CONFIG
-chown 1001:staff $GIT_TEMPLATES
+chown -R 1001:staff $GIT_TEMPLATES


### PR DESCRIPTION
Add -R to $GIT_TEMPLATES to set hooks as executables

I'm currently getting this warning: 
hint: The 'pre-commit' hook was ignored because it's not set as executable.