### PR TITLE
cpanel 2.4.7: Fix to read apps ingresses RoleBinding

### DIFF
--- a/charts/cpanel/CHANGELOG.md
+++ b/charts/cpanel/CHANGELOG.md
@@ -5,6 +5,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [2.4.7] - 2020-09-22
+### Fixed
+Fixed `cpanel-read-apps-ingresses`' `roleRef` to use new
+`cpanel-read-apps-ingresses` name. The `Role` and `RoleBinding` were renamed
+for consistency/readability as part of previous release but this wasn't
+changed and caused CP's "Manage app" page to throw an error because of
+missing permissions.
+
+
 ## [2.4.6] - 2020-09-14
 ### Changed
 Move `worker` containers in separate pod from nginx/django "frontend" containers.

--- a/charts/cpanel/Chart.yaml
+++ b/charts/cpanel/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Analytics Platform Control Panel API webapp
 name: cpanel
-version: 2.4.6
+version: 2.4.7

--- a/charts/cpanel/templates/rbac-bindings.yaml
+++ b/charts/cpanel/templates/rbac-bindings.yaml
@@ -35,7 +35,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: "{{ .Chart.Name }}-read-ingresses"
+  name: "{{ .Chart.Name }}-read-apps-ingresses"
 subjects:
   - apiGroup: ""
     name: "{{ .Chart.Name }}-frontend"


### PR DESCRIPTION
This was referring to the old role name which is now
renamed to `cpanel-read-apps-ingresses` for consistency and
clarity.

This was causing the AP's "Manage app" page to throw an error.

(`RoleBinding` in kubernetes was fixed swiftly, this is just to be
sure helm chart is up-to-date)