### PR TITLE
Remove post-install hook annotations.

### DIFF
--- a/charts/reset-user-home/templates/deployment.yaml
+++ b/charts/reset-user-home/templates/deployment.yaml
@@ -5,10 +5,6 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: "{{ .Chart.Name }}"
-  annotations:
-    "helm.sh/hook": post-install, post-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": hook-succeeded
 spec:
   template:
     spec:


### PR DESCRIPTION
Make the job the main deployment instead of a post hook install.