### PR TITLE
webapp 2.3.11: pull fluent-bit image from AWS ECR

### DIFF
--- a/charts/webapp/CHANGELOG.md
+++ b/charts/webapp/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [2.3.11] - 2020-11-10
+### Changed
+Use same `fluent-bit` image/version but pull from our AWS ECR repository
+to avoid the rate limiting problem with DockerHub.
+
+
 ## [2.3.10] - 2020-06-15
 ### Changed
 Bumped auth-proxy from `v5.2.5` to `v5.2.6`.

--- a/charts/webapp/Chart.yaml
+++ b/charts/webapp/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: webapp Helm chart for Kubernetes
 name: webapp
-version: 2.3.10
+version: 2.3.11
 fluentbitVersion: 1.1.1

--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -29,7 +29,7 @@ FluentBit:
   LogLevel: "info"
   # https://hub.docker.com/r/fluent/fluent-bit
   Image:
-    Repository: fluent/fluent-bit
+    Repository: 593291632749.dkr.ecr.eu-west-1.amazonaws.com/fluent-bit
     Tag: 1.1.1 # Add `-debug` for debugging image
     PullPolicy: "IfNotPresent"
   Resources:


### PR DESCRIPTION
It's the same image used before and same tag also but it's hosted on
our AWS ECR repository so that we don't hit the DockerHub rate limits.