### PR TITLE
Use v5.2.6 of auth-proxy in helm charts

### DIFF
--- a/charts/airflow-sqlite/CHANGELOG.md
+++ b/charts/airflow-sqlite/CHANGELOG.md
@@ -5,6 +5,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [0.3.2] - 2020-06-15
+### Changed
+Bumped auth-proxy from `v5.2.5` to `v5.2.6`.
+
+This is a maintenance release which upgrades some of its dependencies.
+Few of these new dependencies also fix some potential security
+vulnerabilities.
+
+See Release Notes for more: https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.6
+
+
 ## [0.3.1] - 2020-01-31
 ### Changed
 Bumped auth-proxy from `v5.2.1` to `v5.2.4`.

--- a/charts/airflow-sqlite/Chart.yaml
+++ b/charts/airflow-sqlite/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 description: Airflow with sqlite. Tasks are run as pods
 name: airflow-sqlite
 icon: https://airflow.incubator.apache.org/_images/pin_large.png
-version: 0.3.1
+version: 0.3.2
 appVersion: 1.10.6-1

--- a/charts/airflow-sqlite/values.yaml
+++ b/charts/airflow-sqlite/values.yaml
@@ -24,7 +24,7 @@ service:
   port: 80
 authProxy:
   image: "quay.io/mojanalytics/auth-proxy"
-  tag: "v5.2.4"
+  tag: "v5.2.6"
   imagePullPolicy: "IfNotPresent"
   containerPort: "3000"
   resources:

--- a/charts/jupyter-lab/CHANGELOG.md
+++ b/charts/jupyter-lab/CHANGELOG.md
@@ -5,6 +5,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [0.5.2] - 2020-06-15
+### Changed
+Bumped auth-proxy from `v5.2.5` to `v5.2.6`.
+
+This is a maintenance release which upgrades some of its dependencies.
+Few of these new dependencies also fix some potential security
+vulnerabilities.
+
+See Release Notes for more: https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.6
+
+
 ## [0.5.1] - 2020-01-31
 ### Changed
 Bumped auth-proxy from `v5.2.1` to `v5.2.4`.

--- a/charts/jupyter-lab/Chart.yaml
+++ b/charts/jupyter-lab/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: Jupyter Lab with Auth0 authentication proxy
 name: jupyter-lab
-version: 0.5.1
+version: 0.5.2
 appVersion: v0.6.7

--- a/charts/jupyter-lab/values.yaml
+++ b/charts/jupyter-lab/values.yaml
@@ -10,7 +10,7 @@ service:
 
 authProxy:
   image: quay.io/mojanalytics/auth-proxy
-  tag: v5.2.4
+  tag: v5.2.6
   imagePullPolicy: IfNotPresent
   containerPort: 3000
   resources:

--- a/charts/kibana-auth-proxy/CHANGELOG.md
+++ b/charts/kibana-auth-proxy/CHANGELOG.md
@@ -5,6 +5,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [2.1.2] - 2020-06-15
+### Changed
+Bumped auth-proxy from `v5.2.5` to `v5.2.6`.
+
+This is a maintenance release which upgrades some of its dependencies.
+Few of these new dependencies also fix some potential security
+vulnerabilities.
+
+See Release Notes for more: https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.6
+
+
 ## [2.1.1] - 2020-01-31
 ### Changed
 Bumped auth-proxy from `v5.2.1` to `v5.2.4`.

--- a/charts/kibana-auth-proxy/Chart.yaml
+++ b/charts/kibana-auth-proxy/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Auth proxy in front of Kibana
 name: kibana-auth-proxy
-version: 2.1.1
+version: 2.1.2

--- a/charts/kibana-auth-proxy/values.yaml
+++ b/charts/kibana-auth-proxy/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 image:
   repository: quay.io/mojanalytics/auth-proxy
-  tag: "v5.2.4"
+  tag: "v5.2.6"
   pullPolicy: IfNotPresent
 service:
   type: ClusterIP

--- a/charts/kubernetes-dashboard/CHANGELOG.md
+++ b/charts/kubernetes-dashboard/CHANGELOG.md
@@ -5,6 +5,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [2.0.3] - 2020-06-15
+### Changed
+Bumped auth-proxy from `v5.2.5` to `v5.2.6`.
+
+This is a maintenance release which upgrades some of its dependencies.
+Few of these new dependencies also fix some potential security
+vulnerabilities.
+
+See Release Notes for more: https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.6
+
+
 ## [2.0.2] - 2020-01-31
 ### Changed
 Bumped auth-proxy from `v5.2.1` to `v5.2.4`.

--- a/charts/kubernetes-dashboard/Chart.yaml
+++ b/charts/kubernetes-dashboard/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Kubernetes Dashboard with OIDC auth
 name: kubernetes-dashboard
-version: 2.0.2
+version: 2.0.3

--- a/charts/kubernetes-dashboard/values.yaml
+++ b/charts/kubernetes-dashboard/values.yaml
@@ -8,7 +8,7 @@ dashboard:
 
 authProxy:
   image: quay.io/mojanalytics/auth-proxy
-  tag: v5.2.4
+  tag: v5.2.6
   imagePullPolicy: IfNotPresent
   containerPort: 3000
   resources:

