### PR TITLE
rest-user-home 0.4.3: Fix job failing because of semicolons

### DIFF
--- a/charts/reset-user-home/CHANGELOG.md
+++ b/charts/reset-user-home/CHANGELOG.md
@@ -5,6 +5,18 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [0.4.3] - 2020-11-17
+### Fixed
+- Remove semicolon in Bash commands causing job to fail. Semicolons were there
+  because of the `if` statements
+
+### Changed
+- Renamed helm template `deployment.yaml` file to `job.yaml` as this contains
+  a kubernetes `Job`, not a `Deployment`.
+- Just remove conda/rstudio hidden directories instead of testing for their
+  present and copying them (no version bump https://github.com/ministryofjustice/analytics-platform-helm-charts/pull/484 )
+
+
 ## [0.4.2] - 2020-09-15
 ### Changed
 Improved conda reset by moving not only the `~/.conda/envs/rstudio` environment

--- a/charts/reset-user-home/Chart.yaml
+++ b/charts/reset-user-home/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Reset user home environment
 name: reset-user-home
-version: 0.4.2
+version: 0.4.3

--- a/charts/reset-user-home/templates/job.yaml
+++ b/charts/reset-user-home/templates/job.yaml
@@ -18,13 +18,13 @@ spec:
             - /bin/sh
             - -c
             - |
-              rm -rf /home/{{ .Values.Username }}/.rstudio.bak; &&
-              rm -rf /home/{{ .Values.Username }}/.rstudio; &&
-              rm -rf /home/{{ .Values.Username }}/.conda.bak/; &&
-              rm -rf /home/{{ .Values.Username }}/.conda/; &&
-              rm -rf /home/{{ .Values.Username }}/.condarc.bak; &&
-              rm -rf /home/{{ .Values.Username }}/.condarc;  &&
-              rm -rf /home/{{ .Values.Username }}/R/library/*;
+              rm -rf /home/{{ .Values.Username }}/.rstudio.bak &&
+              rm -rf /home/{{ .Values.Username }}/.rstudio &&
+              rm -rf /home/{{ .Values.Username }}/.conda.bak/ &&
+              rm -rf /home/{{ .Values.Username }}/.conda/ &&
+              rm -rf /home/{{ .Values.Username }}/.condarc.bak &&
+              rm -rf /home/{{ .Values.Username }}/.condarc &&
+              rm -rf /home/{{ .Values.Username }}/R/library/*
       volumes:
         - name: home
           persistentVolumeClaim:


### PR DESCRIPTION
This was causing the job to mysteriously fail.

Also:
- bumped patch number in version and updated Changelog (also with details
  about previous changes to chart)
- renamed `deployment.yaml` template file to `job.yaml` as this contains
  a kubernetes `Job` resource (not a `Deployment`)