### PR TITLE
reset-user-home 0.4.2: Deeper Conda cleanup

### DIFF
--- a/charts/reset-user-home/CHANGELOG.md
+++ b/charts/reset-user-home/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+
+## [0.4.2] - 2020-09-15
+### Changed
+Improved conda reset by moving not only the `~/.conda/envs/rstudio` environment
+but the whole `~/.conda/` directory AND the `~/.condarc` config file.
+
+This is to address RStudio startup problems caused by other conda environments
+and/or broken conda configuration on JupyterLab (or whatever).
+
+
+## [0.4.1] - ???
+### Added
+Initial release?

--- a/charts/reset-user-home/Chart.yaml
+++ b/charts/reset-user-home/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Reset user home environment
 name: reset-user-home
-version: 0.4.1
+version: 0.4.2

--- a/charts/reset-user-home/templates/deployment.yaml
+++ b/charts/reset-user-home/templates/deployment.yaml
@@ -19,14 +19,19 @@ spec:
             - -c
             - |
               if test -d /home/{{ .Values.Username }}/.rstudio.bak; then rm -fr /home/{{ .Values.Username }}/.rstudio.bak; fi &&
-              if test -d /home/{{ .Values.Username }}/.conda/envs/rstudio; then rm -rf /home/{{ .Values.Username }}/.conda/envs/rstudio; fi &&
               if test -d /home/{{ .Values.Username }}/.rstudio; then cp -pRf /home/{{ .Values.Username }}/.rstudio /home/{{ .Values.Username }}/.rstudio.bak; fi &&
               if test -d /home/{{ .Values.Username }}/.rstudio; then rm -fr /home/{{ .Values.Username }}/.rstudio; fi &&
+              if test -d /home/{{ .Values.Username }}/.conda.bak/; then rm -fr /home/{{ .Values.Username }}/.conda.bak/; fi &&
+              if test -d /home/{{ .Values.Username }}/.conda/; then cp -pRf /home/{{ .Values.Username }}/.conda/ /home/{{ .Values.Username }}/.conda.bak/; fi &&
+              if test -d /home/{{ .Values.Username }}/.conda/; then rm -fr /home/{{ .Values.Username }}/.conda/; fi &&
+              if test -e /home/{{ .Values.Username }}/.condarc.bak; then rm -fr /home/{{ .Values.Username }}/.condarc.bak; fi &&
+              if test -e /home/{{ .Values.Username }}/.condarc; then cp -pRf /home/{{ .Values.Username }}/.condarc /home/{{ .Values.Username }}/.condarc.bak; fi &&
+              if test -e /home/{{ .Values.Username }}/.condarc; then rm -fr /home/{{ .Values.Username }}/.condarc; fi &&
               if test -d /home/{{ .Values.Username }}/R/library; then rm -fr /home/{{ .Values.Username }}/R/library/*; fi
       volumes:
         - name: home
           persistentVolumeClaim:
             claimName: nfs-home
-  
+
       restartPolicy: OnFailure
   backoffLimit: 5


### PR DESCRIPTION
Archiving not only the `~/.conda/envs/rstudio` environment but also the
whole `~/.conda/` directory AND the `~/.condarc` config file.

This is to address RStudio startup problems caused by other conda
environments and/or broken conda configuration on JupyterLab (or whatever).

Ticket: https://trello.com/c/TWlH6wt1