--- a/charts/prometheus-resources/CHANGELOG.md
+++ b/charts/prometheus-resources/CHANGELOG.md
@@ -5,7 +5,18 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-## [0.1.3] - 2020-12-31
+## [0.1.4] - 2020-06-15
+### Changed
+Bumped auth-proxy from `v5.2.5` to `v5.2.6`.
+
+This is a maintenance release which upgrades some of its dependencies.
+Few of these new dependencies also fix some potential security
+vulnerabilities.
+
+See Release Notes for more: https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.6
+
+
+## [0.1.3] - 2020-01-31
 ### Changed
 Bumped auth-proxy from `v5.2.1` to `v5.2.4`.
 

--- a/charts/prometheus-resources/Chart.yaml
+++ b/charts/prometheus-resources/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "1.0"
 description: Deploys resources related to the [Prometheus-Operator](https://github.com/helm/charts/tree/master/stable/prometheus-operator) helm chart
 name: prometheus-resources
-version: 0.1.3
+version: 0.1.4
 engine: gotpl

--- a/charts/prometheus-resources/values.yaml
+++ b/charts/prometheus-resources/values.yaml
@@ -5,7 +5,7 @@ ingressClass: nginx
 authProxy:
   name: auth-proxy
   image: quay.io/mojanalytics/auth-proxy
-  tag: v5.2.4
+  tag: v5.2.6
   imagePullPolicy: IfNotPresent
   containerPort: 3000
   resources:

--- a/charts/rstudio/CHANGELOG.md
+++ b/charts/rstudio/CHANGELOG.md
@@ -4,11 +4,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+## [2.2.6] - 2020-06-15
+### Changed
+Bumped auth-proxy from `v5.2.5` to `v5.2.6`.
+
+This is a maintenance release which upgrades some of its dependencies.
+Few of these new dependencies also fix some potential security
+vulnerabilities.
+
+See Release Notes for more: https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.6
+
+
 ## [2.2.5] - 2020-05-06
 ### Changed
 Install nbstripout with conda instead of pip
 Changed tag to 1.2.1335-r3.5.1-python3.7.1-conda-10
 Bumped version
+
 
 ## [2.2.4] - 2020-03-23
 ### Changed
@@ -16,15 +29,18 @@ Reverting old code
 Changed tag to 1.2.1335-r3.5.1-python3.7.1-conda-6
 Bumped version
 
+
 ## [2.2.3] - 2020-03-20
 ### Changed
 Changed tag to 1.2.1335-r3.5.1-python3.7.1-conda-5
 Bumped version
 
+
 ## [2.2.2] - 2020-03-19
 ### Changed
 Changed tag to 1.2.1335-r3.5.1-python3.7.1-conda-4
 Bumped version
+
 
 ## [2.2.1] - 2020-01-31
 ### Changed

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: RStudio with Auth0 authentication proxy
 name: rstudio
-version: 2.2.5
+version: 2.2.6
 appVersion: "RStudio: 1.2.1335+conda, R: 3.5.1, Python: 3.7.1, patch: 10"

--- a/charts/rstudio/values.yaml
+++ b/charts/rstudio/values.yaml
@@ -16,7 +16,7 @@ authProxy:
     port: 3000
   image:
     repository: quay.io/mojanalytics/auth-proxy
-    tag: "v5.2.4"
+    tag: "v5.2.6"
     pullPolicy: "IfNotPresent"
   resources:
     limits:

--- a/charts/webapp/CHANGELOG.md
+++ b/charts/webapp/CHANGELOG.md
@@ -4,11 +4,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+## [2.3.10] - 2020-06-15
+### Changed
+Bumped auth-proxy from `v5.2.5` to `v5.2.6`.
+
+This is a maintenance release which upgrades some of its dependencies.
+Few of these new dependencies also fix some potential security
+vulnerabilities.
+
+See Release Notes for more: https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.6
+
+
 ## [2.3.9] - 2020-05-15
 ### Changed
 Bumped auth-proxy from `v5.2.4` to `v5.2.5`.
 
 This fixes a problem with a broken image on the login screen. See: https://github.com/ministryofjustice/analytics-platform-auth-proxy/pull/250
+
 
 ## [2.3.8] - 2020-01-31
 ### Changed

--- a/charts/webapp/Chart.yaml
+++ b/charts/webapp/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: webapp Helm chart for Kubernetes
 name: webapp
-version: 2.3.9
+version: 2.3.10
 fluentbitVersion: 1.1.1

--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -21,7 +21,7 @@ AuthProxy:
     Domain: "AUTH0_USER.eu.auth0.com"
   Image:
     Repository: quay.io/mojanalytics/auth-proxy
-    Tag: "v5.2.5"
+    Tag: "v5.2.6"
     PullPolicy: "IfNotPresent"
 AWS:
   IAMRole: ""


### PR DESCRIPTION
This is a maintenance release of the `auth-proxy` which upgrades
some of its dependencies.
Few of these new dependencies also fix some potential security
vulnerabilities.

This commit updates the following helm charts to use this new version,
all the helm charts were using a recent version of the `auth-proxy`
of the `v5.2.x` series so this change should not - in theory - break any
of the existing helm charts in theory:

- airflow-sqlite
- jupyter-lab
- kibana-auth-proxy
- kubernetes-dashboard
- prometheus-resources
- rstudio
- webapp

See `auth-proxy` Release Notes for more info: https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.6

Part of ticket: https://trello.com/c/wTQiRlcJ