### PR TITLE
Silently drop all kube-probe requests

### DIFF
--- a/charts/fluentd/Chart.yaml
+++ b/charts/fluentd/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: fluentd
-version: 0.2.7
+version: 0.2.8

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -226,6 +226,18 @@ fluentdconffiles:
     </source>
 
   output.conf: |-
+    # remove probes
+    <filter kubernetes.**>
+      @type grep
+      <exclude>
+        key log
+        pattern /kube-probe/
+      </exclude>
+      <exclude>
+        key agent
+        pattern /kube-probe/
+    </filter>
+
     # Enriches records with Kubernetes metadata
     <filter kubernetes.**>
       @type kubernetes_metadata
@@ -253,6 +265,6 @@ fluentdconffiles:
        slow_flush_log_threshold 120s
        max_retry_wait 30
        #disable_retry_limit
-       retry_limit 5
+       retry_limit 10
        num_threads 8
     </match>


### PR DESCRIPTION
Set maximum log retries to be 10 - default is 17 (bit random?), but this has caused problems with queued logs overwhelming the Elastic.co ingress nodes

Fixes:

https://trello.com/c/79iOACmg/845-define-reasonable-retry-limit-for-logs-and-apply-it-via-chart
https://trello.com/c/SnaBMHdz/840-turn-off-healthz-reporting-for-k8s-pods