### PR TITLE
Add priority to concourse workers and remove old loop devices

### DIFF
--- a/charts/concourse/CHANGELOG.md
+++ b/charts/concourse/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.9.1] - 2020-07-13
+### Added
+- Add `priorityClassName` to the concourse worker statefulset so can set a priority class for worker pods.
+- Ensure all loop devices are deleted before starting up a concourse worker.
+
+
 ## [1.9.0] - 2020-07-13
 ### Added
 Added concourse chart as a copy of the stable/concourse chart as we need to make some small changes to it to improve the stability of the concourse workers.

--- a/charts/concourse/Chart.yaml
+++ b/charts/concourse/Chart.yaml
@@ -20,4 +20,4 @@ name: concourse
 sources:
 - https://github.com/concourse/bin
 - https://github.com/kubernetes/charts
-version: 1.9.0
+version: 1.9.1

--- a/charts/concourse/templates/worker-statefulset.yaml
+++ b/charts/concourse/templates/worker-statefulset.yaml
@@ -25,6 +25,7 @@ spec:
       nodeSelector:
 {{ toYaml . | indent 8 }}
     {{- end }}
+      priorityClassName: {{ .Values.worker.priorityClassName }}
       serviceAccountName: {{ if .Values.rbac.create }}{{ template "concourse.worker.fullname" . }}{{ else }}{{ .Values.rbac.workerServiceAccountName }}{{ end }}
       tolerations:
 {{ toYaml .Values.worker.tolerations | indent 8 }}
@@ -39,6 +40,7 @@ spec:
             - -c
             - |-
               cp /dev/null /tmp/.liveness_probe
+              losetup -D
               rm -rf /concourse-work-dir/*
               while ! concourse retire-worker --name=${HOSTNAME} | grep -q worker-not-found; do
                 touch /tmp/.pre_start_cleanup

--- a/charts/concourse/values.yaml
+++ b/charts/concourse/values.yaml
@@ -432,6 +432,8 @@ worker:
   ## in parallel.
   podManagementPolicy: Parallel
 
+  priorityClassName: concourse
+
 ## Persistent Volume Storage configuration.
 ## ref: https://kubernetes.io/docs/user-guide/persistent-volumes
 ##


### PR DESCRIPTION
We have seen issues with the Concourse workers pods failing on a regular basis due to 

- the PVCs that they use to cache config filling up
- workers failing to retire cleanly

The reason that the PVCs seem to be filling up is due to old loop devices being left around after a pods is restarted. As the worker always creates a new loop devices each time it start, we can delete all loop devices on startup which should ensure that old ones are not left around.

It isn't clear why the concourse workers are sometimes failing to retire correctly after restarting. However, if we can limit the number of times the pods are restarted it should reduce the number of time we see this issue. One way of use doing this is to increase the priority of the worker pods so that they are less likely to be rescheduled to a new Kubernetes node.
