### PR TITLE
Update chart deploy commands for upgrading OR installing

### DIFF
--- a/charts/concourse-admin-team/README.md
+++ b/charts/concourse-admin-team/README.md
@@ -9,9 +9,8 @@ components.
 
 To install the chart:
 ```bash
-helm install mojanalytics/concourse-admin-team \
-  --name concourse-admin-team \
-  --values /path/to/chart/configs/concourse-admin-team.yaml
+helm upgrade --install concourse-admin-team mojanalytics/concourse-admin-team \
+  --values ../../analytics-platform-config/chart-env-config/dev/concourse-admin-team.yaml
 ```
 
 

--- a/charts/concourse-org-pipeline/README.md
+++ b/charts/concourse-org-pipeline/README.md
@@ -10,9 +10,8 @@ pipelines for repositories which contain Analytical Platform webapps.
 To install the chart:
 
 ```bash
-helm install mojanalytics/concourse-org-pipeline \
-  --name org-pipeline-$ORG_NAME \
-  --values /path/to/chart/configs/concourse-org-pipeline.yaml
+helm upgrade --install org-pipeline-moj-analytical-services mojanalytics/concourse-org-pipeline \
+  --values ../../analytics-platform-config/chart-env-config/dev/concourse-org-pipeline.yaml
 ```
 
 ## Configuration


### PR DESCRIPTION
Because we normally upgrade these days. Easiest to provide a command for both.

Also put in a more realistic path to the config, so it is clearer.