### PR TITLE
Remove aliasing of pip, so it works with virtualenv.

### DIFF
--- a/charts/jupyter-lab/files/pip-user-home.sh
+++ b/charts/jupyter-lab/files/pip-user-home.sh
@@ -1,9 +1,0 @@
-#!/bin/env sh
-
-set -x
-
-/bin/grep -q -F 'pipcorn' $HOME/.bash_aliases || \
-    /bin/echo "alias pip='pipcorn() { if [ \$1 == \"install\" ]; then /opt/conda/bin/pip install --user \"\${@:2}\"; else /opt/conda/bin/pip \"\$@\"; fi }; pipcorn'" \
-    >> $HOME/.bash_aliases
-
-chown 1001:100 $HOME/.bash_aliases

--- a/charts/jupyter-lab/templates/job-bash-profile.yaml
+++ b/charts/jupyter-lab/templates/job-bash-profile.yaml
@@ -22,8 +22,6 @@ spec:
         - name: {{ template "fullname" . }}-bash-profile-config
           image: busybox
           command: [ "/bin/sh" ]
-          args:
-            - /{{ template "fullname" . }}/pip-user-home.sh
           volumeMounts:
             - name: nfs-home
               mountPath: /root


### PR DESCRIPTION
Currently the `pip` command is aliased so it doesn't work with Python virtual environments on the AP. Instead, a `--user` flag is set which cases `pip` to install packages under the unintuitive and not-on-the-python-path location of `.local`.

This ticket: https://trello.com/c/j3vVOQmL/624-pip-should-work-with-virtual-environments recommends `pip` on the AP should behave in the default manner, as supported by the guidance about using Python, packages and `pip` for all users of the Analytical Platform which can be found here: https://user-guidance.services.alpha.mojanalytics.xyz/tools.html#package-management and here: https://user-guidance.services.alpha.mojanalytics.xyz/tools.html#venv-and-pip

This PR removes the aliasing of the `pip` script that causes the problem behaviour.

In addition, for a current user, for whom `pip` has already been aliased, who wishes to use "default" `pip`, they should simply delete their `.bash_alias` file in their home directory.

I'm unsure how to test this change and any guidance would be most appreciated.