### PR TITLE
WiP - surely I just needed to update the versions..?

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_STORE
 .vscode/
 .idea/
+.envrc

--- a/charts/rstudio/CHANGELOG.md
+++ b/charts/rstudio/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+# [4.0.0] - 2021-04-26
+
+- Working version of RStudio 4 (note the synchornization of versions).
+- Use the new nginx proxy.
+
 ## [3.1.2] - 2021-03-30
 
 - Quote strings incase ints get through to stop Helm complaining

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: RStudio with Auth0 authentication proxy
 name: rstudio
-version: 3.1.3
+version: 4.0.0
 appVersion: "RStudio: 4.0.4"
 maintainers:
   - name: ministryofjustice

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: RStudio with Auth0 authentication proxy
 name: rstudio
-version: 3.1.2
+version: 3.1.3
 appVersion: "RStudio: 4.0.4"
 maintainers:
   - name: ministryofjustice

--- a/charts/rstudio/templates/deployment.yml
+++ b/charts/rstudio/templates/deployment.yml
@@ -62,7 +62,7 @@ spec:
                   name: {{ template "fullname" . }}
                   key: client_secret
             - name: APP_HOST
-              value: http://localhost
+              value: localhost
             - name: APP_PORT
               value: {{ quote .Values.rstudio.port }}
             - name: LOGOUT_URL

--- a/charts/rstudio/values.yaml
+++ b/charts/rstudio/values.yaml
@@ -12,7 +12,7 @@ proxy:
     logoutUrl: "https://controlpanel.services.alpha.mojanalytics.xyz/"
   image:
     repository: 593291632749.dkr.ecr.eu-west-1.amazonaws.com/nginx-proxy
-    tag: "0.0.1"
+    tag: "0.0.4"
     pullPolicy: "IfNotPresent"
   resources:
     limits:

--- a/charts/rstudio/values.yaml
+++ b/charts/rstudio/values.yaml
@@ -12,7 +12,7 @@ proxy:
     logoutUrl: "https://controlpanel.services.alpha.mojanalytics.xyz/"
   image:
     repository: 593291632749.dkr.ecr.eu-west-1.amazonaws.com/nginx-proxy
-    tag: "0.0.4"
+    tag: "0.0.25"
     pullPolicy: "IfNotPresent"
   resources:
     limits:


### PR DESCRIPTION
So this doesn't work. I'm not sure why, although I have some ideas.

1) This helm chart is based on the continuing work that Dan did. I'm not sure if his changes to the helm chart will work with the new work on the docker images I did.
2) I'm just running the wrong sort of commands when trying to test `helm`... 

```
$ helm upgrade --install --wait --force rstudio-ntoll rstudio --version 3.1.3 --namespace user-ntoll --values rstudio/values.yaml --set proxy.auth0.domain=alpha-analytics-moj.eu.auth0.com --set proxy.auth0.clientId=$AUTH0_CLIENT_ID --set proxy.auth0.clientSecret=$AUTH0_CLIENT_SECRET
Release "rstudio-ntoll" does not exist. Installing it now.
Error: release rstudio-ntoll failed: timed out waiting for the condition
```

3) Nicholas does devops is like Godzilla does needlework. ;-)