### PR TITLE
Add priority class for concourse workers

### DIFF
--- a/charts/priority-classes/Chart.yaml
+++ b/charts/priority-classes/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Pod Priority Classes
 name: priority-classes
-version: 0.1.2
+version: 0.1.3
 sources:
   - https://github.com/ministryofjustice/analytics-platform-helm-charts
   - https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption

--- a/charts/priority-classes/values.yaml
+++ b/charts/priority-classes/values.yaml
@@ -8,7 +8,6 @@ priority_classes:
   - name: webapp-default
     priority_value: 2000000
     description: "2 million"
-# - name: default-priority
-#   global: true
-#   priority_value: 50000
-#   description: "Not low or high priority"
+  - name: concourse
+    priority_value: 20000000
+    description: "20 million"


### PR DESCRIPTION
At the moment the concourse worker pods run with a default priorityclass (with a priority of 0).

The workers in the current version of concourse don't seem to be very stable when they are moved to different nodes often (as they have to retire as workers before they can restart and that doesn't always work). Increasing the priority of the concourse pods should mean they are less likely to be scheduled to a different node once they are started.

This PR will create a new priority class named concourse with a priority of 20 million.
It also removes a commented out priorityclass.

