### PR TITLE
Support for `imagePullSecrets`

### DIFF
--- a/charts/airflow-k8s/CHANGELOG.md
+++ b/charts/airflow-k8s/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+## [0.5.0] - 2020-11-22
+### Added
+- Optional support for `imagePullSecrets` via the `imagePullSecrets` value.
+  This can be used, for example, to use authentication when pulling images
+  from DockerHub to get additional pull quota.
+
+
 ## [0.4.0] - 2020-07-07
 ### Changed
 - Updated airflow image to apache/airflow/1.10.10

--- a/charts/airflow-k8s/Chart.yaml
+++ b/charts/airflow-k8s/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 description: Airflow on kubernetes. Tasks are run as pods
 name: airflow-k8s
 icon: https://airflow.incubator.apache.org/_images/pin_large.png
-version: 0.4.0
+version: 0.5.0
 appVersion: "Airflow: 1.10.10, Python: 3.7"

--- a/charts/airflow-k8s/templates/create-nfs-dirs.yml
+++ b/charts/airflow-k8s/templates/create-nfs-dirs.yml
@@ -11,6 +11,12 @@ spec:
     metadata:
       name: {{ .Release.Name }}-create-nfs-dirs
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range . }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
       containers:
       - name: "create-nfs-dirs"
         restart: Never

--- a/charts/airflow-k8s/templates/git-sync-deployment.yml
+++ b/charts/airflow-k8s/templates/git-sync-deployment.yml
@@ -17,7 +17,12 @@ spec:
       labels:
         app: {{ .Release.Name }}-git-sync
     spec:
-
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range . }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
       initContainers:
         - name: "delete-files"
           image: alpine:3.8
@@ -29,7 +34,6 @@ spec:
             - "sh"
             - "-cx"
             - "rm -rf /git/*"
-
       containers:
         - name: git-sync
           image: {{ .Values.gitSync.image.repository }}:{{ .Values.gitSync.image.tag }}

--- a/charts/airflow-k8s/templates/hooks/init-airflow-ns-hook.yml
+++ b/charts/airflow-k8s/templates/hooks/init-airflow-ns-hook.yml
@@ -19,6 +19,12 @@ metadata:
 spec:
   template:
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range . }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
       containers:
       - name: annotator
         image: gcr.io/google_containers/hyperkube:v1.11.7

--- a/charts/airflow-k8s/templates/scheduler-deployment.yml
+++ b/charts/airflow-k8s/templates/scheduler-deployment.yml
@@ -22,6 +22,12 @@ spec:
         app: {{ .Release.Name }}
         component: scheduler
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range . }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
       serviceAccountName: {{ .Release.Name }}
       initContainers:
       - name: "init"

--- a/charts/airflow-k8s/templates/webserver-deployment.yml
+++ b/charts/airflow-k8s/templates/webserver-deployment.yml
@@ -22,6 +22,12 @@ spec:
         component: webserver
         airflow-redis-client: "true"
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range . }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
       serviceAccountName: {{ .Release.Name }}
       containers:
         - name: webserver

--- a/charts/airflow-k8s/values.yaml
+++ b/charts/airflow-k8s/values.yaml
@@ -78,3 +78,5 @@ redis:
 kube2iam:
   allowedRoles: ".*"
   serviceAccountName: ""
+
+imagePullSecrets: []

--- a/charts/concourse-org-pipeline/CHANGELOG.md
+++ b/charts/concourse-org-pipeline/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+## [0.3.0] - 2020-11-23
+### Added
+Support for pulling "set-pipeline" job image container using credentials.
+Courtesy of `imagePullSecrets` value, which defaults to `[]`, e.g. pulling
+image from public DockerHub without authenticating.
+
 ## [0.2.5] - 2019-09-03
 ### Added
 Placeholder secret `alanTuringInstitute` to `ipRanges` to support

--- a/charts/concourse-org-pipeline/Chart.yaml
+++ b/charts/concourse-org-pipeline/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Concourse pipeline for creating deployment pipelines for Github org repos
 name: concourse-org-pipeline
-version: 0.2.5
+version: 0.3.0

--- a/charts/concourse-org-pipeline/templates/job.yaml
+++ b/charts/concourse-org-pipeline/templates/job.yaml
@@ -14,6 +14,12 @@ spec:
     metadata:
       name: set-pipeline
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range . }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
       containers:
       - name: set-pipeline
         image: appropriate/curl:3.1

