### PR TITLE
Use mv rather than copy to backup old directories when resetting user's home

### DIFF
--- a/charts/reset-user-home/templates/deployment.yaml
+++ b/charts/reset-user-home/templates/deployment.yaml
@@ -18,13 +18,13 @@ spec:
             - /bin/sh
             - -c
             - |
-              if test -d /home/{{ .Values.Username }}/.rstudio.bak; then rm -fr /home/{{ .Values.Username }}/.rstudio.bak; fi &&
-              if test -d /home/{{ .Values.Username }}/.rstudio; then rm -rf /home/{{ .Values.Username }}/.rstudio /home/{{ .Values.Username }}/.rstudio.bak; fi &&
-              if test -d /home/{{ .Values.Username }}/.conda.bak/; then rm -fr /home/{{ .Values.Username }}/.conda.bak/; fi &&
-              if test -d /home/{{ .Values.Username }}/.conda/; then rm -rf /home/{{ .Values.Username }}/.conda/ /home/{{ .Values.Username }}/.conda.bak/; fi &&
-              if test -e /home/{{ .Values.Username }}/.condarc.bak; then rm -fr /home/{{ .Values.Username }}/.condarc.bak; fi &&
-              if test -e /home/{{ .Values.Username }}/.condarc; then rm -rf /home/{{ .Values.Username }}/.condarc /home/{{ .Values.Username }}/.condarc.bak; fi &&
-              if test -d /home/{{ .Values.Username }}/R/library; then rm -fr /home/{{ .Values.Username }}/R/library/*; fi
+              rm -rf /home/{{ .Values.Username }}/.rstudio.bak; &&
+              rm -rf /home/{{ .Values.Username }}/.rstudio; &&
+              rm -rf /home/{{ .Values.Username }}/.conda.bak/; &&
+              rm -rf /home/{{ .Values.Username }}/.conda/; &&
+              rm -rf /home/{{ .Values.Username }}/.condarc.bak; &&
+              rm -rf /home/{{ .Values.Username }}/.condarc;  &&
+              rm -rf /home/{{ .Values.Username }}/R/library/*;
       volumes:
         - name: home
           persistentVolumeClaim:

--- a/charts/reset-user-home/templates/deployment.yaml
+++ b/charts/reset-user-home/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
               if test -d /home/{{ .Values.Username }}/.rstudio.bak; then rm -fr /home/{{ .Values.Username }}/.rstudio.bak; fi &&
               if test -d /home/{{ .Values.Username }}/.rstudio; then rm -rf /home/{{ .Values.Username }}/.rstudio /home/{{ .Values.Username }}/.rstudio.bak; fi &&
               if test -d /home/{{ .Values.Username }}/.conda.bak/; then rm -fr /home/{{ .Values.Username }}/.conda.bak/; fi &&
-              if test -d /home/{{ .Values.Username }}/.conda/; then mv -f /home/{{ .Values.Username }}/.conda/ /home/{{ .Values.Username }}/.conda.bak/; fi &&
+              if test -d /home/{{ .Values.Username }}/.conda/; then rm -rf /home/{{ .Values.Username }}/.conda/ /home/{{ .Values.Username }}/.conda.bak/; fi &&
               if test -e /home/{{ .Values.Username }}/.condarc.bak; then rm -fr /home/{{ .Values.Username }}/.condarc.bak; fi &&
               if test -e /home/{{ .Values.Username }}/.condarc; then mv -f /home/{{ .Values.Username }}/.condarc /home/{{ .Values.Username }}/.condarc.bak; fi &&
               if test -d /home/{{ .Values.Username }}/R/library; then rm -fr /home/{{ .Values.Username }}/R/library/*; fi

--- a/charts/reset-user-home/templates/deployment.yaml
+++ b/charts/reset-user-home/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
               if test -d /home/{{ .Values.Username }}/.conda.bak/; then rm -fr /home/{{ .Values.Username }}/.conda.bak/; fi &&
               if test -d /home/{{ .Values.Username }}/.conda/; then rm -rf /home/{{ .Values.Username }}/.conda/ /home/{{ .Values.Username }}/.conda.bak/; fi &&
               if test -e /home/{{ .Values.Username }}/.condarc.bak; then rm -fr /home/{{ .Values.Username }}/.condarc.bak; fi &&
-              if test -e /home/{{ .Values.Username }}/.condarc; then mv -f /home/{{ .Values.Username }}/.condarc /home/{{ .Values.Username }}/.condarc.bak; fi &&
+              if test -e /home/{{ .Values.Username }}/.condarc; then rm -rf /home/{{ .Values.Username }}/.condarc /home/{{ .Values.Username }}/.condarc.bak; fi &&
               if test -d /home/{{ .Values.Username }}/R/library; then rm -fr /home/{{ .Values.Username }}/R/library/*; fi
       volumes:
         - name: home

--- a/charts/reset-user-home/templates/deployment.yaml
+++ b/charts/reset-user-home/templates/deployment.yaml
@@ -19,7 +19,7 @@ spec:
             - -c
             - |
               if test -d /home/{{ .Values.Username }}/.rstudio.bak; then rm -fr /home/{{ .Values.Username }}/.rstudio.bak; fi &&
-              if test -d /home/{{ .Values.Username }}/.rstudio; then mv -f /home/{{ .Values.Username }}/.rstudio /home/{{ .Values.Username }}/.rstudio.bak; fi &&
+              if test -d /home/{{ .Values.Username }}/.rstudio; then rm -rf /home/{{ .Values.Username }}/.rstudio /home/{{ .Values.Username }}/.rstudio.bak; fi &&
               if test -d /home/{{ .Values.Username }}/.conda.bak/; then rm -fr /home/{{ .Values.Username }}/.conda.bak/; fi &&
               if test -d /home/{{ .Values.Username }}/.conda/; then mv -f /home/{{ .Values.Username }}/.conda/ /home/{{ .Values.Username }}/.conda.bak/; fi &&
               if test -e /home/{{ .Values.Username }}/.condarc.bak; then rm -fr /home/{{ .Values.Username }}/.condarc.bak; fi &&

--- a/charts/reset-user-home/templates/deployment.yaml
+++ b/charts/reset-user-home/templates/deployment.yaml
@@ -19,14 +19,11 @@ spec:
             - -c
             - |
               if test -d /home/{{ .Values.Username }}/.rstudio.bak; then rm -fr /home/{{ .Values.Username }}/.rstudio.bak; fi &&
-              if test -d /home/{{ .Values.Username }}/.rstudio; then cp -pRf /home/{{ .Values.Username }}/.rstudio /home/{{ .Values.Username }}/.rstudio.bak; fi &&
-              if test -d /home/{{ .Values.Username }}/.rstudio; then rm -fr /home/{{ .Values.Username }}/.rstudio; fi &&
+              if test -d /home/{{ .Values.Username }}/.rstudio; then mv -f /home/{{ .Values.Username }}/.rstudio /home/{{ .Values.Username }}/.rstudio.bak; fi &&
               if test -d /home/{{ .Values.Username }}/.conda.bak/; then rm -fr /home/{{ .Values.Username }}/.conda.bak/; fi &&
-              if test -d /home/{{ .Values.Username }}/.conda/; then cp -pRf /home/{{ .Values.Username }}/.conda/ /home/{{ .Values.Username }}/.conda.bak/; fi &&
-              if test -d /home/{{ .Values.Username }}/.conda/; then rm -fr /home/{{ .Values.Username }}/.conda/; fi &&
+              if test -d /home/{{ .Values.Username }}/.conda/; then mv -f /home/{{ .Values.Username }}/.conda/ /home/{{ .Values.Username }}/.conda.bak/; fi &&
               if test -e /home/{{ .Values.Username }}/.condarc.bak; then rm -fr /home/{{ .Values.Username }}/.condarc.bak; fi &&
-              if test -e /home/{{ .Values.Username }}/.condarc; then cp -pRf /home/{{ .Values.Username }}/.condarc /home/{{ .Values.Username }}/.condarc.bak; fi &&
-              if test -e /home/{{ .Values.Username }}/.condarc; then rm -fr /home/{{ .Values.Username }}/.condarc; fi &&
+              if test -e /home/{{ .Values.Username }}/.condarc; then mv -f /home/{{ .Values.Username }}/.condarc /home/{{ .Values.Username }}/.condarc.bak; fi &&
               if test -d /home/{{ .Values.Username }}/R/library; then rm -fr /home/{{ .Values.Username }}/R/library/*; fi
       volumes:
         - name: home


### PR DESCRIPTION
* Use `mv -f` to force the rename.
* I've removed the superfluous `rm -rf` of the path that's just been `mv`-ed.
* No idea how to test this. #helmnewbie ;-)

Please feel free to ignore.

Related Trello card: https://trello.com/c/eEmNEwI7/830-make-home-reset-faster