### PR TITLE
Update R studio chart to use image tag that installs nbstripout with conda

### DIFF
--- a/charts/rstudio/CHANGELOG.md
+++ b/charts/rstudio/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [2.2.4] - 2020-03-23
 ### Changed
+Install nbstripout with conda instead of pip
+Changed tag to 1.2.1335-r3.5.1-python3.7.1-conda-10
+Bumped version
+
+## [2.2.4] - 2020-03-23
+### Changed
 Reverting old code
 Changed tag to 1.2.1335-r3.5.1-python3.7.1-conda-6
 Bumped version

--- a/charts/rstudio/CHANGELOG.md
+++ b/charts/rstudio/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [2.2.4] - 2020-03-23
+## [2.2.5] - 2020-05-06
 ### Changed
 Install nbstripout with conda instead of pip
 Changed tag to 1.2.1335-r3.5.1-python3.7.1-conda-10

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: RStudio with Auth0 authentication proxy
 name: rstudio
-version: 2.2.4
-appVersion: "RStudio: 1.2.1335+conda, R: 3.5.1, Python: 3.7.1, patch: 3"
+version: 2.2.5
+appVersion: "RStudio: 1.2.1335+conda, R: 3.5.1, Python: 3.7.1, patch: 10"

--- a/charts/rstudio/values.yaml
+++ b/charts/rstudio/values.yaml
@@ -30,7 +30,7 @@ rstudio:
   port: "8787"
   image:
     repository: quay.io/mojanalytics/rstudio
-    tag: "1.2.1335-r3.5.1-python3.7.1-conda-9"
+    tag: "1.2.1335-r3.5.1-python3.7.1-conda-10"
     pullPolicy: "IfNotPresent"
     # init option allows you to run an init container that does the setup of the conda environment
     # this is quite slow and if it was run as part of the main container then it would cause problems.


### PR DESCRIPTION
Background
nbstripout is a tool that strips outputs from Jupyter notebooks (https://github.com/kynan/nbstripout)

We use it as a pre-commit hook to remove outputs from Jupyter notebooks before they are committed to Github as they may contain sensitive details.

Currently, nbstripout is installed via pip in the default R Studio image.

This causes issues with the initialisation of new conda environments which stops R Studio from starting up.
We have also issues with R Studio startup due to some files in the ~/.conda/env/rstudio/bin directory that have incorrect permissions. This appears to be because we are now using a later version of conda (4.8.3) than the latest stable R Studio image which is using conda 4.7.9.


Changes

This PR updates the default image tag for R Studio to use release 1.2.1335-r3.5.1-python3.7.1-conda-10

This release has the following changes.

- stop installing nbstripout via pip
- add nbstripout to list of packages installed with conda
- update permissions on ~/.conda/envs/rstudio/bin and ~/.conda/envs/rstudio/lib/R/bin directories after the conda environment has been initialised.