--- a/charts/concourse-org-pipeline/values.yaml
+++ b/charts/concourse-org-pipeline/values.yaml
@@ -60,3 +60,5 @@ kubernetes:
   apiUrl: ""
   caCert: ""
   token: ""
+
+imagePullSecrets: []

--- a/charts/concourse/CHANGELOG.md
+++ b/charts/concourse/CHANGELOG.md
@@ -1,15 +1,32 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+## [1.10.0] - 2020-11-13
+
+- Adds support for k8s `imagePullSecrets` so images can be pulled from DockerHub
+  with authentication.
+
+**NOTE**: This is added in both the main chart and the sub-chart (postgresql)
+via the `imagePullSecrets`/`postgresql.imagePullSecrets` values **NOT** the
+`image.pullSecrets` value as in other our our helm charts.
+This is because this chart and the `posgresql` one already have an `image`
+value but it's not a dictionary (so we can't add to it without breaking
+the chart and/or backward compatibility).
+Also note that this value will have to be both set in `imagePullSecrets` AND
+in `postgresql.imagePullSecrets` for this to be used by both charts.
+
+
 ## [1.9.1] - 2020-07-13
-### Added
+
 - Add `priorityClassName` to the concourse worker statefulset so can set a priority class for worker pods.
 - Ensure all loop devices are deleted before starting up a concourse worker.
 
 
 ## [1.9.0] - 2020-07-13
-### Added
+
 Added concourse chart as a copy of the stable/concourse chart as we need to make some small changes to it to improve the stability of the concourse workers.

--- a/charts/concourse/Chart.yaml
+++ b/charts/concourse/Chart.yaml
@@ -20,4 +20,4 @@ name: concourse
 sources:
 - https://github.com/concourse/bin
 - https://github.com/kubernetes/charts
-version: 1.9.1
+version: 1.10.0

--- a/charts/concourse/charts/postgresql/templates/deployment.yaml
+++ b/charts/concourse/charts/postgresql/templates/deployment.yaml
@@ -25,6 +25,12 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
       {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range . }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
       containers:
       - name: {{ template "postgresql.fullname" . }}
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"

--- a/charts/concourse/charts/postgresql/values.yaml
+++ b/charts/concourse/charts/postgresql/values.yaml
@@ -5,6 +5,9 @@ image: "postgres"
 ##
 imageTag: "9.6.2"
 
+# Secret names with credentials for container registry authentication
+imagePullSecrets: []
+
 ## Specify a imagePullPolicy
 ## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/charts/concourse/templates/web-deployment.yaml
+++ b/charts/concourse/templates/web-deployment.yaml
@@ -20,6 +20,12 @@ spec:
       serviceAccountName: {{ if .Values.rbac.create }}{{ template "concourse.web.fullname" . }}{{ else }}{{ .Values.rbac.webServiceAccountName }}{{ end }}
       tolerations:
 {{ toYaml .Values.web.tolerations | indent 8 }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range . }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
       containers:
         - name: {{ template "concourse.web.fullname" . }}
           image: "{{ .Values.image }}:{{ .Values.imageTag }}"

--- a/charts/concourse/templates/worker-statefulset.yaml
+++ b/charts/concourse/templates/worker-statefulset.yaml
@@ -30,6 +30,12 @@ spec:
       tolerations:
 {{ toYaml .Values.worker.tolerations | indent 8 }}
       terminationGracePeriodSeconds: {{ .Values.worker.terminationGracePeriodSeconds }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range . }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
       containers:
         - name: {{ template "concourse.worker.fullname" . }}
           image: "{{ .Values.image }}:{{ .Values.imageTag }}"

--- a/charts/concourse/values.yaml
+++ b/charts/concourse/values.yaml
@@ -20,6 +20,9 @@ imageTag: "3.14.1"
 ##
 imagePullPolicy: IfNotPresent
 
+# Secret names with credentials for container registry authentication
+imagePullSecrets: []
+
 ## Configuration values for Concourse.
 ## ref: https://concourse-ci.org/setting-up.html
 ##
