### PR TITLE
Release for unidler v 1.0.6

### DIFF
--- a/charts/unidler/CHANGELOG.md
+++ b/charts/unidler/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v4.0.6] - 2020-08-18
+###
+- Update class names in CSS and JavaScript to the correct GDS framework names.
+
 
 ## [v4.0.5] - 2020-08-13
 ### Changed

--- a/charts/unidler/Chart.yaml
+++ b/charts/unidler/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: unidler proxy
 name: unidler
-version: "v4.0.5"
-appVersion: "v1.0.5"
+version: "v4.0.6"
+appVersion: "v1.0.6"

--- a/charts/unidler/values.yaml
+++ b/charts/unidler/values.yaml
@@ -1,7 +1,7 @@
 # Docker image
 image:
   name: quay.io/mojanalytics/go-unidler
-  tag: v1.0.5
+  tag: v1.0.6
   pullPolicy: IfNotPresent
 
 unidleKeyLabel: "host"


### PR DESCRIPTION
This PR allows me to release the new version of the un-idler (see [this PR](https://github.com/ministryofjustice/analytics-platform-go-unidler/pull/16)).