### PR TITLE
ANPL-498 Add Renviron configmap to Rstudio chart

### DIFF
--- a/charts/rstudio/CHANGELOG.md
+++ b/charts/rstudio/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 # [4.1.2] - 2021-06-21
-- Mount .Renviron file to configure AWS credentials environment variables
+- Optionally mount a .Renviron file to configure environment variables used to get AWS credentials on EKS
 
 # [4.1.1] - 2021-06-18
 - Setup Git config with Rstudio

--- a/charts/rstudio/CHANGELOG.md
+++ b/charts/rstudio/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+# [4.1.2] - 2021-06-21
+- Mount .Renviron file to configure AWS credentials environment variables
+
 # [4.1.1] - 2021-06-18
 - Setup Git config with Rstudio
 

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: RStudio with Auth0 authentication proxy
 name: rstudio
 
-version: 4.1.1
+version: 4.1.2
 
 appVersion: "RStudio: 4.0.5"
 maintainers:

--- a/charts/rstudio/templates/configmap-renviron.yaml
+++ b/charts/rstudio/templates/configmap-renviron.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: renviron
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: {{ template "fullname" . }}
+data:
+  .Renviron: |
+    AWS_ROLE_ARN=arn:aws:iam::{{ .Values.aws.accountID }}:role/{{ .Values.aws.iamRole }}
+    AWS_WEB_IDENTITY_TOKEN_FILE=/var/run/secrets/eks.amazonaws.com/serviceaccount/token

--- a/charts/rstudio/templates/configmap-renviron.yaml
+++ b/charts/rstudio/templates/configmap-renviron.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rstudio.renviron.mount -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -10,3 +11,4 @@ data:
   .Renviron: |
     AWS_ROLE_ARN=arn:aws:iam::{{ .Values.aws.accountID }}:role/{{ .Values.aws.iamRole }}
     AWS_WEB_IDENTITY_TOKEN_FILE=/var/run/secrets/eks.amazonaws.com/serviceaccount/token
+{{- end -}}

--- a/charts/rstudio/templates/deployment.yml
+++ b/charts/rstudio/templates/deployment.yml
@@ -117,6 +117,9 @@ spec:
             - name: home
               mountPath: "/home/{{ .Values.username }}"
               subPath: {{.Values.username}}/rstudio
+            - name: renviron-configmap
+              mountPath: "/home/{{ .Values.username }}"/.Renviron
+              subPath: .Renviron
           resources:
 {{ toYaml .Values.rstudio.resources | indent 12 }}
 
@@ -128,6 +131,10 @@ spec:
         - name: home
           persistentVolumeClaim:
             claimName: efs-home
+        - name: renviron-configmap
+          configMap:
+            name: "renviron"
+            defaultMode: 0644
   selector:
     matchLabels:
       app: "{{ .Chart.Name }}"

--- a/charts/rstudio/templates/deployment.yml
+++ b/charts/rstudio/templates/deployment.yml
@@ -117,9 +117,11 @@ spec:
             - name: home
               mountPath: "/home/{{ .Values.username }}"
               subPath: {{.Values.username}}/rstudio
+            {{- if .Values.rstudio.renviron.mount }}
             - name: renviron-configmap
-              mountPath: "/home/{{ .Values.username }}"/.Renviron
+              mountPath: /home/{{ .Values.username }}/.Renviron
               subPath: .Renviron
+            {{- end }}
           resources:
 {{ toYaml .Values.rstudio.resources | indent 12 }}
 
@@ -131,10 +133,12 @@ spec:
         - name: home
           persistentVolumeClaim:
             claimName: efs-home
+        {{- if .Values.rstudio.renviron.mount }}
         - name: renviron-configmap
           configMap:
             name: "renviron"
             defaultMode: 0644
+        {{- end  }}
   selector:
     matchLabels:
       app: "{{ .Chart.Name }}"

--- a/charts/rstudio/values.yaml
+++ b/charts/rstudio/values.yaml
@@ -33,6 +33,9 @@ rstudio:
     # This exists here because you might want to downgrade to an older image, which doesn't take the arg
     # to the ./start.sh script
     init: false
+  renviron:
+    mount: false
+    # Whether to mount a .Renviron file in RStudio or not to set environment variables needed for AWS Authentication on EKS
   resources:
     limits:
       cpu: 1.5


### PR DESCRIPTION
In order for RStudio users to be able to access AWS resources from RStudio, they need to be able to get AWS credentials by assuming their IAM role.

- For users running on EKS we will grant AWS access using IAM for Service Accounts.

- For users running on the legacy (kops) clusters, we will continue to use use kube2iam to grant AWS access.

RStudio sessions run under a different user from the RStudio container (which runs as root).

This means that for users running on EKS we need to set the  AWS_ROLE_ARN and AWS_WEB_IDENTITY_TOKEN_FILE environment variables for the R Studio session.

This can be done in a few different way, but the more flexible will be to mount a .Renviron file in the root of a users home directory . This will will contain the AWS_ROLE_ARN and AWS_WEB_IDENTITY_TOKEN_FILE environment variables for the R Studio session.

For more details see https://rviews.rstudio.com/2017/04/19/r-for-enterprise-understanding-r-s-startup/

By default we will not mount a .Renviron file, which will ensure this is not mounted for RStudio users on the legacy (kops) clusters.






