### PR TITLE
Enable/Disable nbstripout hook

### DIFF
--- a/charts/config-user/CHANGELOG.md
+++ b/charts/config-user/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.2.11] - 2020-04-24
+### Changed
+- Add if/else statement to enable disable nbstripout hook
+
 ## [0.2.10] - 2020-03-31
 ### Changed
 - Export PATH for rstudio and jupyter for dev and alpha environments 

--- a/charts/config-user/Chart.yaml
+++ b/charts/config-user/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Configure the user (e.g. git setup, etc...)
 name: config-user
-version: 0.2.10
+version: 0.2.11

--- a/charts/config-user/files/pre-commit
+++ b/charts/config-user/files/pre-commit
@@ -22,7 +22,7 @@ if [ "$HAS_ERROR" != "" ]; then
 fi
 
 
-if [[ "$ENABLE_NBSTRIPOUT" == "true" ]]; then
+if [[ "$ENABLE_NBSTRIPOUT" != "false" ]]; then
     
     # add nbstripout to strip output from IPython notebooks 
     if git rev-parse --verify HEAD >/dev/null 2>&1; then
@@ -49,9 +49,5 @@ if [[ "$ENABLE_NBSTRIPOUT" == "true" ]]; then
         git add "$NB"
     done
     )
-
-else 
-
-    ENABLE_NBSTRIPOUT="false"
 
 fi

--- a/charts/config-user/files/pre-commit
+++ b/charts/config-user/files/pre-commit
@@ -22,28 +22,36 @@ if [ "$HAS_ERROR" != "" ]; then
 fi
 
 
-# add nbstripout to strip output from IPython notebooks 
-if git rev-parse --verify HEAD >/dev/null 2>&1; then
-   against=HEAD
-else
-   # Initial commit: diff against an empty tree object
-   against=4b825dc642cb6eb9a060e54bf8d69288fbee4904
+if [[ "$ENABLE_NBSTRIPOUT" == "true" ]]; then
+    
+    # add nbstripout to strip output from IPython notebooks 
+    if git rev-parse --verify HEAD >/dev/null 2>&1; then
+        against=HEAD
+    else
+        # Initial commit: diff against an empty tree object
+        against=4b825dc642cb6eb9a060e54bf8d69288fbee4904
+    fi
+
+    # set path for nbstripout in rstudio and jupyter
+    export PATH=/opt/conda/bin:~/.local/bin:$PATH
+
+    # Find notebooks to be committed
+    (
+    IFS='
+    '
+    NBS=`git diff --cached $against --name-only | grep '.ipynb$' | sort | uniq`
+
+    for NB in $NBS ; do
+        echo "Removing outputs from $NB"
+        nbstripout "$NB"
+        echo "nbstripout has run"
+
+        git add "$NB"
+    done
+    )
+
+else 
+
+    ENABLE_NBSTRIPOUT="false"
+
 fi
-
-# set path for nbstripout in rstudio and jupyter
-export PATH=/opt/conda/bin:~/.local/bin:$PATH
-
-# Find notebooks to be committed
-(
-IFS='
-'
-NBS=`git diff --cached $against --name-only | grep '.ipynb$' | sort | uniq`
-
-for NB in $NBS ; do
-    echo "Removing outputs from $NB"
-    nbstripout "$NB"
-    echo "nbstripout has run"
-
-    git add "$NB"
-done
-)


### PR DESCRIPTION
Data science users can set an env variable called ENABLE_NBSTRIPOUT=false to skip the nbstripout code that will run in the pre-commit hook.
