### PR TITLE
jupyter-lab 1.0.0: Spark image is now default

### DIFF
--- a/charts/jupyter-lab/CHANGELOG.md
+++ b/charts/jupyter-lab/CHANGELOG.md
@@ -4,9 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+## [1.0.0] - 2020-12-10
+### Changed
+- use `allspark` Docker image by default (`v1.1.1`)
+- this *may* break things in new and exciting ways hence
+  the major version bump
+- use image hosted in AWS ECR registry
+
+
 ## [0.5.4] - 2020-12-11
 ### Changed
 - Running jupyter deployment with arg ` --ContentsManager.allow_hidden=True` to allow users to see hidden files in the file browser side panel.
+
 
 ## [0.5.3] - 2020-11-25
 ### Changed

--- a/charts/jupyter-lab/Chart.yaml
+++ b/charts/jupyter-lab/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: Jupyter Lab with Auth0 authentication proxy
 name: jupyter-lab
-version: 0.5.4
-appVersion: v0.6.7
+version: 1.0.0
+appVersion: "JupyterLab: 2.2.9, Python: 3.8.6"

--- a/charts/jupyter-lab/templates/deployment.yaml
+++ b/charts/jupyter-lab/templates/deployment.yaml
@@ -93,11 +93,13 @@ spec:
             - name: jupyter
               containerPort: {{ .Values.jupyter.containerPort }}
           command:
-            - "start.sh"
+            - "start-notebook.sh"
           args:
-            - "jupyter lab"
             - "--NotebookApp.token=''"
             - --ContentsManager.allow_hidden=True
+          env:
+            - name: JUPYTER_ENABLE_LAB
+              value: "1"
           readinessProbe:
             httpGet:
               path: /

--- a/charts/jupyter-lab/values.yaml
+++ b/charts/jupyter-lab/values.yaml
@@ -29,8 +29,8 @@ authProxy:
     port_range: "8050,4040-4050"
 
 jupyter:
-  image: quay.io/mojanalytics/datascience-notebook
-  tag: v0.6.9
+  image: 593291632749.dkr.ecr.eu-west-1.amazonaws.com/allspark-notebook
+  tag: v1.1.1
   imagePullPolicy: IfNotPresent
   containerPort: 8888
   resources:


### PR DESCRIPTION
Why?
----
- use `allspark` flavour of JupyterLab image means more users can use Spark
  when needed
- move a user to `allspark` flavour is currently a manual and error-prone
  process (although documented in our [wiki])
- reduced fragementation and potential retirement of one of the current three
  flavours of JupyterLab images

Potential drawbacks
-------------------
- image sizes concerns seem to not be a problem especially after updating
  `allspark`'s BASE image. `allspark-notebook:v1.1.0` is ~2.7GB which is
  smaller than `datascience-notebook:v0.6.9` previosly used which
  was ~4.4GB
- above would be mitigated anyway by the fact this Docker image is now
  pulled from the AWS ECR registry and not quay.io which should be faster
- potential unexpected breaking changes caused by a different Docker image.
  This is always a risk even when updating the same Docker image but we
  can do some manual test and hopefully this image would work mostly in the
  same manner as `datascience` one

Resources
---------
- [Robin L. comment] explaining `allspark` image entrypoint/command
  differences
- [wiki] with instructions on how to manually deploy `allspark` flabour
  of JupyterLab

[Robin L. comment]: https://github.com/ministryofjustice/analytics-platform-jupyter-notebook/pull/24#issuecomment-603248428
[wiki]: https://github.com/ministryofjustice/analytics-platform/wiki/Deploying-jupyterlab#spark-version