### PR TITLE
Add path to pre-commit hook

### DIFF
--- a/charts/config-user/CHANGELOG.md
+++ b/charts/config-user/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.2.10] - 2020-03-31
+### Changed
+- Export PATH for rstudio and jupyter for dev and alpha environments 
+
 ## [0.2.9] - 2020-03-23
 ### Changed
 - Add -R to $GIT_TEMPLATES to set hooks as executables

--- a/charts/config-user/Chart.yaml
+++ b/charts/config-user/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Configure the user (e.g. git setup, etc...)
 name: config-user
-version: 0.2.9
+version: 0.2.10

--- a/charts/config-user/files/pre-commit
+++ b/charts/config-user/files/pre-commit
@@ -30,6 +30,7 @@ else
    against=4b825dc642cb6eb9a060e54bf8d69288fbee4904
 fi
 
+# set path for nbstripout in rstudio and jupyter
 export PATH=/opt/conda/bin:~/.local/bin:$PATH
 
 # Find notebooks to be committed

--- a/charts/config-user/files/pre-commit
+++ b/charts/config-user/files/pre-commit
@@ -30,6 +30,8 @@ else
    against=4b825dc642cb6eb9a060e54bf8d69288fbee4904
 fi
 
+export PATH=/opt/conda/bin:~/.local/bin:$PATH
+
 # Find notebooks to be committed
 (
 IFS='
@@ -38,7 +40,7 @@ NBS=`git diff --cached $against --name-only | grep '.ipynb$' | sort | uniq`
 
 for NB in $NBS ; do
     echo "Removing outputs from $NB"
-    ~/.local/bin/nbstripout "$NB"
+    nbstripout "$NB"
     echo "nbstripout has run"
 
     git add "$NB"

--- a/charts/jupyter-lab/values.yaml
+++ b/charts/jupyter-lab/values.yaml
@@ -29,10 +29,10 @@ authProxy:
     port_range: "8050,4040-4050"
 
 jupyter:
-  # image: quay.io/mojanalytics/datascience-notebook
-  image: quay.io/mojanalytics/all-spark
-  # tag: v0.6.9
-  tag: add-nbstripout
+  image: quay.io/mojanalytics/datascience-notebook
+  # image: quay.io/mojanalytics/all-spark
+  tag: v0.6.9
+  # tag: add-nbstripout
   imagePullPolicy: IfNotPresent
   containerPort: 8888
   resources:

--- a/charts/jupyter-lab/values.yaml
+++ b/charts/jupyter-lab/values.yaml
@@ -30,7 +30,7 @@ authProxy:
 
 jupyter:
   image: quay.io/mojanalytics/datascience-notebook
-  tag: v0.6.7
+  tag: v0.6.8
   imagePullPolicy: IfNotPresent
   containerPort: 8888
   resources:

--- a/charts/jupyter-lab/values.yaml
+++ b/charts/jupyter-lab/values.yaml
@@ -29,8 +29,10 @@ authProxy:
     port_range: "8050,4040-4050"
 
 jupyter:
-  image: quay.io/mojanalytics/datascience-notebook
-  tag: v0.6.8
+  # image: quay.io/mojanalytics/datascience-notebook
+  image: quay.io/mojanalytics/all-spark
+  # tag: v0.6.9
+  tag: add-nbstripout
   imagePullPolicy: IfNotPresent
   containerPort: 8888
   resources:

--- a/charts/rstudio/values.yaml
+++ b/charts/rstudio/values.yaml
@@ -30,7 +30,7 @@ rstudio:
   port: "8787"
   image:
     repository: quay.io/mojanalytics/rstudio
-    tag: "1.2.1335-r3.5.1-python3.7.1-conda-7"
+    tag: "1.2.1335-r3.5.1-python3.7.1-conda-9"
     pullPolicy: "IfNotPresent"
     # init option allows you to run an init container that does the setup of the conda environment
     # this is quite slow and if it was run as part of the main container then it would cause problems.


### PR DESCRIPTION
Add Path to both jupyter and r-studio nbstripout PATHS to git pre-commit hook rather than individual docker image.

In dev nbstripout gets installed in ~/.local/bin and in alpha in /opt/conda/bin.
