### PR TITLE
ANPL-369 Add secret for mojo network

### DIFF
--- a/charts/concourse-org-pipeline/CHANGELOG.md
+++ b/charts/concourse-org-pipeline/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2021-04-12
+### Added
+Added IP range secrets for mojo network for use in webapp
+deployment IP restriction parameters.
 
 ## [0.3.0] - 2020-11-23
 ### Added

--- a/charts/concourse-org-pipeline/Chart.yaml
+++ b/charts/concourse-org-pipeline/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Concourse pipeline for creating deployment pipelines for Github org repos
 name: concourse-org-pipeline
-version: 0.3.0
+version: 0.3.1

--- a/charts/concourse-org-pipeline/Chart.yaml
+++ b/charts/concourse-org-pipeline/Chart.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 description: Concourse pipeline for creating deployment pipelines for Github org repos
 name: concourse-org-pipeline
 version: 0.3.1
+maintainers:
+  - name: ministryofjustice

--- a/charts/concourse-org-pipeline/templates/secrets.yaml
+++ b/charts/concourse-org-pipeline/templates/secrets.yaml
@@ -28,6 +28,7 @@ data:
   ip-102pf: {{ .Values.ipRanges.wifi102pf | b64enc | quote }}
   ip-digital: {{ .Values.ipRanges.mojDigitalWifiAndVpn | b64enc | quote }}
   ip-dom1: {{ .Values.ipRanges.dom1 | b64enc | quote }}
+  ip-mojo: {{ .Values.ipRanges.mojo | b64enc | quote }}
   ip-quantum: {{ .Values.ipRanges.quantum | b64enc | quote }}
   ip-turing: {{ .Values.ipRanges.alanTuringInstitute | b64enc | quote}}
   kubernetes-api-url: {{ .Values.kubernetes.apiUrl | b64enc | quote }}

--- a/charts/concourse-org-pipeline/values.yaml
+++ b/charts/concourse-org-pipeline/values.yaml
@@ -49,6 +49,9 @@ githubOrgResource:
   image: quay.io/mojanalytics/github-org-resource
   tag: v0.6.0
 
+gitCrypt:
+  symmetricKey: ""
+
 ipRanges:
   wifi102pf: ""
   dom1: ""

--- a/charts/concourse-org-pipeline/values.yaml
+++ b/charts/concourse-org-pipeline/values.yaml
@@ -55,6 +55,7 @@ ipRanges:
   quantum: ""
   mojDigitalWifiAndVpn: ""
   alanTuringInstitute: ""
+  mojo: ""
 
 kubernetes:
   apiUrl: ""


### PR DESCRIPTION
- Added IP range secrets for mojo network to concourse org pipeline chart for use in webapp deployment IP restriction parameters.
- Add maintainer and missing value to keep chart linting happy