### PR TITLE
cpanel 2.4.5: tweaks to worker livelinessProbe

### DIFF
--- a/charts/cpanel/CHANGELOG.md
+++ b/charts/cpanel/CHANGELOG.md
@@ -5,6 +5,26 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [2.4.5] - 2020-09-14
+### Changed
+Further tweaking liveliness probe for `worker` (Django Channels) container
+to account for potentially very slow background tasks blocking a specific
+worker.
+
+Specifically new Deploy/Initialisation of RStudio can be VERY slow
+and CP is doing a `helm upgrade --wait` so it is blocking the worker:
+
+https://github.com/ministryofjustice/analytics-platform-control-panel/blob/main/controlpanel/frontend/consumers.py#L109-L132
+
+The default `--timeout` for `helm` is 300s/5 minutes:
+
+https://helm.sh/docs/helm/helm_upgrade/#options
+
+So I'm tweaking the worker liveliness probe to consider a worker stalled when
+it didn't run something for 5 minutes and reduce the chance that a worker
+container is restarted just because someone installed a tool.
+
+
 ## [2.4.4] - 2020-09-11
 ### Added
 - Added liveliness probe to `worker` (Django Channels) container

--- a/charts/cpanel/Chart.yaml
+++ b/charts/cpanel/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Analytics Platform Control Panel API webapp
 name: cpanel
-version: 2.4.4
+version: 2.4.5

--- a/charts/cpanel/templates/deployment.yaml
+++ b/charts/cpanel/templates/deployment.yaml
@@ -74,7 +74,7 @@ spec:
                   - python3
                   - manage.py
                   - worker_health
-                  - "--stale-after-secs=120"
+                  - "--stale-after-secs=300"
               initialDelaySeconds: 10
               periodSeconds: 30
               failureThreshold: 6


### PR DESCRIPTION
Further tweaking liveliness probe for `worker` (Django Channels) container
to account for potentially very slow background tasks blocking a specific
worker.

Specifically new Deploy/Initialisation of RStudio can be VERY slow
and CP is doing a `helm upgrade --wait` so it is blocking the worker:

https://github.com/ministryofjustice/analytics-platform-control-panel/blob/main/controlpanel/frontend/consumers.py#L109-L132

The default `--timeout` for `helm` is 300s/5 minutes:

https://helm.sh/docs/helm/helm_upgrade/#options

So I'm tweaking the worker liveliness probe to consider a worker stalled when
it didn't run something for 5 minutes and reduce the chance that a worker
container is restarted just because someone installed a tool.

Part of ticket: https://trello.com/c/eUMRw1gK