### PR TITLE
Rollback the Helm API version to v1 for github-actions-runner 

### DIFF
--- a/charts/github-actions-runner/Chart.yaml
+++ b/charts/github-actions-runner/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v2
+apiVersion: v1
 appVersion: 2.267.1
 description: Self-hosted GitHub Actions Runner
 name: github-actions-runner


### PR DESCRIPTION
Rollback the Helm API version to v1 for github-actions-runner