### PR TITLE
Tidy the runner configuration

### DIFF
--- a/charts/github-actions-runner/Chart.yaml
+++ b/charts/github-actions-runner/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 2.273.5
 description: Self-hosted GitHub Actions Runner
 name: github-actions-runner
-version: 0.4.2
+version: 0.5.0
 type: application
 keywords:
   - github

--- a/charts/github-actions-runner/org_runner.yaml
+++ b/charts/github-actions-runner/org_runner.yaml
@@ -1,0 +1,5 @@
+---
+runner:
+  orgName: "foo"
+  labels: "kubernetes,foo,bar"
+  runnerGroup: "specialGroup"

--- a/charts/github-actions-runner/repo_runner.yaml
+++ b/charts/github-actions-runner/repo_runner.yaml
@@ -1,0 +1,4 @@
+---
+runner:
+  repoUrl: "https://github.com/ministryofjustice/analytics-platform-helm-charts"
+  labels: "kubernetes,foo,bar,baz"

--- a/charts/github-actions-runner/templates/deployment.yaml
+++ b/charts/github-actions-runner/templates/deployment.yaml
@@ -19,41 +19,43 @@ spec:
       labels:
         app.kubernetes.io/instance: {{ .Release.Name | quote }}
         app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-      {{- if .Values.podAnnotations }}
+      {{- if .Values.runner.podAnnotations }}
       annotations:
-        {{- range $key, $value := .Values.podAnnotations }}
+        {{- range $key, $value := .Values.runner.podAnnotations }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
       {{- end }}
     spec:
       containers:
       - name: runner
-        image: {{ printf "%s:%s"  .Values.image.repository .Values.image.tag | quote }}
-        imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+        image: {{ printf "%s:%s"  .Values.runner.image.repository .Values.runner.image.tag | quote }}
+        imagePullPolicy: {{ .Values.runner.image.pullPolicy | quote }}
         env:
-        {{- if eq .Values.orgRunner "true" }}
+        {{- if .Values.runner.orgName }}
         - name: ORG_RUNNER
           value: "true"
         - name: ORG_NAME
-          value: {{ .Values.orgName | quote }}
+          value: {{ .Values.runner.orgName | quote }}
         {{- else }}
         - name: ORG_RUNNER
           value: "false"
         - name: REPO_URL
-          value: {{ .Values.repoUrl | quote }}
+          value: {{ .Values.runner.repoUrl | quote }}
         {{- end }}
         - name: ACCESS_TOKEN
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.secretAccessTokenName | quote }}
+              name: {{ .Values.runner.secretAccessTokenName | quote }}
               key: "token"
         - name: LABELS
-          value: {{ .Values.labels | quote }}
+          value: {{ .Values.runner.labels | quote }}
         - name: DOCKER_HOST
-          value: tcp://localhost:2376
-        {{- if .Values.runnerNamePrefix }}
+          value: {{ .Values.dockerHost }}
+        - name: RUNNER_GROUP
+          value: {{ .Values.runner.runnerGroup }}
+        {{- if .Values.runner.runnerNamePrefix }}
         - name: RUNNER_NAME_PREFIX
-          value: {{ .Values.runnerNamePrefix | quote }}
+          value: {{ .Values.runner.runnerNamePrefix | quote }}
         {{- else }}
         - name: RUNNER_NAME
           valueFrom:
@@ -64,10 +66,10 @@ spec:
         command:
         - dockerd
         - --host=unix:///var/run/docker.sock
-        - --host=tcp://0.0.0.0:2376
+        - --host={{ .Values.dockerHost | quote }}
         env:
         - name: DOCKER_TLS_CERTDIR
-        image: docker:19.03.12-dind
+        image: {{ printf "%s:%s" .Values.dind.image.repository .Values.dind.image.tag | quote }}
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true

--- a/charts/github-actions-runner/values.yaml
+++ b/charts/github-actions-runner/values.yaml
@@ -1,18 +1,31 @@
 ---
-image:
-  repository: myoung34/github-runner
-  pullPolicy: Always
-  tag: "2.273.5"
+runner:
+  image:
+    repository: myoung34/github-runner
+    pullPolicy: Always
+    tag: "ubuntu-bionic"
+  orgName: ""
+  repoUrl: ""
+  secretAccessTokenName: github-token
+  labels: "kubernetes"
+  runnerNamePrefix: "github-actions-runner"
+  runnerGroup: "default"
 
-orgRunner: "true"
-orgName: ""
-secretAccessTokenName: github-token
-labels: "kubernetes"
-
-runnerNamePrefix: "github-actions-runner"
+dind:
+  image:
+    repository: docker
+    pullPolicy: IfNotPresent
+    tag: "19.03.12-dind"
+    securityContext:
+      privileged: true
+      readOnlyRootFilesystem: false
+    stdin: true
+    tty: true
 
 autoscaling:
   enabled: true
   minReplicas: 1
   maxReplicas: 50
   targetCPUUtilizationPercentage: 80
+
+dockerHost: tcp://0.0.0.0:2376


### PR DESCRIPTION
# Overview 

- Adds org_runner and repo_runner example configuration
- Namespace the runner now we also have dind configuration
- Make the dockerhost configurable
- Make the Docker image configurable
- Make runner groups configurable

## What

Adding org_runner and repo_runner configuration make it easier to test the logic in the deployment.yaml

Namespacing the runner values makes the hierarchy easier to understand for new users, and clarifies the shared values i.e. the values that are not under either the dind or runner key.

Making the DIND container image configurable makes it easy to update the Docker version without needing to update the Helm chart every time.

We can now configure runners to register with a specified runner group.

## Trello link
https://trello.com/c/ZNtuRljD/819-github-actions-runner

## Testing

Run

```shell
helm install runner . --namespace runners --dry-run -f org_runner.yaml
```

```shell
helm install runner . --namespace runners --dry-run -f repo_runner.yaml
```
