### PR TITLE
Add concourse workers cleaner chart

### DIFF
--- a/charts/concourse-workers-cleaner/Chart.yaml
+++ b/charts/concourse-workers-cleaner/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: Run a cronjob to prune stalled concourse workers
+name: concourse-workers-cleaner
+version: 0.0.1

--- a/charts/concourse-workers-cleaner/README.md
+++ b/charts/concourse-workers-cleaner/README.md
@@ -1,0 +1,26 @@
+# Concourse Workers Cleaner Chart
+
+
+## Installing the Chart
+
+This will install a CronJob object to periodically prune concourse workers that have stalled.
+
+To install:
+
+```bash
+$ helm upgrade concourse-workers-cleaner mojanalytics/concourse-workers-cleaner -f chart-env-config/ENV/concourse-workers-cleaner.yaml --install --namespace default
+```
+
+The job's status can be viewed with `kubectl get cronjobs`
+
+## Configuration
+
+Listing only the required params here.
+
+| Parameter             | Description                   | Default |
+| --------------------- | ----------------------------- | ------- |
+| `concourse.adminUsername`   | Concourse Admin user      | ``    |
+| `concourse.adminPassword`   | Concourse Admin password  | ``    |
+| `concourse.target`          | Concourse target          | ``    |
+| `concourse.team`            | Concourse team            | ``    |
+| `concourse.url`             | Concourse URL             | ``    |

--- a/charts/concourse-workers-cleaner/README.md
+++ b/charts/concourse-workers-cleaner/README.md
@@ -17,10 +17,10 @@ The job's status can be viewed with `kubectl get cronjobs`
 
 Listing only the required params here.
 
-| Parameter             | Description                   | Default |
-| --------------------- | ----------------------------- | ------- |
-| `concourse.adminUsername`   | Concourse Admin user      | ``    |
-| `concourse.adminPassword`   | Concourse Admin password  | ``    |
-| `concourse.target`          | Concourse target          | ``    |
-| `concourse.team`            | Concourse team            | ``    |
-| `concourse.url`             | Concourse URL             | ``    |
+| Parameter                   | Description               | Default |
+| --------------------------- | ------------------------- | ------- |
+| `concourse.adminUsername`   | Concourse Admin user      | ``      |
+| `concourse.adminPassword`   | Concourse Admin password  | ``      |
+| `concourse.target`          | Concourse target          | ``      |
+| `concourse.team`            | Concourse team            | ``      |
+| `concourse.url`             | Concourse URL             | ``      |

--- a/charts/concourse-workers-cleaner/templates/_helpers.tpl
+++ b/charts/concourse-workers-cleaner/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/concourse-workers-cleaner/templates/cronjob.yml
+++ b/charts/concourse-workers-cleaner/templates/cronjob.yml
@@ -1,0 +1,35 @@
+apiVersion: batch/v2alpha1
+kind: CronJob
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: "{{ .Chart.Name }}"
+spec:
+  schedule: "{{ .Values.schedule }}"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: {{ .Values.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.failedJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          name: {{ template "fullname" . }}
+        spec:
+          containers:
+          - image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+            imagePullPolicy: {{ .Values.image.pullPolicy }}
+            name: cleanup-workers
+            env:
+            env:
+            - name: CONCOURSE_ADMIN_USERNAME
+              value: {{ .Values.concourse.adminUsername }}
+            - name: CONCOURSE_ADMIN_PASSWORD
+              value: {{ .Values.concourse.adminPassword }}
+            - name: CONCOURSE_TARGET
+              value: {{ .Values.concourse.target }}
+            - name: CONCOURSE_TEAM
+              value: {{ .Values.concourse.team }}
+            - name: CONCOURSE_URL
+              value: {{ .Values.concourse.url }}
+          restartPolicy: OnFailure

--- a/charts/concourse-workers-cleaner/values.yaml
+++ b/charts/concourse-workers-cleaner/values.yaml
@@ -1,0 +1,15 @@
+image:
+  repository: 593291632749.dkr.ecr.eu-west-1.amazonaws.com/concourse-worker-cleaner
+  tag: 0.0.1
+  pullPolicy: IfNotPresent
+
+schedule: "*/10 * * * *"
+successfulJobsHistoryLimit: 5
+failedJobsHistoryLimit: 5
+
+concourse:
+  adminUsername: username
+  adminPassword: password
+  target: target
+  team: team
+  url: http://concourse:8080


### PR DESCRIPTION
Sometimes our concourse workers go into a stalled state and need to be pruned manually.

The long term fix would be to upgrade Concourse to a later version but we are likely to move away from using Concourse and the upgrade is not straightforward. Therefore this job should help reduce the number of issues we have with stalled concourse workers in the meantime.

This chart will install a CronJob object to periodically prune concourse workers that have stalled.

Based on https://github.com/luispabon/concourse-workers-cleaner