### PR TITLE
idler 2.1.1: maintainance release with libraries bumps

### DIFF
--- a/charts/idler/CHANGELOG.md
+++ b/charts/idler/CHANGELOG.md
@@ -5,6 +5,21 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [2.1.1] - 2020-07-22
+### Changed
+- Maintainance release of the `idler` with updated tests dependencies
+  and `kubernetes` dependency (client upgraded from `v9` to `v11`).
+- The above newer version had some breaking changes but these shouldn't
+  have any impact on the external API or behaviour of the `idler` (hence
+  the patch release here), see PR: https://github.com/ministryofjustice/analytics-platform-idler/pull/194
+
+
+See:
+- Ticket: https://trello.com/c/dYDMOvny
+- Ticket: https://trello.com/c/cQCHuIDP
+- Kubernetes bump PR: https://github.com/ministryofjustice/analytics-platform-idler/pull/194
+
+
 ## [2.1.0] - 2019-11-13
 ### Changed
 - Updated default schedule to run idler every Tuesday at 22:00 instead

--- a/charts/idler/Chart.yaml
+++ b/charts/idler/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: idler cronjob
 name: idler
-version: 2.1.0
-appVersion: v1.0.1
+version: 2.1.1
+appVersion: v1.0.2

--- a/charts/idler/values.yaml
+++ b/charts/idler/values.yaml
@@ -1,5 +1,5 @@
 # Docker image version
-image: quay.io/mojanalytics/idler:v1.0.1
+image: quay.io/mojanalytics/idler:v1.0.2
 
 # Schedule when to run
 #   min    hour   day    month (Sun-Sat)


### PR DESCRIPTION
- Maintainance release of the `idler` with updated tests dependencies
  and `kubernetes` dependency (client upgraded from `v9` to `v11`).
- The above newer version had some breaking changes but these shouldn't
  have any impact on the external API or behaviour of the `idler` (hence
  the patch release here), see PR: https://github.com/ministryofjustice/analytics-platform-idler/pull/194

See:
- Ticket: https://trello.com/c/dYDMOvny
- Ticket: https://trello.com/c/cQCHuIDP
- Kubernetes bump PR: https://github.com/ministryofjustice/analytics-platform-idler/pull/194

**NOTE** ⚠️ : Don't merge this yet as the [`idler` PR](https://github.com/ministryofjustice/analytics-platform-idler/pull/194) is still unmerged and this rely on the release/image with this tag to be built.