### PR TITLE
Fix variable interpolation for 564-alert-settings

### DIFF
--- a/charts/prometheus-resources/Chart.yaml
+++ b/charts/prometheus-resources/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "1.0"
 description: Deploys resources related to the [Prometheus-Operator](https://github.com/helm/charts/tree/master/stable/prometheus-operator) helm chart
 name: prometheus-resources
-version: 0.1.5
+version: 0.1.6
 engine: gotpl

--- a/charts/prometheus-resources/values.yaml
+++ b/charts/prometheus-resources/values.yaml
@@ -78,7 +78,7 @@ prometheusRules:
       rules:
       - alert: KubeNodeNotReady
         annotations:
-          message: '{{`{{ $labels.node }}`}} has been unready for more than 5 minutes.'
+          message: '{{ $labels.node }} has been unready for more than 5 minutes.'
           runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubenodenotready
         expr: kube_node_status_condition{job="kube-state-metrics",condition="Ready",status="true"} == 0
         for: 5m
@@ -86,7 +86,7 @@ prometheusRules:
           severity: critical
       - alert: KubeVersionMismatch
         annotations:
-          message: There are {{`{{ $value }}`}} different semantic versions of Kubernetes components running.
+          message: There are {{ $value }} different semantic versions of Kubernetes components running.
           runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeversionmismatch
         expr: count(count by (gitVersion) (label_replace(kubernetes_build_info{job!="kube-dns"},"gitVersion","$1","gitVersion","(v[0-9]*.[0-9]*.[0-9]*).*"))) > 1
         for: 1h
@@ -94,7 +94,7 @@ prometheusRules:
           severity: warning
       - alert: KubeClientErrors
         annotations:
-          message: Kubernetes API server client '{{`{{ $labels.job }}`}}/{{`{{ $labels.instance }}`}}' is experiencing {{`{{ printf "%0.0f" $value }}`}}% errors.'
+          message: Kubernetes API server client '{{ $labels.job }}/{{ $labels.instance }}' is experiencing {{ printf "%0.0f" $value }}% errors.'
           runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeclienterrors
         expr: |-
           (sum(rate(rest_client_requests_total{code=~"5.."}[5m])) by (instance, job)
@@ -106,7 +106,7 @@ prometheusRules:
           severity: warning
       - alert: KubeClientErrors
         annotations:
-          message: Kubernetes API server client '{{`{{ $labels.job }}`}}/{{`{{ $labels.instance }}`}}' is experiencing {{`{{ printf "%0.0f" $value }}`}} errors / second.
+          message: Kubernetes API server client '{{ $labels.job }}/{{ $labels.instance }}' is experiencing {{ printf "%0.0f" $value }} errors / second.
           runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeclienterrors
         expr: sum(rate(ksm_scrape_error_total{job="kube-state-metrics"}[5m])) by (instance, job) > 0.1
         for: 15m
@@ -114,7 +114,7 @@ prometheusRules:
           severity: warning
       - alert: KubeletTooManyPods
         annotations:
-          message: Kubelet {{`{{ $labels.instance }}`}} is running {{`{{ $value }}`}} Pods, close to the limit of 110.
+          message: Kubelet {{ $labels.instance }} is running {{ $value }} Pods, close to the limit of 110.
           runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubelettoomanypods
         expr: kubelet_running_pod_count{job="kubelet"} > 110 * 0.9
         for: 15m
@@ -122,7 +122,7 @@ prometheusRules:
           severity: warning
       - alert: KubeAPILatencyHigh
         annotations:
-          message: The API server has a 99th percentile latency of {{`{{ $value }}`}} seconds for {{`{{ $labels.verb }}`}} {{`{{ $labels.resource }}`}}.
+          message: The API server has a 99th percentile latency of {{ $value }} seconds for {{ $labels.verb }} {{ $labels.resource }}.
           runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapilatencyhigh
         expr: cluster_quantile:apiserver_request_latencies:histogram_quantile{job="apiserver",quantile="0.99",subresource!="log",verb!~"^(?:LIST|WATCH|WATCHLIST|PROXY|CONNECT)$"} > 1
         for: 10m
@@ -130,7 +130,7 @@ prometheusRules:
           severity: warning
       - alert: KubeAPILatencyHigh
         annotations:
-          message: The API server has a 99th percentile latency of {{`{{ $value }}`}} seconds for {{`{{ $labels.verb }}`}} {{`{{ $labels.resource }}`}}.
+          message: The API server has a 99th percentile latency of {{ $value }} seconds for {{ $labels.verb }} {{ $labels.resource }}.
           runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapilatencyhigh
         expr: cluster_quantile:apiserver_request_latencies:histogram_quantile{job="apiserver",quantile="0.99",subresource!="log",verb!~"^(?:LIST|WATCH|WATCHLIST|PROXY|CONNECT)$"} > 4
         for: 10m
@@ -138,7 +138,7 @@ prometheusRules:
           severity: critical
       - alert: KubeAPIErrorsHigh
         annotations:
-          message: API server is returning errors for {{`{{ $value }}`}}% of requests.
+          message: API server is returning errors for {{ $value }}% of requests.
           runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapierrorshigh
         expr: |-
           sum(rate(apiserver_request_count{job="apiserver",code=~"^(?:5..)$"}[5m])) without(instance, pod)
@@ -149,7 +149,7 @@ prometheusRules:
           severity: critical
       - alert: KubeAPIErrorsHigh
         annotations:
-          message: API server is returning errors for {{`{{ $value }}`}}% of requests.
+          message: API server is returning errors for {{ $value }}% of requests.
           runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapierrorshigh
         expr: |-
           sum(rate(apiserver_request_count{job="apiserver",code=~"^(?:5..)$"}[5m])) without(instance, pod)


### PR DESCRIPTION
Remove escaping on variables as they aren't needed in this scope.