### PR TITLE
Stop quoting the docker host variable

### DIFF
--- a/charts/github-actions-runner/Chart.yaml
+++ b/charts/github-actions-runner/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 2.273.5
 description: Self-hosted GitHub Actions Runner
 name: github-actions-runner
-version: 0.5.0
+version: 0.5.1
 type: application
 keywords:
   - github

--- a/charts/github-actions-runner/templates/deployment.yaml
+++ b/charts/github-actions-runner/templates/deployment.yaml
@@ -66,7 +66,7 @@ spec:
         command:
         - dockerd
         - --host=unix:///var/run/docker.sock
-        - --host={{ .Values.dockerHost | quote }}
+        - --host={{ .Values.dockerHost }}
         env:
         - name: DOCKER_TLS_CERTDIR
         image: {{ printf "%s:%s" .Values.dind.image.repository .Values.dind.image.tag | quote }}


### PR DESCRIPTION
Fixes the error:
Status: invalid argument "\"tcp://0.0.0.0:276\"" for "-H, --host" flag: Invalid bind address format: "tcp://0.0.0.0:2376"