### PR TITLE
Image pull secrets

### DIFF
--- a/charts/airflow-k8s/CHANGELOG.md
+++ b/charts/airflow-k8s/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2020-11-13
+
+- Adds image pull secrets so images can be pulled from Docker Hub with authentication
+
 ## [0.4.0] - 2020-07-07
 ### Changed
 - Updated airflow image to apache/airflow/1.10.10

--- a/charts/airflow-k8s/Chart.yaml
+++ b/charts/airflow-k8s/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 description: Airflow on kubernetes. Tasks are run as pods
 name: airflow-k8s
 icon: https://airflow.incubator.apache.org/_images/pin_large.png
-version: 0.4.0
+version: 0.5.0
 appVersion: "Airflow: 1.10.10, Python: 3.7"

--- a/charts/airflow-k8s/templates/create-nfs-dirs.yml
+++ b/charts/airflow-k8s/templates/create-nfs-dirs.yml
@@ -11,6 +11,12 @@ spec:
     metadata:
       name: {{ .Release.Name }}-create-nfs-dirs
     spec:
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range . }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
       containers:
       - name: "create-nfs-dirs"
         restart: Never

--- a/charts/airflow-k8s/templates/git-sync-deployment.yml
+++ b/charts/airflow-k8s/templates/git-sync-deployment.yml
@@ -17,7 +17,12 @@ spec:
       labels:
         app: {{ .Release.Name }}-git-sync
     spec:
-
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range . }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
       initContainers:
         - name: "delete-files"
           image: alpine:3.8
@@ -29,7 +34,6 @@ spec:
             - "sh"
             - "-cx"
             - "rm -rf /git/*"
-
       containers:
         - name: git-sync
           image: {{ .Values.gitSync.image.repository }}:{{ .Values.gitSync.image.tag }}

--- a/charts/airflow-k8s/templates/scheduler-deployment.yml
+++ b/charts/airflow-k8s/templates/scheduler-deployment.yml
@@ -22,6 +22,12 @@ spec:
         app: {{ .Release.Name }}
         component: scheduler
     spec:
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range . }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
       serviceAccountName: {{ .Release.Name }}
       initContainers:
       - name: "init"

--- a/charts/airflow-k8s/templates/webserver-deployment.yml
+++ b/charts/airflow-k8s/templates/webserver-deployment.yml
@@ -22,6 +22,12 @@ spec:
         component: webserver
         airflow-redis-client: "true"
     spec:
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range . }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
       serviceAccountName: {{ .Release.Name }}
       containers:
         - name: webserver

--- a/charts/airflow-k8s/values.yaml
+++ b/charts/airflow-k8s/values.yaml
@@ -78,3 +78,6 @@ redis:
 kube2iam:
   allowedRoles: ".*"
   serviceAccountName: ""
+
+image:
+  pullSecrets: []

--- a/charts/airflow-sqlite/CHANGELOG.md
+++ b/charts/airflow-sqlite/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [0.4.1] - 2020-11-13
+## [0.5.0] - 2020-11-13
 
 - Adds image pull secrets so images can be pulled from Docker Hub with authentication
 

--- a/charts/airflow-sqlite/CHANGELOG.md
+++ b/charts/airflow-sqlite/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [0.4.1] - 2020-11-13
+
+- Adds image pull secrets so images can be pulled from Docker Hub with authentication
 
 ## [0.4.0] - 2020-07-07
 ### Changed

--- a/charts/airflow-sqlite/Chart.yaml
+++ b/charts/airflow-sqlite/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 description: Airflow with sqlite. Tasks are run as pods
 name: airflow-sqlite
 icon: https://airflow.incubator.apache.org/_images/pin_large.png
-version: 0.4.1
+version: 0.5.0
 appVersion: "Airflow: 1.10.10, Python: 3.7"

--- a/charts/airflow-sqlite/Chart.yaml
+++ b/charts/airflow-sqlite/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 description: Airflow with sqlite. Tasks are run as pods
 name: airflow-sqlite
 icon: https://airflow.incubator.apache.org/_images/pin_large.png
-version: 0.4.0
+version: 0.4.1
 appVersion: "Airflow: 1.10.10, Python: 3.7"

--- a/charts/airflow-sqlite/templates/deployment.yml
+++ b/charts/airflow-sqlite/templates/deployment.yml
@@ -24,6 +24,12 @@ spec:
         component: all
         airflow-redis-client: "false"
     spec:
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range . }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
       serviceAccountName: {{ .Release.Name }}
       initContainers:
         - name: "init"

--- a/charts/airflow-sqlite/values.yaml
+++ b/charts/airflow-sqlite/values.yaml
@@ -45,3 +45,5 @@ cookie_secret: ""
 kube2iam:
   allowedRoles: ".*"
   serviceAccountName: ""
+image:
+  pullSecrets: []

--- a/charts/aws-login/CHANGELOG.md
+++ b/charts/aws-login/CHANGELOG.md
@@ -1,18 +1,27 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.1.0]
+
+- Adds image pull secrets so images can be pulled from Docker Hub with authentication
+
+## [1.0.1]
 
 ## [1.0.0] - 2018-09-26
+
 ### Added
+
 Added (optional) TLS block in ingress resource.
 You can set the `ingress.addTlsBlock` value to `false` if your
 ingress-controller doesn't work when ingress resources have this block (e.g.
 [traefik](https://traefik.io) doesn't seem to work)
 
 ### Changed
+
 `ingress.*` values structure changed so now you'll just pass a single
 host in `ingress.host` instead of an array in `ingress.hosts`.
 

--- a/charts/aws-login/Chart.yaml
+++ b/charts/aws-login/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: aws-login
-version: 1.0.1
+version: 1.1.0

--- a/charts/aws-login/templates/deployment.yaml
+++ b/charts/aws-login/templates/deployment.yaml
@@ -19,6 +19,12 @@ spec:
         app: {{ template "aws-login.name" . }}
         release: {{ .Release.Name }}
     spec:
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range . }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/aws-login/values.yaml
+++ b/charts/aws-login/values.yaml
@@ -12,6 +12,7 @@ image:
   repository: quay.io/mojanalytics/aws-federated-login
   tag: "v1.1.3"
   pullPolicy: IfNotPresent
+  pullSecrets: []
 
 service:
   type: ClusterIP

--- a/charts/buckets-archiver/CHANGELOG.md
+++ b/charts/buckets-archiver/CHANGELOG.md
@@ -1,12 +1,18 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.1.0] - 2020-11-13
+
+- Adds image pull secrets so images can be pulled from Docker Hub with authentication
 
 ## [0.0.1] - 2020-02-26
+
 ### Added
+
 - Initial release
 
-Ticket: https://trello.com/c/6VdNPbzz
+Ticket: <https://trello.com/c/6VdNPbzz>

--- a/charts/buckets-archiver/Chart.yaml
+++ b/charts/buckets-archiver/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 name: buckets-archiver
 description: Archives S3 buckets tagged 'to-archive'
-version: 0.0.1
+version: 0.1.0
 appVersion: v0.0.1

--- a/charts/buckets-archiver/README.md
+++ b/charts/buckets-archiver/README.md
@@ -7,19 +7,16 @@ before the S3 bucket is actually deleted.
 
 The CronJob's schedule is determined by the `schedule` value (see below).
 