@@ -466,6 +469,9 @@ persistence:
 ## ref: https://github.com/kubernetes/charts/blob/master/stable/postgresql/README.md
 ##
 postgresql:
+
+  # Secret names with credentials for container registry authentication
+  imagePullSecrets: []
 
   ## Use the PostgreSQL chart dependency.
   ## Set to false if bringing your own PostgreSQL, and set secret value postgresql-uri.

--- a/charts/cpanel/CHANGELOG.md
+++ b/charts/cpanel/CHANGELOG.md
@@ -5,6 +5,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [3.1.0] - 2020-11-23
+### Added
+- Support for `imagePullSecrets` to allow pulling of docker images using
+  credentials in given secret files. This is an empty list by default (so
+  not used). Also, at the moment the only image used by this helm chart which
+  is in DockerHub is the reverse proxy one (`nginxinc/nginx-unprivileged:1.16.0-alpine`).
+
+
 ## [3.0.0] - 2020-10-01
 ### Changed - BREAKING CHANGES
 - Removed `redis` chart dependency, the Redis cluster will **not** be

--- a/charts/cpanel/Chart.yaml
+++ b/charts/cpanel/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Analytics Platform Control Panel API webapp
 name: cpanel
-version: 3.0.0
+version: 3.1.0

--- a/charts/cpanel/README.md
+++ b/charts/cpanel/README.md
@@ -47,6 +47,7 @@ In Auth0 you need to install Extension 'Auth0 Authorization':
 | `env.K8S_WORKER_ROLE_NAME` | | |
 | `env.LOGS_BUCKET_NAME` | | |
 | `env.SAML_PROVIDER` | Name of SAML provider. Concatenated with `IAM_ARN_BASE:saml-provider/` to make an ARN | |
+| `imagePullSecrets` | List of secret names containing the credentials to authenticate/pull from a docker container registry. | `[]` |
 | `ingress.addTlsBlock` | Adds tls block to ingress resource. This needs to be `true` if you're using `nginx` as ingress-controller but it may need to be `false` for others (e.g. `traefik`) | `true` |
 | `postgresql.postgresDatabase` | The database name where API data will be stored | |
 | `postgresql.postgresHost` | The hostname of the database. Get it from terraform platform output `control_panel_api_db_host` | |

--- a/charts/cpanel/templates/frontend-deployment.yaml
+++ b/charts/cpanel/templates/frontend-deployment.yaml
@@ -26,6 +26,12 @@ spec:
         name: nginxconf
       - emptyDir: {}
         name: staticfiles
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range . }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
       initContainers:
       - name: init-nginx
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/cpanel/templates/job.yaml
+++ b/charts/cpanel/templates/job.yaml
@@ -12,6 +12,12 @@ metadata:
 spec:
   template:
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range . }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
       containers:
         - name: django-migrate
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/cpanel/templates/worker-deployment.yaml
+++ b/charts/cpanel/templates/worker-deployment.yaml
@@ -27,6 +27,12 @@ spec:
     #     iam.amazonaws.com/role: "{{ .Values.aws.iamRole }}"
     spec:
       serviceAccountName: "{{ .Chart.Name }}-worker"
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range . }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
       containers:
         - name: worker
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/cpanel/values.yaml
+++ b/charts/cpanel/values.yaml
@@ -2,6 +2,9 @@ servicesDomain: ""
 branch: "master"
 appsNamespace: "apps-prod"
 
+# Secrets contains credentials for pulling images from container registry
+imagePullSecrets: []
+
 image:
   repository: quay.io/mojanalytics/control-panel
   tag: v0.13.6

--- a/charts/init-user/CHANGELOG.md
+++ b/charts/init-user/CHANGELOG.md
@@ -4,21 +4,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+## [1.0.0] - 2020-11-23
+## Changed
+- Use Ubuntu docker image in our ECR container registry (private) rather than
+  the public DockerHub one. This is to reduce the number of pulls we make
+  to DockerHub and reduce the pressure on our newly introduced small quota
+
+**NOTE**: Techically this is a breaking change to this helm chart if it's
+used by someone outside our team, hence the major version bump.
+If this affects you (potential external user of this helm chart), just
+override the `ubuntu.image` value and it should work for you.
+
+
 ## [0.1.6] - 2019-09-10
 ## User Read Rolebinding
 - Add a `RoleBinding` in user namespaces for __user-read__ `ClusterRole` and team.
 
