### PR TITLE
cpanel 2.4.3: reverse-proxy container readinessProbe

### DIFF
--- a/charts/cpanel/CHANGELOG.md
+++ b/charts/cpanel/CHANGELOG.md
@@ -5,9 +5,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [2.4.3] - 2020-09-04
+### Added
+- Added readiness probe to `reverse-proxy` (nginx) container
+
+
 ## [2.4.2] - 2019-11-13
 ### Changed
 - Pass Slack API token to migrations job to fix error
+
 
 ## [2.4.1] - 2019-11-07
 ### Changed

--- a/charts/cpanel/Chart.yaml
+++ b/charts/cpanel/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Analytics Platform Control Panel API webapp
 name: cpanel
-version: 2.4.2
+version: 2.4.3

--- a/charts/cpanel/templates/deployment.yaml
+++ b/charts/cpanel/templates/deployment.yaml
@@ -51,6 +51,12 @@ spec:
               mountPath: /etc/nginx/conf.d
             - name: staticfiles
               mountPath: /usr/share/nginx/html
+          readinessProbe:
+            httpGet:
+              path: /nginx-health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
         - name: worker
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"


### PR DESCRIPTION
Using newly added `/nginx-health` endpoint in the CP nginx config to
periodically check that nginx is still alive and serving traffic.

See: https://github.com/ministryofjustice/analytics-platform-control-panel/pull/834/commits/d2e2ba33f46205b66f3060009bbc490890e52275
Part of: https://trello.com/c/eUMRw1gK