### PR TITLE
cpanel 2.4.4: Added liveliness probe to `worker` (Django Channels)

### DIFF
--- a/charts/cpanel/CHANGELOG.md
+++ b/charts/cpanel/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [2.4.4] - 2020-09-11
+### Added
+- Added liveliness probe to `worker` (Django Channels) container
+
+
 ## [2.4.3] - 2020-09-04
 ### Added
 - Added readiness probe to `reverse-proxy` (nginx) container

--- a/charts/cpanel/Chart.yaml
+++ b/charts/cpanel/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Analytics Platform Control Panel API webapp
 name: cpanel
-version: 2.4.3
+version: 2.4.4

--- a/charts/cpanel/templates/deployment.yaml
+++ b/charts/cpanel/templates/deployment.yaml
@@ -68,6 +68,18 @@ spec:
               name: "{{ .Chart.Name }}-env-secrets"
           - secretRef:
               name: "{{ .Chart.Name }}-db-env"
+          livenessProbe:
+              exec:
+                command:
+                  - python3
+                  - manage.py
+                  - worker_health
+                  - "--stale-after-secs=120"
+              initialDelaySeconds: 10
+              periodSeconds: 30
+              failureThreshold: 6
+              successThreshold: 1
+              timeoutSeconds: 30
         - name: backend
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"


### PR DESCRIPTION
### What

Use newly added CP command to check whether a worker is still processing
background tasks at a reasonable rate or it's somehow stuck.

### How
This is achieved by using the CP `worker_health` command (see PR below)

```
$ python3 manage.py worker_health --stale-after-secs=120
```

which will periodically submit health tasks and check if one has been
performed recently (withing 2 minutes in this case, configurable using
`----stale-after-secs=120`)

Probes are sent every 30s but note how one or more individual probes can
fail without triggering the restart of the `worker` container.
This is by design as you don't want Kubernetes to be happy-trigger and
restart this container too easily.

`successThreshold=6` means that 6 *consecutive* probes will have to fail
in order to trigger a container restart (that is nothing was run for few
minutes on that specific pod/worker container).

Also note how in reality tasks will be performed by each worker at fairly
regular intervals of every ~30s (confirmed by testing in `dev` environment)

### Resources
Also see Control Panel command PR: ministryofjustice/analytics-platform-control-panel#840

Part of ticket: https://trello.com/c/eUMRw1gK