-## [0.1.5] - 2019-08-19 
+
+## [0.1.5] - 2019-08-19
 ## User Support role
 - Allow members of the user-support github team to have admin access to user namespaces
 
 
-## [0.1.4] - 2018-03-13 
+## [0.1.4] - 2018-03-13
 ## Lock down namespace assume role
 - Restrict a users namespace to only assuming the role from their own user
 
 
-## [0.1.2] - 2018-03-13 
+## [0.1.2] - 2018-03-13
 ## OIDC Username Claim
 - Add idp prefix to username in Clusterrolebinding
 

--- a/charts/init-user/Chart.yaml
+++ b/charts/init-user/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: init-user
-version: 0.1.6
+version: 1.0.0

--- a/charts/init-user/templates/create-user-home-job.yml
+++ b/charts/init-user/templates/create-user-home-job.yml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
       - name: ubuntu
-        image: ubuntu:16.04
+        image: {{ .Values.ubuntu.image }}
         command: ["/bin/sh", "-c",
           "useradd -u 1001 -g staff -m -d /homes/{{ .Values.Username }} {{ .Values.Username }}"]
         volumeMounts:

--- a/charts/init-user/values.yaml
+++ b/charts/init-user/values.yaml
@@ -4,3 +4,6 @@ Email: ""
 Fullname: ""
 Env: ""
 OidcDomain: ""
+
+ubuntu:
+  image: 593291632749.dkr.ecr.eu-west-1.amazonaws.com/ubuntu:16.04

--- a/charts/nfs-backup/Chart.yaml
+++ b/charts/nfs-backup/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: nfs-backup
-version: 0.2.4
+version: 1.0.0

--- a/charts/nfs-backup/values.yaml
+++ b/charts/nfs-backup/values.yaml
@@ -3,7 +3,7 @@ AWS:
   S3:
     BucketName: "alpha-moj-analytics-nfs-backup"
 Image:
-  Repository: amazon/aws-cli
+  Repository: 593291632749.dkr.ecr.eu-west-1.amazonaws.com/awscli
   Tag: 2.0.31
   PullPolicy: IfNotPresent
 Schedule: "@daily"

--- a/charts/pod-cleaner/CHANGELOG.md
+++ b/charts/pod-cleaner/CHANGELOG.md
@@ -5,6 +5,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0] - 2020-11-23
+### Changed
+Pull `kubectl` image from our private AWS ECR registry.
+This is technical a breaking change - in case anyone outside our team uses
+this helm chart (unlikely) - and that's why the major version number bump.
+This image value can be overridden if necessary to point to the same image
+in a public container registry.
+
+
 ## [0.1.1] - 2019-07-02
 ### Fixed
 Fixed Docker permission error while executing `pod_cleaner.sh` script.

--- a/charts/pod-cleaner/Chart.yaml
+++ b/charts/pod-cleaner/Chart.yaml
@@ -1,3 +1,3 @@
 name: pod-cleaner
 description: Delete old succeeded/failed/pending pods
-version: 0.1.1
+version: 1.0.0

--- a/charts/pod-cleaner/values.yaml
+++ b/charts/pod-cleaner/values.yaml
@@ -4,7 +4,7 @@ deletePendingAfter: 10 # days
 deleteSucceededAfter: 3 # days
 
 # Docker image
-image: "bitnami/kubectl:1.14.1"
+image: "593291632749.dkr.ecr.eu-west-1.amazonaws.com/kubectl:1.14.1"
 
 # Schedule when to run
 #   min    hour   day    month (Sun-Sat)


### PR DESCRIPTION
The point of this PR is really reduce the number of pull request made to DockerHub and enable this either by adding authentication support (using k8s' `imagePullSecrets`) or by just using the same docker image hosted in our private AWS ECR registry (which simpler and better as it wouldn't require us to add a secret in the namespace as well)

I've done this in alphabetical order so that I don't get too confused about what's done and what's not.
I've got to the charts starting with "P" so far. 

Also, as said in Slack, if we're happy with these changes so far we can just merge this PR and continue this in another PR.

**NOTE**: This is a subset (with alterations!) of Dan's PR here: https://github.com/ministryofjustice/analytics-platform-helm-charts/pull/492