### PR TITLE
Pull init container for prepull pods from ECR

### DIFF
--- a/charts/images-prepuller/Chart.yaml
+++ b/charts/images-prepuller/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Pre-pull/cache docker images on k8s nodes
 name: images-prepuller
-version: 0.1.0
+version: 0.1.1

--- a/charts/images-prepuller/templates/deamonset.yaml
+++ b/charts/images-prepuller/templates/deamonset.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       initContainers:
         - name: prepull
-          image: "docker:18.09.1"
+          image: "593291632749.dkr.ecr.eu-west-1.amazonaws.com/docker:18.09.1"
           env:
             - name: NODE_NAME
               valueFrom:


### PR DESCRIPTION
Pull init container for prepull pods from ECR. Reducing number of images we need to pull from Docker Hub.