### PR TITLE
Bump logstash version to 7.9.1

### DIFF
--- a/charts/fluentd/Chart.yaml
+++ b/charts/fluentd/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: fluentd
-version: 0.2.8
+version: 0.2.9

--- a/charts/fluentd/Chart.yaml
+++ b/charts/fluentd/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: fluentd
-version: 0.2.7
+version: 0.2.8

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -36,6 +36,15 @@ fluentdconffiles:
       read_from_head true
     </source>
 
+    # filter out some of the junk
+    <filter raw.kubernetes.**>
+      @type grep
+      <exclude>
+        key log
+        pattern /GET|kube-probe|healthz.*200|level=info|INFO|Feature 27|hosts update|updating hosts|not leader|starting controller iteration|skipping update of unchanged|not refreshing commands|heartbeat\.done|guardian\.list-containers\.starting|OpenAPI AggregationController|tsa\.connection\.keepalive|DEBUG/
+      </exclude>
+    </filter>
+
     <match raw.kubernetes.**>
       @id raw.kubernetes
       @type detect_exceptions
@@ -226,25 +235,12 @@ fluentdconffiles:
     </source>
 
   output.conf: |-
-    # remove probes
-    <filter kubernetes.**>
-      @type grep
-      <exclude>
-        key log
-        pattern /kube-probe/
-      </exclude>
-      <exclude>
-        key agent
-        pattern /kube-probe/
-    </filter>
-
     # Enriches records with Kubernetes metadata
     <filter kubernetes.**>
       @type kubernetes_metadata
     </filter>
 
     # Everything to Elasticsearch
-
     <match **>
        @id elasticsearch
        @type elasticsearch

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -226,6 +226,18 @@ fluentdconffiles:
     </source>
 
   output.conf: |-
+    # remove probes
+    <filter kubernetes.**>
+      @type grep
+      <exclude>
+        key log
+        pattern /kube-probe/
+      </exclude>
+      <exclude>
+        key agent
+        pattern /kube-probe/
+    </filter>
+
     # Enriches records with Kubernetes metadata
     <filter kubernetes.**>
       @type kubernetes_metadata
@@ -253,6 +265,6 @@ fluentdconffiles:
        slow_flush_log_threshold 120s
        max_retry_wait 30
        #disable_retry_limit
-       retry_limit 5
+       retry_limit 10
        num_threads 8
     </match>

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -41,7 +41,7 @@ fluentdconffiles:
       @type grep
       <exclude>
         key log
-        pattern /GET|kube-probe|healthz.*200|level=info|INFO|Feature 27|hosts update|updating hosts|not leader|starting controller iteration|skipping update of unchanged|not refreshing commands|heartbeat\.done|guardian\.list-containers\.starting|OpenAPI AggregationController|tsa\.connection\.keepalive|DEBUG/
+        pattern /kube-probe|healthz.*200|level=info|INFO|Feature 27|hosts update|updating hosts|not leader|starting controller iteration|skipping update of unchanged|not refreshing commands|heartbeat\.done|guardian\.list-containers\.starting|OpenAPI AggregationController|tsa\.connection\.keepalive|DEBUG/
       </exclude>
     </filter>
 
@@ -101,6 +101,14 @@ fluentdconffiles:
       pos_file /var/log/etcd.log.pos
       tag etcd
     </source>
+
+    <filter etcd**>
+      @type grep
+      <exclude>
+        key message
+        pattern /controller loop complete|TTL not hit|hosts update|updating hosts|sending map to all peers|starting controller iteration|I am leader with token|we are not leader|retaining backup/
+      </exclude>
+    </filter>
 
     <source>
       @id kube-proxy.log
@@ -179,6 +187,14 @@ fluentdconffiles:
       read_from_head true
       tag kubelet
     </source>
+
+    <filter syslog>
+      @type grep
+      <exclude>
+        key message
+        pattern /replacing cloudprovider-reported hostname/
+      </exclude>
+    </filter>
 
     <source>
       @id journald-node-problem-detector

--- a/charts/logstash/Chart.yaml
+++ b/charts/logstash/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: logstash
-version: 1.0.0
+version: 1.0.1

--- a/charts/logstash/values.yaml
+++ b/charts/logstash/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 
 image:
   repository: docker.elastic.co/logstash/logstash
-  tag: 6.3.1
+  tag: 7.9.1
   pullPolicy: IfNotPresent
   port: 8080
 
@@ -27,6 +27,8 @@ config:
   logstash.yml: |-
     http.host: "0.0.0.0"
     path.config: /usr/share/logstash/pipeline
-    xpack.monitoring.elasticsearch.url: '${ELASTICSEARCH_URL}'
+    xpack.monitoring.enabled: true
+    xpack.monitoring.elasticsearch.hosts: ["${ELASTICSEARCH_URL}"]
     xpack.monitoring.elasticsearch.username: '${ELASTICSEARCH_USER}'
     xpack.monitoring.elasticsearch.password: '${ELASTICSEARCH_PASSWORD}'
+    log.level: debug


### PR DESCRIPTION
This is the same version we're running in the elastic.co cluster. Add some parameters which Elastic have changed for..... reasons..... 

Add some filters to prevent certain things being ingested into Elastic.co