### PR TITLE
ANPL-479 - Update RStudio helm chart to use nginx proxy image with configurable redirect url

### DIFF
--- a/charts/rstudio/CHANGELOG.md
+++ b/charts/rstudio/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+# [4.0.7] - 2021-06-09
+- Use the nginx proxy image with a configurable redirect url
+
 # [4.0.0] - 2021-04-26
 
 - Working version of RStudio 4 (note the synchornization of versions).

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: RStudio with Auth0 authentication proxy
 name: rstudio
-version: 4.0.6
+version: 4.0.7
 appVersion: "RStudio: 4.0.5"
 maintainers:
   - name: ministryofjustice

--- a/charts/rstudio/values.yaml
+++ b/charts/rstudio/values.yaml
@@ -12,7 +12,7 @@ proxy:
     logoutUrl: "https://controlpanel.services.alpha.mojanalytics.xyz/"
   image:
     repository: 593291632749.dkr.ecr.eu-west-1.amazonaws.com/nginx-proxy
-    tag: "0.0.26"
+    tag: "0.0.27"
     pullPolicy: "IfNotPresent"
   resources:
     limits:


### PR DESCRIPTION
Update RStudio helm chart to use the nginx proxy image with a configurable redirect url