### PR TITLE
Add helm chart to apply limit ranges to kubernetes namespaces

### DIFF
--- a/charts/limit-ranges/Chart.yaml
+++ b/charts/limit-ranges/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+description: Deploy Limit Ranges for Kubernetes namespaces
+name: limit-ranges
+version: 0.0.1
+sources:
+  - https://github.com/ministryofjustice/analytics-platform-helm-charts
+  - https://kubernetes.io/docs/concepts/policy/limit-range

--- a/charts/limit-ranges/README.md
+++ b/charts/limit-ranges/README.md
@@ -1,0 +1,33 @@
+# Limit ranges
+
+Creates `limit ranges` for a namespace [Limit Ranges](https://kubernetes.io/docs/concepts/policy/limit-range)
+
+### Installing
+
+```bash
+helm upgrade limit-ranges mojanalytics/limit-ranges --install
+```
+
+### Configuration
+
+| Parameter        | Description                     |
+| ----------       | ---------------                 |
+| `namespace`      | (__required__) The name of the namespace to apply the Limit Range to |
+| `limits`         | (__required__) The CPU and Memory limits to apply to pods that don't have them defined |
+| `requests`       | (__required__) The CPU and Memory requests to apply to pods that don't have them defined |
+
+
+### Usage
+
+Add `LimitRange` in the `apps-prod` namespace:
+
+```yaml
+limit_ranges:
+  - namespace: apps-prod
+    limits:
+      cpu: 2
+      memory: 2Gi
+    requests:
+      cpu: 100m
+      memory: 100Mi
+```

--- a/charts/limit-ranges/README.md
+++ b/charts/limit-ranges/README.md
@@ -30,4 +30,11 @@ limit_ranges:
     requests:
       cpu: 100m
       memory: 100Mi
+  - namespace: default
+    limits:
+      cpu: 1
+      memory: 4Gi
+    requests:
+      cpu: 100m
+      memory: 100Mi  
 ```

--- a/charts/limit-ranges/templates/limit-ranges.yaml
+++ b/charts/limit-ranges/templates/limit-ranges.yaml
@@ -1,0 +1,17 @@
+{{ range .Values.limit_ranges }}
+---
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: {{ .namespace }}-limit-ranges
+  namespace: {{ .namespace }}
+spec:
+  limits:
+  - default:
+      memory: {{ .limits.memory }}
+      cpu: {{ .limits.cpu }}
+    defaultRequest:
+      memory: {{ .requests.memory }}
+      cpu: {{ .requests.cpu }}
+    type: Container
+{{ end }}

--- a/charts/limit-ranges/values.yaml
+++ b/charts/limit-ranges/values.yaml
@@ -1,0 +1,8 @@
+limit_ranges:
+  - namespace: apps-prod
+    limits:
+      cpu: 2
+      memory: 8Gi
+    requests:
+      cpu: 100m
+      memory: 100Mi


### PR DESCRIPTION
If pods do not specify limits for CPU and Memory then can potentially use all the CPU and Memory on a node which can cause problems for other apps running on the same node.

We can apply Limit ranges to a namespace which will apply CPU and Memory limits and requests to containers in a pod if they don't specify them.

https://kubernetes.io/docs/concepts/policy/limit-range


