### PR TITLE
ANPL-400 Add option to disable secret creation in the control panel helm chart

### DIFF
--- a/charts/cpanel/CHANGELOG.md
+++ b/charts/cpanel/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.2.0] - 2021-05-04
+### Added
+- Added `secrets.create` with a default of `true`. This dictates if the helm chart creates Kubernetes secret resources
+.
 
 ## [3.1.0] - 2020-11-23
 ### Added

--- a/charts/cpanel/CHANGELOG.md
+++ b/charts/cpanel/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [3.2.0] - 2021-05-04
 ### Added
 - Added `secrets.create` with a default of `true`. This dictates if the helm chart creates Kubernetes secret resources
+- Change the Deployment resources to use the `apps/v1 API version` instead of `extensions/v1beta1` as this is no longer served since Kubernetes 1.16.
 .
 
 ## [3.1.0] - 2020-11-23

--- a/charts/cpanel/Chart.yaml
+++ b/charts/cpanel/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Analytics Platform Control Panel API webapp
 name: cpanel
-version: 3.1.0
+version: 3.2.0

--- a/charts/cpanel/Chart.yaml
+++ b/charts/cpanel/Chart.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 description: Analytics Platform Control Panel API webapp
 name: cpanel
 version: 3.2.0
+maintainers:
+  - name: ministryofjustice

--- a/charts/cpanel/README.md
+++ b/charts/cpanel/README.md
@@ -56,6 +56,7 @@ In Auth0 you need to install Extension 'Auth0 Authorization':
 | `redis.scheme` | Scheme to connect to Redis cluster, can be `redis` for insecure connection or `rediss` to use SSL/TLS and encryption in-transit | `rediss` |
 | `redis.host` | host for the Redis cluster, see "Primary endpoint" value in AWS EC | `""` |
 | `redis.port` | Redis port | `"6379"` |
+| `secrets.create` | Whether we should create Kubernetes secret resources with Helm. | `true` |
 | `secretEnv.AWS_ACCOUNT_ID` | AWS account ID e.g. `123456789012`. Find this with e.g. `aws sts get-caller-identity --query Account --output text` (**DEPRECATED**) | `""` |
 | `secretEnv.AWS_COMPUTE_ACCOUNT_ID` | AWS account ID where apps and tools run. | `""` |
 | `secretEnv.AWS_DATA_ACCOUNT_ID` | AWS account ID where data sits. | `""` |

--- a/charts/cpanel/templates/frontend-deployment.yaml
+++ b/charts/cpanel/templates/frontend-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: "{{ .Chart.Name }}-frontend"

--- a/charts/cpanel/templates/ingress.yaml
+++ b/charts/cpanel/templates/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: "{{ .Chart.Name }}"

--- a/charts/cpanel/templates/ingress.yaml
+++ b/charts/cpanel/templates/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: "{{ .Chart.Name }}"

--- a/charts/cpanel/templates/secrets.yaml
+++ b/charts/cpanel/templates/secrets.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.secrets.create }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -36,3 +37,4 @@ data:
   {{ $key }}: {{ $value | b64enc | quote }}
   {{ end -}}
   REDIS_PASSWORD: {{ .Values.redis.password | b64enc | quote }}
+{{- end }}  

--- a/charts/cpanel/templates/worker-deployment.yaml
+++ b/charts/cpanel/templates/worker-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: "{{ .Chart.Name }}-worker"

--- a/charts/cpanel/values.yaml
+++ b/charts/cpanel/values.yaml
@@ -28,7 +28,7 @@ secretEnv:
   AIRFLOW_AUTH_CLIENT_SECRET: ""
   AIRFLOW_FERNET_KEY: ""
   AIRFLOW_SECRET_KEY: ""
-  AWS_ACCOUNT_ID: "" # TODO: Remove once CP stops using it
+  AWS_ACCOUNT_ID: ""  # TODO: Remove once CP stops using it
   AWS_COMPUTE_ACCOUNT_ID: ""
   AWS_DATA_ACCOUNT_ID: ""
   ELASTICSEARCH_HOST: ""
@@ -69,7 +69,7 @@ worker:
   replicas: 10
 
 redis:
-  scheme: "rediss" # use SSL/TLS by default
+  scheme: "rediss"  # use SSL/TLS by default
   host: ""
   port: "6379"
   password: "controlpanel"

--- a/charts/cpanel/values.yaml
+++ b/charts/cpanel/values.yaml
@@ -20,7 +20,7 @@ env:
   SLACK_CHANNEL: ""
 
 secrets:
-  create: true  
+  create: true
 
 secretEnv:
   AIRFLOW_AUTH_CLIENT_DOMAIN: ""

--- a/charts/cpanel/values.yaml
+++ b/charts/cpanel/values.yaml
@@ -19,6 +19,9 @@ env:
   SAML_PROVIDER: ""
   SLACK_CHANNEL: ""
 
+secrets:
+  create: true  
+
 secretEnv:
   AIRFLOW_AUTH_CLIENT_DOMAIN: ""
   AIRFLOW_AUTH_CLIENT_ID: ""


### PR DESCRIPTION
When we move to EKS we would like to avoid having to create Kubernetes secrets with Helm charts, as this requires us to provide secret values, in the clear as inputs to helm charts.

Instead we would like to have the option of creating the Kubernetes secrets from values stored in AWS secrets manager.

This change allows us to disable to create of Kubernetes secrets for in the control panel helm chart by setting a secrets.create to false.

By default all Kubernetes secrets will continue to be created as in previous versions of the chart.