-See: https://github.com/ministryofjustice/analytics-platform-buckets-archiver
-
+See: <https://github.com/ministryofjustice/analytics-platform-buckets-archiver>
 
 ## Installing/upgrading the Chart
 
-
 ```bash
-$ helm upgrade --dry-run --debug --install buckets-archiver charts/buckets-archiver --namespace default  -f chart-env-config/ENV/buckets-archiver.yml
+helm upgrade --dry-run --debug --install buckets-archiver charts/buckets-archiver --namespace default  -f chart-env-config/ENV/buckets-archiver.yml
 ```
 
 **NOTE**: Remove `--dry-run` to actually install/upgrade once you're
 happy with the output.
-
 
 ## Configuration
 
@@ -29,7 +26,5 @@ happy with the output.
 | `archiveBucket` | S3 bucket where the archived data will go (e.g. `dev-archived-buckets-data`)                | `""`                       |
 | `iamRole`       | IAM role assumed by the buckets-archiver. See [buckets-archiver's permissions] for details. | `""`                       |
 | `schedule`      | Cron format string defining time and frequency of runs                                      | `"*/5 * * * *"` (every 5m) |
-
-
 
 [buckets-archiver's permissions]: https://github.com/ministryofjustice/analytics-platform-buckets-archiver#permissions

--- a/charts/buckets-archiver/templates/cronjob.yaml
+++ b/charts/buckets-archiver/templates/cronjob.yaml
@@ -19,10 +19,16 @@ spec:
           labels:
             app: {{ .Release.Name }}
         spec:
+          {{- with .Values.image.pullSecrets }}
+          imagePullSecrets:
+          {{- range . }}
+            - name: {{ . }}
+          {{- end }}
+          {{- end }}
           serviceAccountName: {{ .Release.Name }}
           containers:
             - name: {{ .Release.Name }}
-              image: "{{ .Values.image }}"
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
               args:
                 - "archive"
               env:

--- a/charts/buckets-archiver/values.yaml
+++ b/charts/buckets-archiver/values.yaml
@@ -8,7 +8,10 @@ archiveBucket: ""
 iamRole: ""
 
 # Docker image version
-image: quay.io/mojanalytics/buckets-archiver:v0.0.1
+image:
+  repository: quay.io/mojanalytics/buckets-archiver
+  tag: v0.0.1
+  pullSecrets: []
 
 # Schedule when to run
 #   min    hour   day    month (Sun-Sat)

--- a/charts/calicoctl/CHANGELOG.md
+++ b/charts/calicoctl/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [0.2.0] - 2020-11-13
+
+- Adds image pull secrets so images can be pulled from Docker Hub with authentication

--- a/charts/calicoctl/Chart.yaml
+++ b/charts/calicoctl/Chart.yaml
@@ -1,4 +1,4 @@
 appVersion: v1
 description: calicoctl command line tool for configuring calico network provider
 name: calicoctl
-version: 0.1.0
+version: 0.2.0

--- a/charts/calicoctl/templates/pod.yaml
+++ b/charts/calicoctl/templates/pod.yaml
@@ -9,6 +9,12 @@ metadata:
   name: calicoctl
   namespace: kube-system
 spec:
+  {{- with .Values.image.pullSecrets }}
+  imagePullSecrets:
+  {{- range . }}
+    - name: {{ . }}
+  {{- end }}
+  {{- end }}
   hostNetwork: true
   containers:
   - name: calicoctl

--- a/charts/calicoctl/values.yaml
+++ b/charts/calicoctl/values.yaml
@@ -1,1 +1,2 @@
-# nothing needed here
+image:
+  pullSecrets: []

--- a/charts/cluster-autoscaler/CHANGELOG.md
+++ b/charts/cluster-autoscaler/CHANGELOG.md
@@ -1,27 +1,34 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2020-11-13
+
+- Adds image pull secrets so images can be pulled from Docker Hub with authentication
+
 ## [0.1.5] - 2019-10-21
-### Changed
+
 - Upgraded cluster autoscaler to lockstep with k8s version in new environment from `1.12.8` to `1.13.8`
 
 ## [0.1.4] - 2019-10-21
-### Changed
+
 - Updated clusterrole api-group for replicasets
 - Upgraded cluster autoscaler to lockstep with k8s version in __OLD__ environment from `1.3.5` to `1.12.8`
 
 ## [0.1.3] - 2019-03-13
-### Changed
-- Increased CPU requests and limits from 100m to 200m and 500m respectively  
+
+- Increased CPU requests and limits from 100m to 200m and 500m respectively
 
 ## [0.1.2] - 2018-11-20
+
 ### Added
+
 - Modified image tag from `v1.2.2` to `v1.3.5` after cluster upgrade. See [version table](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler#releases)
 
 ## [0.1.1] - 2018-11-20
-### Added
+
 - Added `Rolebinding` that allows __cluster-autoscaler__ to read the `configmap: cluster-autoscaler-status` in `namespace: default`
 - Added `--namespace=default` flag as __cluster-autoscaler__ assumes that it's deployed to `namespace: kube-system`

--- a/charts/cluster-autoscaler/Chart.yaml
+++ b/charts/cluster-autoscaler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.13.8
 description: Scales worker nodes within autoscaling groups
 name: cluster-autoscaler
-version: 0.1.5
+version: 0.2.0
 sources:
 - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 - https://github.com/spotinst/kubernetes-autoscaler/tree/master/cluster-autoscaler

--- a/charts/cluster-autoscaler/README.md
+++ b/charts/cluster-autoscaler/README.md
@@ -2,9 +2,9 @@
 
 The [Cluster Autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler) on AWS scales worker nodes within any specified autoscaling group. It will run as a Deployment in the cluster.
 
-See: [configuration flags](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-are-the-parameters-to-ca) 
+See: [configuration flags](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-are-the-parameters-to-ca)
 
-### Dependency
+## Dependencies
 
 This chart requires the following IAM permissions.  More information can be found [here](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler/cloudprovider/aws#permissions).
 
@@ -26,19 +26,15 @@ This chart requires the following IAM permissions.  More information can be foun
 }
 ```
 
-
 ### Installing/Upgrading chart
 
-```
+```shell
 helm upgrade cluster-autoscaler mojanalytics/cluster-autoscaler --namespace=default -f ../analytics-platform-config/chart-env-config/$ENV/cluster-autoscaler.yaml --install
 ```
 
-**Note**
-
 Contrary to online documentation it's best for us to ensure this chart is installed in a namespace other than `kube-system`, as opposed to modifying the `kube-system` namespace.
-This is because we use [kube2iam](https://github.com/jtblin/kube2iam), which imposes namespace restrictions and can prevent 
-the [Cluster Autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler) from functioning correctly. 
-
+This is because we use [kube2iam](https://github.com/jtblin/kube2iam), which imposes namespace restrictions and can prevent
+the [Cluster Autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler) from functioning correctly.
 
 ### Configuration
 
@@ -53,10 +49,8 @@ the [Cluster Autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cl
 | `pdb.val` | The value of the target Pod's label you wish to create a PodDisruptionBudget for | "" |
 
 
-**Note**
-
 By default [Cluster Autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler) ignores nodes that contain `pods`
 in the `kube-system` namespace.  It is likely that this behaviour will lead to underutilised nodes remaining after a scale down operation.
 [Cluster Autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler) uses the eviction API and respects [PodDisruptionBudgets](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/).
-Implementing [PodDisruptionBudgets](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/), allows [Cluster Autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler) to evict `pods` in the 
+Implementing [PodDisruptionBudgets](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/), allows [Cluster Autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler) to evict `pods` in the
 `kube-system` namespace.

--- a/charts/cluster-autoscaler/templates/deployment.yaml
+++ b/charts/cluster-autoscaler/templates/deployment.yaml
@@ -17,6 +17,12 @@ spec:
       labels:
         app: cluster-autoscaler
     spec:
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range . }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
       serviceAccountName: {{ .Release.Name }}
       containers:
         - image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/concourse/CHANGELOG.md
+++ b/charts/concourse/CHANGELOG.md
@@ -1,15 +1,19 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.10.0] - 2020-11-13
+
+- Adds image pull secrets so images can be pulled from Docker Hub with authentication
+
 ## [1.9.1] - 2020-07-13
-### Added
+
 - Add `priorityClassName` to the concourse worker statefulset so can set a priority class for worker pods.
 - Ensure all loop devices are deleted before starting up a concourse worker.
 
-
 ## [1.9.0] - 2020-07-13
-### Added
+
 Added concourse chart as a copy of the stable/concourse chart as we need to make some small changes to it to improve the stability of the concourse workers.

--- a/charts/concourse/Chart.yaml
+++ b/charts/concourse/Chart.yaml
@@ -20,4 +20,4 @@ name: concourse
 sources:
 - https://github.com/concourse/bin
 - https://github.com/kubernetes/charts
-version: 1.9.1
+version: 1.10.0

--- a/charts/concourse/charts/postgresql/templates/deployment.yaml
+++ b/charts/concourse/charts/postgresql/templates/deployment.yaml
@@ -25,6 +25,12 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
       {{- end }}
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range . }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
       containers:
       - name: {{ template "postgresql.fullname" . }}
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"

--- a/charts/init-user/CHANGELOG.md
+++ b/charts/init-user/CHANGELOG.md
@@ -1,32 +1,44 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2020-11-13
+
+- Adds image pull secrets so images can be pulled from Docker Hub with authentication
+
 ## [0.1.6] - 2019-09-10
+
 ## User Read Rolebinding
+
 - Add a `RoleBinding` in user namespaces for __user-read__ `ClusterRole` and team.
 
-## [0.1.5] - 2019-08-19 
+## [0.1.5] - 2019-08-19
+
 ## User Support role
+
 - Allow members of the user-support github team to have admin access to user namespaces
 
+## [0.1.4] - 2018-03-13
 
-## [0.1.4] - 2018-03-13 
 ## Lock down namespace assume role
+
 - Restrict a users namespace to only assuming the role from their own user
 
+## [0.1.2] - 2018-03-13
 
-## [0.1.2] - 2018-03-13 
-## OIDC Username Claim
+# OIDC Username Claim
+
 - Add idp prefix to username in Clusterrolebinding
 
-
 ## [0.1.1] - 2018-01-09
+
 ## Add Clusterrolebinding
+
 - This assigns the admin user-facing role to a user, scoped to the user's namespace
 
-
 ## [0.1.0] - 2017-07-13
+
 ## Copy charts from ops

--- a/charts/init-user/Chart.yaml
+++ b/charts/init-user/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: init-user
-version: 0.1.6
+version: 0.2.0

--- a/charts/init-user/templates/create-user-home-job.yml
+++ b/charts/init-user/templates/create-user-home-job.yml
@@ -10,6 +10,12 @@ spec:
     metadata:
       name: create-user-home
     spec:
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range . }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
       containers:
       - name: ubuntu
         image: ubuntu:16.04

--- a/charts/init-user/values.yaml
+++ b/charts/init-user/values.yaml
@@ -4,3 +4,5 @@ Email: ""
 Fullname: ""
 Env: ""
 OidcDomain: ""
+image:
+  pullSecrets: []

--- a/charts/jupyter-lab/CHANGELOG.md
+++ b/charts/jupyter-lab/CHANGELOG.md
@@ -1,55 +1,56 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2020-11-13
+
+- Adds the ability to specify image pullSecrets for container authentication
 
 ## [0.5.2] - 2020-06-15
-### Changed
-Bumped auth-proxy from `v5.2.5` to `v5.2.6`.
 
-This is a maintenance release which upgrades some of its dependencies.
-Few of these new dependencies also fix some potential security
-vulnerabilities.
+- Bumped auth-proxy from `v5.2.5` to `v5.2.6`.
 
-See Release Notes for more: https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.6
+  This is a maintenance release which upgrades some of its dependencies.
+  Few of these new dependencies also fix some potential security
+  vulnerabilities.
 
+  See Release Notes for more: <https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.6>
 
 ## [0.5.1] - 2020-01-31
-### Changed
-Bumped auth-proxy from `v5.2.1` to `v5.2.4`.
 
-This version updates some of the dependencies, [including
-`handlebars` `4.7.2`](https://github.com/ministryofjustice/analytics-platform-auth-proxy/pull/214)
-which fixes a security vulnerability.
+- Bumped auth-proxy from `v5.2.1` to `v5.2.4`.
 
-See:
-- https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.4
-- https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.3
+  This version updates some of the dependencies, [including
+  `handlebars` `4.7.2`](https://github.com/ministryofjustice/analytics-platform-auth-proxy/pull/214)
+  which fixes a security vulnerability.
 
+  See:
+  - <https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.4>
+  - <https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.3>
 
 ## [0.5.0] - 2020-01-21
-### Changed
-Give containers fixed cpu and memory to guarantee QoS
 
+- Give containers fixed cpu and memory to guarantee QoS
 
 ## [0.4.6] - 2019-11-04
-### Changed
-Diffent approach to long `host` labels.
-Truncate to 63 chars was not good enough if the 63th
-character happened to be a dot (`.`) because labels
-can't end with a dot.
+
+- Diffent approach to long `host` labels.
+- Truncate to 63 chars was not good enough if the 63th character happened to be a dot (`.`) because labels can't end with a dot.
 
 To maintain compatibility with existing clusters, charts
 and unidler:
-- if the length of `host` label value is <= 63 the value
+
+- If the length of `host` label value is <= 63 the value
   is the full host (as before)
-- if the full host if longer than 63 characters we split
+- If the full host if longer than 63 characters we split
   by dots and we only use the part of the host before
   the first dot
 
 Labels changes:
+
 - Added `unidle-key` label to resources selected by the unidler
   to be more explicit than just using `host`.
 - `host` label stays there as it's used in old `alpha` by
@@ -59,174 +60,141 @@ Labels changes:
   (the rest were just added for consistency for human debugging
   but could lead to confusion, so removing)
 
-
 ## [0.4.5] - 2019-10-25
-### Changed
+
 - Truncate `host` label to make sure it's less than 63
   characters once we move to new domain.
 
-
 ## [0.4.4] - 2019-10-21
-### Added
-Added `priorityClassName` to pod spec
+
+- Added `priorityClassName` to pod spec
 Updated `Deployment` APIGroup
 
-
 ## [0.4.3] - 2019-08-23
-### Changed
-Bumped auth-proxy to version v5.2.1.
-This version removes the non-standard `prompt=none`.
-Also note that v5.2.0 introduced support for logic to log into kibana.
 
-This shouldn't be a breaking change.
+- Bumped auth-proxy to version v5.2.1.
+  This version removes the non-standard `prompt=none`.
+  Also note that v5.2.0 introduced support for logic to log into kibana.
 
-https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.1
-
+  <https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.1>
 
 ## [0.4.2] - 2019-06-05
-### Changed
-Bumped `quay.io/mojanalytics/datascience-notebook` to version [`v0.6.7`](https://github.com/ministryofjustice/analytics-platform-jupyter-notebook/releases/tag/v0.6.7).
 
-This version adds flake8 and python black to show pep8 errors and add a file formatter.
-
+- Bumped `quay.io/mojanalytics/datascience-notebook` to version [`v0.6.7`](https://github.com/ministryofjustice/analytics-platform-jupyter-notebook/releases/tag/v0.6.7).
+- Adds flake8 and python black to show pep8 errors and add a file formatter.
 
 ## [0.4.1] - 2019-05-22
-### Changed
-Bumped `auth-proxy` to version [`v4.0.1`](https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v4.0.1).
 
-This version removes support for `NICKNAME_RE` and replaces it with
-a simple equality check with the `USER` environment variable.
-
+- Bumped `auth-proxy` to version [`v4.0.1`](https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v4.0.1).
+- Remove support for `NICKNAME_RE` and replaces it with a simple equality check with the `USER` environment variable.
 
 ## [0.4.0] - 2019-05-15
-### Changed
-- `auth-proxy` to version [`v3.1.0`](https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v3.1.0)
 
+- Bump `auth-proxy` to version [`v3.1.0`](https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v3.1.0)
 
 ## [0.3.2] - 2019-04-26
-### Changed
-- `auth-proxy` container don't run as root user
 
+- Change `auth-proxy` container to not run as root user
 
 ## [0.3.1] - 2019-04-25
-### Changed
+
 - Set auth-proxy name regex to exact match of username
 
-
 ## [0.3.0] - 2019-04-04
-### Changed
+
 - Added `"mojanalytics.xyz/idleable": "true"` label to pods. This will
   make the "don't idle if CPU usage is above X%" logic work again.
 
-
 ## [0.2.1] - 2019-03-28
-### Changed
+
 - Update version of auth-proxy to one that supports tunneling.
 - Allow people to tunnel dash apps.
 
-
 ## [0.2.0] - 2019-03-15
-### Changed
-- added `host=` label to everything, this will help simplify the idler
-- simplified installation/upgrade instructions in README
-- added `host` template to remove duplication
-- added NOTES.txt so that jupyter URL will be shown after installation
 
+- Added `host=` label to everything, this will help simplify the idler
+- Simplified installation/upgrade instructions in README
+- Added `host` template to remove duplication
+- Added NOTES.txt so that jupyter URL will be shown after installation
 
 ## [0.1.17] - 2019-03-07
-### Changed
+
 - Run `usermod` in Docker build to avoid it being run on startup. This will
 improve startup time for users.
 
-
 ## [0.1.16] - 2018-12-13
-### Changed
+
 - Revert previous change setting uid as 1001 at the pod level. We have
 put this back into the image as we found a couple of issues with this approach
 
-
 ## [0.1.14] - 2018-11-29
-### Changed
+
 - Jupyter-lab container will run as uid 1001 to match r-studio. This is
   no longer done by the image itself
 - Re-added `livenessProbe` and `readinessProbe` from Jupyter container
 
-
 ## [0.1.13] - 2018-11-28
-### Changed
+
 - Removed `livenessProbe` and `readinessProbe` from Jupyter container
 
-
 ## [0.1.12] - 2018-11-19
-### Changed
+
 - Modified `livenessProbe` and `readinessProbe` to type `exec` for Jupyter container
 
-
 ## [0.1.11] - 2018-11-14
-### Changed
+
 - Adjusted `livenessProbe` and `readinessProbe` to bigger values for Jupyter container
 
-
 ## [0.1.10] - 2018-10-19
-### Changed
+
 - Added `livenessProbe` to be sure pods are terminated when unhealthy
 - Reduced probes' `periodSeconds` from `5` to `2`
 - Renamed ports in `Deployment` to `proxy`/`jupyter` instead of using `http`
   for everything which could lead to confusion
 - Fixed indentation in `Deployment` YAML file
 
-
 ## [0.1.9] - 2018-10-16
-### Changed
+
 - Updated image tag to v0.6.0, which adds geospatial functionality, support for s3 access in spark, and the latest version of jupyter lab.
 
-
 ## [0.1.8] - 2018-10-05
-### Added
+
 - Add `idleable=true` annoation to the deployment. This is to allow opt-in to
   the idler.
 
-
 ## [0.1.7] - 2018-08-15
-### Changed
+
 - Added tls config to ingress.  This is required for tls termination with the nginx ingress controller. See [Trello](https://trello.com/c/M1snktNZ)
 - Auth-proxy image tag from 0.1.4 to 0.1.3 while investigating ssl redirect issues
 
-
 ## [0.1.6] - 2018-08-10
-## jupyter-tag-3
+
 - Update datascience-notebook image tag from 0.3.3 to 0.4.0. Relates to [PR](https://github.com/ministryofjustice/analytics-platform-jupyter-notebook/pull/8)
 
-
 ## [0.1.5] - 2018-08-02
-## Changed
+
 - Update auth-proxy to v0.1.4, which fixes the login loop problem which happens
   when a user fails to login but is redirected back to the login page without an
   error message.
 
-
 ## [0.1.4] - 2018-07-17
-## Jupyter Tag
--Updating the image tag from 0.3.2 to 0.3.3
 
+- Update the image tag from 0.3.2 to 0.3.3
 
 ## [0.1.3] - 2018-5-18
-## Package Home
+
 - Profile failed to auto load alias. Amended `pip-user-home.sh` to create `.bash_aliases` file which `.bashrc` checks exists
 - [Trello](https://trello.com/c/NKz0zS0m)
 
-
 ## [0.1.2] - 2018-04-10
-## Jupyter Auth0 CallBack URL
--  Fixing auth proxy callback envvar to point to the correct endpoint
 
+- Jupyter Auth0 CallBack URL: Fix auth proxy callback envvar to point to the correct endpoint
 
 ## [0.1.1] - 2018-02-15
-## Image Tag
+
 - Modifying Image tag to point to latest image
 
-
 ## [0.1.0] - 2018-02-08
-### Initial Commit
+
 - Initial chart development
 - Bash Profile job

--- a/charts/jupyter-lab/Chart.yaml
+++ b/charts/jupyter-lab/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: Jupyter Lab with Auth0 authentication proxy
 name: jupyter-lab
-version: 0.5.2
+version: 0.6.0
 appVersion: v0.6.7

--- a/charts/jupyter-lab/templates/deployment.yaml
+++ b/charts/jupyter-lab/templates/deployment.yaml
@@ -29,6 +29,12 @@ spec:
     spec:
       priorityClassName: {{ .Chart.Name }}
       serviceAccountName: {{ .Values.Username }}-jupyter
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range . }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}-auth-proxy
           image: {{ .Values.authProxy.image }}:{{ .Values.authProxy.tag }}

--- a/charts/jupyter-lab/templates/job-bash-profile.yaml
+++ b/charts/jupyter-lab/templates/job-bash-profile.yaml
@@ -16,6 +16,12 @@ spec:
         #       to direct traffic to the jupyter pod and we don't want the
         #       Job's pod to receive that traffic.
     spec:
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range . }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
       serviceAccountName: {{ .Values.Username }}-jupyter
       restartPolicy: Never
       containers:

--- a/charts/jupyter-lab/values.yaml
+++ b/charts/jupyter-lab/values.yaml
@@ -5,6 +5,9 @@ aws:
   iamRole: ""
   defaultRegion: "eu-west-1"
 
+image:
+  pullSecrets: []
+
 service:
   port: 80
 

--- a/charts/logstash/CHANGELOG.md
+++ b/charts/logstash/CHANGELOG.md
@@ -1,22 +1,24 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2020-11-13
+
+- Adds image pull secrets so images can be pulled from Docker Hub with authentication
 
 ## [1.0.0] - 2018-09-27
-## Changed
+
 Added (optional) TLS block in ingress resource.
 You can set the `ingress.addTlsBlock` value to `false` if your
 ingress-controller doesn't work when ingress resources have this block (e.g. [traefik](https://traefik.io) doesn't seem to work)
 
-
 ## [0.1.1] - 2018-07-09
-## Upgrade Logstash
+
 - Bumping image tag to 6.3.1 (from 5.6.10) to match elasticsearch version
 
-
 ## [0.1.0] - 2018-06-26
-### Initial Commit
+
 - Initial chart development

--- a/charts/logstash/Chart.yaml
+++ b/charts/logstash/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: logstash
-version: 1.0.0
+version: 1.1.0

--- a/charts/logstash/README.md
+++ b/charts/logstash/README.md
@@ -2,9 +2,8 @@
 
 Deploys [logstash](https://www.elastic.co/products/logstash)
 
-
 ### Installing and Upgrading a release
 
 ``` bash
-$ helm upgrade logstash-auth0 charts/logstash -f chart-env-config/ENV/logstash.yaml --namespace=default --install
+helm upgrade logstash-auth0 charts/logstash -f chart-env-config/ENV/logstash.yaml --namespace=default --install
 ```

--- a/charts/logstash/templates/deployment.yaml
+++ b/charts/logstash/templates/deployment.yaml
@@ -20,6 +20,12 @@ spec:
         release: {{ .Release.Name }}
     spec:
       serviceAccountName: {{ .Release.Name }}
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range . }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}

--- a/charts/logstash/values.yaml
+++ b/charts/logstash/values.yaml
@@ -6,6 +6,7 @@ image:
   tag: 6.3.1
   pullPolicy: IfNotPresent
   port: 8080
+  pullSecrets: []
 
 resources:
   limits:

--- a/charts/nfs-backup/CHANGELOG.md
+++ b/charts/nfs-backup/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [0.3.0] - 2020-11-13
+
+- Adds image pull secrets so images can be pulled from Docker Hub with authentication

--- a/charts/nfs-backup/Chart.yaml
+++ b/charts/nfs-backup/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: nfs-backup
-version: 0.2.4
+version: 0.3.0

--- a/charts/nfs-backup/templates/cronjob.yml
+++ b/charts/nfs-backup/templates/cronjob.yml
@@ -18,6 +18,12 @@ spec:
           annotations:
             iam.amazonaws.com/role: {{ .Values.AWS.IAMRole }}
         spec:
+          {{- with .Values.image.pullSecrets }}
+          imagePullSecrets:
+          {{- range . }}
+            - name: {{ . }}
+          {{- end }}
+          {{- end }}
           containers:
           - image: "{{ .Values.Image.Repository }}:{{ .Values.Image.Tag }}"
             imagePullPolicy: {{ .Values.Image.PullPolicy }}
@@ -28,12 +34,12 @@ spec:
               - /homes
               - s3://$(S3_BACKUP_BUCKET_NAME)
               - --only-show-errors
-              - --storage-class 
+              - --storage-class
               - STANDARD_IA
-              - --sse 
+              - --sse
               - AES256
-              - --delete 
-              - --exclude 
+              - --delete
+              - --exclude
               - "*/.rstudio/*"
               - --exclude
               - "*/R/library/*"

--- a/charts/nfs-backup/values.yaml
+++ b/charts/nfs-backup/values.yaml
@@ -9,3 +9,6 @@ Image:
 Schedule: "@daily"
 successfulJobsHistoryLimit: 5
 failedJobsHistoryLimit: 5
+
+image:
+  pullSecrets: []

--- a/charts/pod-cleaner/CHANGELOG.md
+++ b/charts/pod-cleaner/CHANGELOG.md
@@ -1,21 +1,25 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2020-11-13
+
+- Adds image pull secrets so images can be pulled from Docker Hub with authentication
 
 ## [0.1.1] - 2019-07-02
-### Fixed
-Fixed Docker permission error while executing `pod_cleaner.sh` script.
+
+- Fixed Docker permission error while executing `pod_cleaner.sh` script.
 Possibly caused by some change in Kubernetes.
 
-
 ## [0.1.0] - 2019-05-03
-### Added
-Also delete pods in `Pending` phase.
 
+- Delete pods in `Pending` phase.
 
 ## [0.0.1] - 2019-04-30
+
 ### Added
-Initial release, yay!
+
+Initial release.

--- a/charts/pod-cleaner/Chart.yaml
+++ b/charts/pod-cleaner/Chart.yaml
@@ -1,3 +1,3 @@
 name: pod-cleaner
 description: Delete old succeeded/failed/pending pods
-version: 0.1.1
+version: 0.2.0

--- a/charts/pod-cleaner/README.md
+++ b/charts/pod-cleaner/README.md
@@ -13,18 +13,16 @@ See kubernetes documentation on [pods phases](https://kubernetes.io/docs/concept
 **NOTE**: A pod with status `ErrImagePull` or `ImagePullBackOff` is in
 `Pending` phase.
 
-
 ## Installing the chart
 
 ```bash
-$ helm upgrade --dry-run --debug --install pod-cleaner charts/pod-cleaner --namespace airflow
+helm upgrade --dry-run --debug --install pod-cleaner charts/pod-cleaner --namespace airflow
 ```
 
 Install the helm chart in the namespace where you want the cron job
 to delete old pods.
 
 **NOTE**: Remove `--dry-run` and adjust the values file path.
-
 
 ## Configuration
 
@@ -35,14 +33,14 @@ to delete old pods.
 | `deleteSucceededAfter` | Number of days after which a pod in `Succeeded` phase should be deleted | `3` |
 | `schedule` | When to run the job that delete the old pods | `"0 5 * * *"` - every day at 5am, see https://kubernetes.io/docs/user-guide/cron-jobs/#schedule |
 
-
 ## Caveats
+
 Pods which are failing but that have `RestartPolicy=Always` will not be
 deleted because from kubernetes perspective these are still in `Running`
 phase.
 
-
 ## Technical details
+
 The cron job will start a container for each of the phases, they'll run
 the `pod_cleaner.sh` script with the right arguments.
 

--- a/charts/pod-cleaner/templates/cronjob.yaml
+++ b/charts/pod-cleaner/templates/cronjob.yaml
@@ -17,10 +17,16 @@ spec:
             app: {{ .Release.Name }}
             chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         spec:
+          {{- with .Values.image.pullSecrets }}
+          imagePullSecrets:
+          {{- range . }}
+            - name: {{ . }}
+          {{- end }}
+          {{- end }}
           serviceAccountName: {{ .Release.Name }}
           containers:
           - name: failed-pods-cleaner
-            image: "{{ .Values.image }}"
+            image: "{{ .Values.image.value }}"
             command:
             - "scripts/pod_cleaner.sh"
             env:
@@ -32,7 +38,7 @@ spec:
               - name: {{ .Release.Name }}
                 mountPath: "/scripts"
           - name: pending-pods-cleaner
-            image: "{{ .Values.image }}"
+            image: "{{ .Values.image.value }}"
             command:
             - "scripts/pod_cleaner.sh"
             env:
@@ -44,7 +50,7 @@ spec:
               - name: {{ .Release.Name }}
                 mountPath: "/scripts"
           - name: succeeded-pods-cleaner
-            image: "{{ .Values.image }}"
+            image: "{{ .Values.image.value }}"
             command:
             - "scripts/pod_cleaner.sh"
             env:

--- a/charts/pod-cleaner/values.yaml
+++ b/charts/pod-cleaner/values.yaml
@@ -1,13 +1,11 @@
-# Delete pods after...
-deleteFailedAfter: 10 # days
-deletePendingAfter: 10 # days
-deleteSucceededAfter: 3 # days
+# Delete pods after x days
+deleteFailedAfter: 10
+deletePendingAfter: 10
+deleteSucceededAfter: 3
 
-# Docker image
-image: "bitnami/kubectl:1.14.1"
+image:
+  value: "bitnami/kubectl:1.14.1"
+  pullSecrets: []
 
-# Schedule when to run
-#   min    hour   day    month (Sun-Sat)
-# "(0-59) (0-23) (1-31) (1-12) (0-6)"
 # See https://kubernetes.io/docs/user-guide/cron-jobs/#schedule
 schedule: "0 5 * * *"

--- a/charts/prometheus-resources/CHANGELOG.md
+++ b/charts/prometheus-resources/CHANGELOG.md
@@ -1,57 +1,57 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] 202-11-13
+
+- Adds image pull secrets so images can be pulled from Docker Hub with authentication
+
 ## [0.2.0] - 2020-07-22
-### Added
+
 - Added an alert for KubeDNS errors
 
+## [01.4] - 2020-06-15
 
-## [0.1.4] - 2020-06-15
-### Changed
-Bumped auth-proxy from `v5.2.5` to `v5.2.6`.
+- Bumped auth-proxy from `v5.2.5` to `v5.2.6`.
 
-This is a maintenance release which upgrades some of its dependencies.
-Few of these new dependencies also fix some potential security
-vulnerabilities.
+  This is a maintenance release which upgrades some of its dependencies.
+  Few of these new dependencies also fix some potential security
+  vulnerabilities.
 
-See Release Notes for more: https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.6
-
+  See [Release Notes for more information](https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.6)
 
 ## [0.1.3] - 2020-01-31
-### Changed
-Bumped auth-proxy from `v5.2.1` to `v5.2.4`.
 
-This version updates some of the dependencies, [including
-`handlebars` `4.7.2`](https://github.com/ministryofjustice/analytics-platform-auth-proxy/pull/214)
-which fixes a security vulnerability.
+- Bumped auth-proxy from `v5.2.1` to `v5.2.4`.
 
-See:
-- https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.4
-- https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.3
+  This version updates some of the dependencies, [including
+  `handlebars` `4.7.2`](https://github.com/ministryofjustice/analytics-platform-auth-proxy/pull/214)
+  which fixes a security vulnerability.
 
+  See:
+  - <https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.4>
+  - <https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.3>
 
 ## [0.1.2] - 2019-08-23
-### Changed
-Bumped auth-proxy to version `v5.2.1`.
-This version removes the non-standard `prompt=none`.
-Also note that `v5.2.0` introduced support for logic to log into kibana.
 
-This shouldn't be a breaking change.
+- Bumped auth-proxy to version `v5.2.1`.
+  This version removes the non-standard `prompt=none`.
+  Also note that `v5.2.0` introduced support for logic to log into kibana.
 
-https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.1
+  This shouldn't be a breaking change.
 
+  <https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.1>
 
 ## [0.1.1] - 2019-03-18
-### Upstream Chart Migration/Initial Commit
+
 - Removed duplicate alerting rules
 - Modified custom alerts to display message field like operator alerts
 
-
 ## [0.1.0] - 2019-02-05
-### Upstream Chart Migration/Initial Commit
+
 - Initial commit
 - Migrated our deployment from [CoreOS's deprecated chart](https://github.com/coreos/prometheus-operator/tree/master/helm) to [Helm stable repo chart](https://github.com/helm/charts/tree/master/stable/prometheus-operator)
 - Secured [Prometheus](https://prometheus.services.dev.mojanalytics.xyz) and [AlertManager](https://alertmanager.services.dev.mojanalytics.xyz) front-ends with [auth-proxy](https://github.com/ministryofjustice/analytics-platform-auth-proxy)

--- a/charts/prometheus-resources/Chart.yaml
+++ b/charts/prometheus-resources/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "1.0"
 description: Deploys resources related to the [Prometheus-Operator](https://github.com/helm/charts/tree/master/stable/prometheus-operator) helm chart
 name: prometheus-resources
-version: 0.2.0
+version: 0.3.0
 engine: gotpl

--- a/charts/prometheus-resources/templates/deployment.yaml
+++ b/charts/prometheus-resources/templates/deployment.yaml
@@ -27,6 +27,12 @@ spec:
         target: {{ .name }}
     spec:
       serviceAccountName: {{ $.Release.Name }}-{{ .name }}
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range . }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
       containers:
         - name: {{ $name }}
           image: {{ $.Values.authProxy.image }}:{{ $.Values.authProxy.tag }}

--- a/charts/prometheus-resources/values.yaml
+++ b/charts/prometheus-resources/values.yaml
@@ -34,7 +34,8 @@ serviceMonitors:
  #   targetPort: 8443
  #   scrapeInterval: 20s
 
-
+image:
+  pullSecrets: []
 
 prometheusOperator:
   crdApiGroup: monitoring.coreos.com

--- a/charts/rstudio/CHANGELOG.md
+++ b/charts/rstudio/CHANGELOG.md
@@ -1,67 +1,61 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.3.0] - 2020-11-13
+
+- Adds the ability to specify image pullSecrets for container authentication
 
 ## [2.2.6] - 2020-06-15
-### Changed
-Bumped auth-proxy from `v5.2.5` to `v5.2.6`.
 
-This is a maintenance release which upgrades some of its dependencies.
-Few of these new dependencies also fix some potential security
-vulnerabilities.
+- Bumped auth-proxy from `v5.2.5` to `v5.2.6`.
 
-See Release Notes for more: https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.6
+  This is a maintenance release which upgrades some of its dependencies.
+  Few of these new dependencies also fix some potential security
+  vulnerabilities.
 
+  See Release Notes for more: <https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.6>
 
 ## [2.2.5] - 2020-05-06
-### Changed
-Install nbstripout with conda instead of pip
-Changed tag to 1.2.1335-r3.5.1-python3.7.1-conda-10
-Bumped version
 
+- Install nbstripout with conda instead of pip
+- Changed tag to 1.2.1335-r3.5.1-python3.7.1-conda-10
 
 ## [2.2.4] - 2020-03-23
-### Changed
-Reverting old code
-Changed tag to 1.2.1335-r3.5.1-python3.7.1-conda-6
-Bumped version
 
+- Reverting old code
+- Changed tag to 1.2.1335-r3.5.1-python3.7.1-conda-6
 
 ## [2.2.3] - 2020-03-20
-### Changed
-Changed tag to 1.2.1335-r3.5.1-python3.7.1-conda-5
-Bumped version
 
+- Changed tag to 1.2.1335-r3.5.1-python3.7.1-conda-5
 
 ## [2.2.2] - 2020-03-19
-### Changed
-Changed tag to 1.2.1335-r3.5.1-python3.7.1-conda-4
-Bumped version
 
+- Changed tag to 1.2.1335-r3.5.1-python3.7.1-conda-4
 
 ## [2.2.1] - 2020-01-31
-### Changed
+
 Bumped auth-proxy from `v5.2.1` to `v5.2.4`.
 
-This version updates some of the dependencies, [including
-`handlebars` `4.7.2`](https://github.com/ministryofjustice/analytics-platform-auth-proxy/pull/214)
-which fixes a security vulnerability.
+  This version updates some of the dependencies, [including
+  `handlebars` `4.7.2`](https://github.com/ministryofjustice/analytics-platform-auth-proxy/pull/214)
+  which fixes a security vulnerability.
 
-See:
-- https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.4
-- https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.3
-
+  See:
+  - <https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.4>
+  - <https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.3>
 
 ## [2.2.0] - 2020-01-21
-### Changed
-Give containers fixed cpu and memory to guarantee QoS
 
+- Give containers fixed cpu and memory to guarantee QoS
 
 ## [2.1.5] - 2019-10-30
-### Changed
+
+
 Diffent approach to long `host` labels.
 Truncate to 63 chars was not good enough if the 63th
 character happened to be a dot (`.`) because labels
@@ -69,6 +63,7 @@ can't end with a dot.
 
 To maintain compatibility with existing clusters, charts
 and unidler:
+
 - if the length of `host` label value is <= 63 the value
   is the full host (as before)
 - if the full host if longer than 63 characters we split
@@ -76,6 +71,7 @@ and unidler:
   the first dot
 
 Labels changes:
+
 - Added `unidle-key` label to resources selected by the unidler
   to be more explicit than just using `host`.
 - `host` label stays there as it's used in old `alpha` by
@@ -85,194 +81,161 @@ Labels changes:
   (the rest were just added for consistency for human debugging
   but could lead to confusion, so removing)
 
-
 ## [2.1.4] - 2019-10-25
-### Changed
+
 - Truncate `host` label to make sure it's less than 63
   characters once we move to new domain.
 - Added labels to `ServiceAccount` for consistency
 
-
 ## [2.1.3] - 2019-10-23
-### Added
-Added `spec.selector.matchLabels` to deployment spec
 
+- Added `spec.selector.matchLabels` to deployment spec
 
 ## [2.1.2] - 2019-10-21
-### Added
-Added `priorityClassName` to pod spec
-Updated `Deployment` APIGroup
-Increased requested memory from `5GI` to `8GI`
 
+- Added `priorityClassName` to pod spec
+- Updated `Deployment` APIGroup
+- Increased requested memory from `5GI` to `8GI`
 
 ## [2.1.1] - 2019-08-23
-### Changed
-Bumped auth-proxy to version v5.2.1.
-This version removes the non-standard `prompt=none`.
-Also note that v5.2.0 introduced support for logic to log into kibana.
 
-This shouldn't be a breaking change.
+- Bumped auth-proxy to version v5.2.1.
+  This version removes the non-standard `prompt=none`.
+  Also note that v5.2.0 introduced support for logic to log into kibana.
 
-https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.1
-
+  <https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v5.2.1>
 
 ## [2.1.0] - 2019-07-08
-### Changed
-Using newer docker image with RStudio 1.2.
-The rest should be the same, same R version, still using conda, etc...
 
-See: https://blog.rstudio.com/2019/04/30/rstudio-1-2-release/
+- Use newer docker image with RStudio 1.2.
+  The rest should be the same, same R version, still using conda, etc...
 
+  See: <https://blog.rstudio.com/2019/04/30/rstudio-1-2-release/>
 
 ## [2.0.1] - 2019-05-21
-### Changed
-Bumped `auth-proxy` to version [`v4.0.1`](https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v4.0.1).
 
-This version of the proxy reads the `X-Forwarded-For` header
-but fixes the problem for websockets not able to read the headers.
+- Bump `auth-proxy` to version [`v4.0.1`](https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v4.0.1).
 
+  This version of the proxy reads the `X-Forwarded-For` header
+  but fixes the problem for websockets not able to read the headers.
 
 ## [2.0.0] - 2019-05-20
-### Changed
-Using `auth-proxy` [`v4.0.0`](https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v4.0.0)
-instead of the special `rstudio-auth-proxy`.
 
-The logic to add the RStudio secure cookie is now in the `auth-proxy`
-so we don't need to maintain two separate auth proxies.
+- Using `auth-proxy` [`v4.0.0`](https://github.com/ministryofjustice/analytics-platform-auth-proxy/releases/tag/v4.0.0)
+  instead of the special `rstudio-auth-proxy`.
 
+  The logic to add the RStudio secure cookie is now in the `auth-proxy`
+  so we don't need to maintain two separate auth proxies.
 
 ## [1.10.0] - 2019-05-15
-### Changed
-Use `rstudio-auth-proxy` [`v2.0.0`](https://github.com/ministryofjustice/analytics-platform-rstudio-auth-proxy/releases/tag/v2.0.0).
 
+- Use `rstudio-auth-proxy` [`v2.0.0`](https://github.com/ministryofjustice/analytics-platform-rstudio-auth-proxy/releases/tag/v2.0.0).
 
 ## [1.9.0] - 2019-03-10
-### Changed
-- Version of RStudio image with conda (r3.5.1-py3.7-conda-1)
+
+- Update the version of RStudio image with conda (r3.5.1-py3.7-conda-1)
 
   New image able to recover from bad conda install better
 
-
 ## [1.8.0] - 2019-03-15
-### Changed
+
 - Added `"mojanalytics.xyz/idleable": "true"` label to pods. This will
   make the "don't idle if CPU usage is above X%" logic work again.
 
-
 ## [1.7.0] - 2019-03-15
-### Changed
-- added `host=` label to everything, this will help simplify the idler
-- don't set unused `TOOLS_DOMAIN` environment variable
-- simplified installation/upgrade instructions in README
-- added `host` template to remove duplication
-- removed unused `name` template
 
+- Added `host=` label to everything, this will help simplify the idler
+- Don't set unused `TOOLS_DOMAIN` environment variable
+- Simplified installation/upgrade instructions in README
+- Added `host` template to remove duplication
+- Removed unused `name` template
 
 ## [1.6.0] - 2019-02-14
-### Changed
-- Version of RStudio image with conda (r3.5.1-py3.7-conda)
-- it doesn't point at the cran proxy
-- does initial setup in an init container
-- has a rstudio conda environment
-- maintains support for projects still using packrat
 
+- Version of RStudio image with conda (r3.5.1-py3.7-conda)
+- It doesn't point at the cran proxy
+- Does initial setup in an init container
+- Has a RStudio conda environment
+- Maintains support for projects still using packrat
 
 ## [1.5.8] - 2018-10-17
-### Changed
-- Version of rstudio image (3.4.2-6), it now points at the cran proxy, has boto3
-  installed by default and is able to build udunits2 r package
-- Change pull policy for rstudio container to be 'IfNotPresent' instead of 'Always'
 
+- Change the version of rstudio image (3.4.2-6).
+  It now points at the cran proxy, has boto3 installed by default and is able to build udunits2 R package
+- Change pull policy for RStudio container to be 'IfNotPresent' instead of 'Always'
 
 ## [1.5.7] - 2018-10-17
-### Changed
+
 - Don't hardcode target port in `Service`, use provided value
 - Renamed ports in `Deployment` to be more explicit and avoid any possible
   confusion (they're now called `proxy` and `rstudio` respectively)
 - Increaded probes' frequency by reduced `periodSeconds` to `2` from `5`,
   this could help with the user experience as k8s could respond to problems
   more promptly.
-
-### Added
 - Added `livenessProbe` to containers. This will ensure that containers
   are terminated (and restarted) when containers stop serving traffic
   for whatever reason.
 
-
 ## [1.5.6] - 2018-10-05
-### Added
+
 - Deployment has new label `idleable: "true"` to allow for future opt-in to new
   label-selector in the idler. This will allow idling of both rstudio (as
   currently avaiable) and jupyter or any other deployment we add this label to.
 
-
 ## [1.5.5] - 2018-08-15
-### Changed
+
 - Added tls config to ingress.  This is required for tls termination with the nginx ingress controller. See [Trello](https://trello.com/c/M1snktNZ)
 
-
 ## [1.5.4] - 2018-07-09
-### Changed
+
 - Modified RStudio image tag from v1.3.2 to 3.4.2-5 See: [PR](https://github.com/ministryofjustice/analytics-platform-rstudio/pull/34)
 
-
 ## [1.5.3] - 2018-06-05
-### Changed
+
 - Adjusted memory resource limits and requests from `request: 1GB => 5GB` & `limit: 12GB => 20GB`
 
-
 ## [1.5.2] - 2018-05-10
-### Changed
-Use `rstudio-auth-proxy` [`v1.4.3`](https://github.com/ministryofjustice/analytics-platform-rstudio-auth-proxy/releases/tag/v1.4.3.).
-This version of the proxy updates some dependencies and fixes [CVE-2018-3728](https://nvd.nist.gov/vuln/detail/CVE-2018-3728).
 
+- Use `rstudio-auth-proxy` [`v1.4.3`](https://github.com/ministryofjustice/analytics-platform-rstudio-auth-proxy/releases/tag/v1.4.3.).
+  This version of the proxy updates some dependencies and fixes [CVE-2018-3728](https://nvd.nist.gov/vuln/detail/CVE-2018-3728).
 
 ## [1.5.1] - 2018-04-27
-### RStudio Image
+
 - Modified `values.yaml` to use v1.3.2 RStudio image.
 
-
 ## [1.5.0] - 2018-04-26
-### New RStudio Image
+
 - Modified `values.yaml` to use latest RStudio image. [Trello](https://trello.com/c/RvX3onRE)
 
-
 ## [1.4.2] - 2018-04-10
-### Changed
-- Cookie session lasts 8h instead of 1h (`COOKIE_MAXAGE` environment
-variable).
+
+- Cookie session lasts 8h instead of 1h (`COOKIE_MAXAGE` environment variable).
   The reason is because RStudio is not making new HTTP requests and therefore
   not triggering the silent re-logging for users keeping RStudio open for
   more than 1h.
 
-
 ## [1.4.1] - 2018-02-28
-### Added
-- sets `COOKIE_MAXAGE` variable in auth proxy to expire session cookies after
+
+- Sets `COOKIE_MAXAGE` variable in auth proxy to expire session cookies after
   1 hour (can be configured via `authProxy.cookieMaxAge` value which by default
   is `3600` seconds)
-
-### Changed
 - Bumped `rstudio-auth-proxy` docker image used to `v1.4.2`.
   This version expires session cookies (after 1 hour by default).
 
-
 ## [1.4.0] - 2018-02-22
-### Changed
+
 - Bumped rstudio-auth-proxy docker image used to v1.4.1.
   This version enable silent SSO for RStudio
 - Use newly added rstudio-auth-proxy's `GET /healthz` endpoint as
   readiness probe
 
-
 ## [1.3.3] - 2018-02-16
-### Changed
+
 - Bumped rstudio-auth-proxy docker image used to v1.3.0.
   This is the version using Auth0 hosted login page
 
-
 ## [1.3.0] - 2018-02-14
-### Added
+
 - Pass `APP_PROTOCOL` and `APP_HOST` to rstudio-auth-proxy container.
   This is required in order to Auth0 hosted login page logout to work.
 - Added `CHANGELOG.md`

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: RStudio with Auth0 authentication proxy
 name: rstudio
-version: 2.2.6
+version: 2.3.0
 appVersion: "RStudio: 1.2.1335+conda, R: 3.5.1, Python: 3.7.1, patch: 10"

--- a/charts/rstudio/templates/deployment.yml
+++ b/charts/rstudio/templates/deployment.yml
@@ -23,6 +23,12 @@ spec:
       annotations:
         iam.amazonaws.com/role: {{ .Values.aws.iamRole }}
     spec:
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range . }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
       priorityClassName: {{ .Chart.Name }}
       serviceAccountName: {{ .Values.username }}-rstudio
       {{ if and .Values.rstudio.image.init }}
@@ -46,7 +52,6 @@ spec:
               mountPath: "/home/{{ .Values.username }}"
       {{ end }}
       containers:
-
         - name: rstudio-auth-proxy
           image: "{{ .Values.authProxy.image.repository }}:{{ .Values.authProxy.image.tag }}"
           imagePullPolicy: {{ .Values.authProxy.image.pullPolicy }}

--- a/charts/rstudio/values.yaml
+++ b/charts/rstudio/values.yaml
@@ -1,5 +1,7 @@
 username: ""
 toolsDomain: "tools.EXAMPLE.COM"
+image:
+  pullSecrets: []
 aws:
   iamRole: ""
   defaultRegion: "eu-west-1"


### PR DESCRIPTION
- [x] airflow-k8s
- [x] airflow-sqlite
- [x] aws-login
- [x] buckets-archiver
- [x] calicoctl
- [x] cluster-autoscaler
- [x] concourse
- [x] init-user
- [ ] dns-controller
- [ ] kube2iam
- [ ] kuberos
- [x] logstash-auth0
- [x] nfs backup
- [x] pod cleaner
- [x]  prometheus operator (grafana pod)
- [x] RStudio
- [x]  jupyterlab (job bash profile)


The following didn't have any Helm charts to update: 

- [ ] dns-controller
- [ ] kube2iam
- [ ] kuberos
