### PR TITLE
Add a Prometheus rule for KubeDNS errors

### DIFF
--- a/charts/prometheus-resources/CHANGELOG.md
+++ b/charts/prometheus-resources/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.1.7] - 2020-07-22
+### Added
+- Added an alert for KubeDNS errors
+
 
 ## [0.1.4] - 2020-06-15
 ### Changed

--- a/charts/prometheus-resources/CHANGELOG.md
+++ b/charts/prometheus-resources/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [0.1.7] - 2020-07-22
+## [0.2.0] - 2020-07-22
 ### Added
 - Added an alert for KubeDNS errors
 

--- a/charts/prometheus-resources/Chart.yaml
+++ b/charts/prometheus-resources/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "1.0"
 description: Deploys resources related to the [Prometheus-Operator](https://github.com/helm/charts/tree/master/stable/prometheus-operator) helm chart
 name: prometheus-resources
-version: 0.1.6
+version: 0.1.7
 engine: gotpl

--- a/charts/prometheus-resources/Chart.yaml
+++ b/charts/prometheus-resources/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "1.0"
 description: Deploys resources related to the [Prometheus-Operator](https://github.com/helm/charts/tree/master/stable/prometheus-operator) helm chart
 name: prometheus-resources
-version: 0.1.7
+version: 0.2.0
 engine: gotpl

--- a/charts/prometheus-resources/values.yaml
+++ b/charts/prometheus-resources/values.yaml
@@ -53,7 +53,7 @@ prometheusRules:
         labels:
           severity: warning
 
-      - alert: PreditciveHostDiskSpace
+      - alert: PredictiveHostDiskSpace
         annotations:
           message: 'Based on recent sampling, the disk is likely to will fill on volume
              {{ $labels.mountpoint }} within the next 5 hours for instace: {{ $labels.instance_id
@@ -72,6 +72,15 @@ prometheusRules:
         for: 1m
         label:
           severity: warning
+
+      - alert: KubeDNSErrors
+        annotations:
+          message: 'KubeDNS: {{ $labels.pod }} has returned {{ $value }} errors in the last 10 minutes'
+          summary: KubeDNS pod errors
+        expr: increase(kubedns_dnsmasq_errors[10m]) > 0
+        for: 1m
+        label:
+          severity: critical
 
 # custom kubernetes rules
     - name: kubernetes-system


### PR DESCRIPTION
Add a prometheus rule that will trigger an alert if the value of kubedns_dnsmasq_errors increases.

This should allow us to detect when KubeDNS pods log errors.

(Also correct annoying spelling mistake)